### PR TITLE
Create folder structure and modify to enable monorepo

### DIFF
--- a/policyengine_api_v2/task_api/Makefile
+++ b/policyengine_api_v2/task_api/Makefile
@@ -1,0 +1,5 @@
+format:
+	black . -l 79
+
+debug-api:
+	fastapi dev task_api/api/app.py

--- a/policyengine_api_v2/task_api/Makefile
+++ b/policyengine_api_v2/task_api/Makefile
@@ -1,5 +1,5 @@
 format:
 	black . -l 79
 
-debug-api:
-	fastapi dev task_api/api/app.py
+debug:
+	LOCAL_DATABASE=true fastapi dev task_api/api/app.py

--- a/policyengine_api_v2/task_api/pyproject.toml
+++ b/policyengine_api_v2/task_api/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
     "policyengine",
     "pydantic",
     "fastapi[standard]",
-    "sqlmodel"
+    "sqlmodel",
+    "cloud-sql-python-connector[pg8000]",
+    "python-dotenv"
 ]
 
 [project.optional-dependencies]
@@ -32,11 +34,12 @@ dev = [
 ]
 
 [tool.setuptools]
+package-dir = {"policyengine_task_api" = "task_api"}
 packages = ["policyengine_task_api"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-"policyengine" = ["**/*"]
+"policyengine_task_api" = ["**/*"]
 
 [tool.pytest.ini_options]
 addopts = "-v"

--- a/policyengine_api_v2/task_api/pyproject.toml
+++ b/policyengine_api_v2/task_api/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "policyengine_task_api"
+version = "0.1.0"
+description = "API utilities."
+readme = "README.md"
+authors = [
+    {name = "PolicyEngine", email = "hello@policyengine.org"},
+]
+license = {file = "LICENSE"}
+requires-python = ">=3.6"
+dependencies = [
+    "policyengine",
+    "pydantic",
+    "fastapi[standard]",
+    "sqlmodel"
+]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "pytest",
+    "furo",
+    "autodoc_pydantic",
+    "jupyter-book",
+    "yaml-changelog>=0.1.7",
+    "itables",
+    "build",
+]
+
+[tool.setuptools]
+packages = ["policyengine_task_api"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"policyengine" = ["**/*"]
+
+[tool.pytest.ini_options]
+addopts = "-v"
+testpaths = [
+    "tests",
+]
+
+[tool.black]
+line-length = 79
+target-version = ['py311']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''

--- a/policyengine_api_v2/task_api/task_api/api/app.py
+++ b/policyengine_api_v2/task_api/task_api/api/app.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI
+from sqlmodel import Field, Session, SQLModel, create_engine
+import os
+from dotenv import load_dotenv
+from task_api.core.database import (
+    Job,
+    get_local_database_engine,
+    get_production_database_engine,
+)
+import time
+
+load_dotenv()
+
+if os.getenv("LOCAL_DATABASE"):
+    engine = get_local_database_engine()
+else:
+    engine = get_production_database_engine()
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, World!"}
+
+
+@app.post("/job")
+def create_job(parameters: dict) -> Job:
+    with Session(engine) as session:
+        job = Job(parameters=parameters)
+        session.add(job)
+        session.commit()
+
+        return job
+
+
+@app.get("/job/{job_id}")
+def read_job(job_id: int) -> Job:
+    with Session(engine) as session:
+        job = session.get(Job, job_id)
+        return job

--- a/policyengine_api_v2/task_api/task_api/api/requirements.txt
+++ b/policyengine_api_v2/task_api/task_api/api/requirements.txt
@@ -1,3 +1,0 @@
-git+https://github.com/policyengine/policyengine-api-prototype
-cloud-sql-python-connector[pg8000]
-python_dotenv

--- a/policyengine_api_v2/task_api/task_api/api/requirements.txt
+++ b/policyengine_api_v2/task_api/task_api/api/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/policyengine/policyengine-api-prototype
+cloud-sql-python-connector[pg8000]
+python_dotenv

--- a/policyengine_api_v2/task_api/task_api/core/database.py
+++ b/policyengine_api_v2/task_api/task_api/core/database.py
@@ -1,0 +1,50 @@
+from sqlmodel import (
+    Field,
+    Session,
+    SQLModel,
+    create_engine,
+    Column,
+    JSON,
+    TIMESTAMP,
+)
+from policyengine import SimulationOptions
+from datetime import datetime
+from dotenv import load_dotenv
+from pathlib import Path
+import os
+from google.cloud.sql.connector import Connector
+
+load_dotenv()
+
+
+class Job(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    parameters: dict | None = Field(default=None, sa_column=Column(JSON))
+    result: dict | None = Field(default=None, sa_column=Column(JSON))
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(TIMESTAMP, default=datetime.utcnow),
+    )
+
+
+def get_local_database_engine():
+    engine = create_engine(Path(__file__).parent / "database.db")
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def get_production_database_engine():
+    connector = Connector()
+    getconn = lambda: connector.connect(
+        "policyengine-api-prototype:us-central1:policyengine-api-prototype-database",
+        "pg8000",
+        user="postgres",
+        password="postgres",  # Obviously bad, just for testing
+        db="postgres",
+    )
+    engine = create_engine(
+        "postgresql+pg8000://",
+        creator=getconn,
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine

--- a/policyengine_api_v2/task_api/task_api/core/database.py
+++ b/policyengine_api_v2/task_api/task_api/core/database.py
@@ -28,7 +28,12 @@ class Job(SQLModel, table=True):
 
 
 def get_local_database_engine():
-    engine = create_engine(Path(__file__).parent / "database.db")
+    SQLITE_PREFIX = "sqlite:///"
+
+    PATH_TO_DB: str = str(Path(__file__).parent / "database.db")
+
+    engine = create_engine(SQLITE_PREFIX + PATH_TO_DB)
+    # engine = create_engine(Path(__file__).parent / "database.db")
     SQLModel.metadata.create_all(engine)
     return engine
 

--- a/policyengine_api_v2/task_api/task_api/core/functions/main/main.py
+++ b/policyengine_api_v2/task_api/task_api/core/functions/main/main.py
@@ -1,0 +1,44 @@
+import flask
+import functions_framework
+from pydantic import BaseModel
+from policyengine import Simulation
+import os
+from sqlmodel import Field, Session, SQLModel, create_engine
+from policyengine_api_prototype import Job
+from dotenv import load_dotenv
+from policyengine_api_prototype import (
+    Job,
+    get_local_database_engine,
+    get_production_database_engine,
+)
+
+load_dotenv()
+
+if os.getenv("LOCAL_DATABASE"):
+    engine = get_local_database_engine()
+else:
+    engine = get_production_database_engine()
+
+
+def execute_job(parameters: dict):
+    simulation = Simulation(parameters)
+    result = simulation.calculate().model_dump()
+    return result
+
+
+def execute_job_from_id(job_id: int):
+    with Session(engine) as session:
+        job = session.get(Job, job_id)
+        job.result = execute_job(job.parameters)
+        session.add(job)
+        session.commit()
+
+
+@functions_framework.http
+def main(request: flask.Request) -> dict:
+    # Get job_id from query parameter
+    job_id = int(request.args.get("job_id"))
+
+    execute_job_from_id(job_id)
+
+    return {"message": "Job executed"}

--- a/policyengine_api_v2/task_api/task_api/core/functions/main/requirements.txt
+++ b/policyengine_api_v2/task_api/task_api/core/functions/main/requirements.txt
@@ -1,0 +1,6 @@
+policyengine>=2.5.0
+cloud-sql-python-connector[pg8000]
+git+https://github.com/policyengine/policyengine-api-prototype
+argparse
+python_dotenv
+sqlmodel

--- a/policyengine_api_v2/task_api/task_api/core/jobs/main/Dockerfile
+++ b/policyengine_api_v2/task_api/task_api/core/jobs/main/Dockerfile
@@ -1,0 +1,14 @@
+# Use official Python image
+FROM python:3.10-slim
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN apt-get update && apt-get install -y git
+
+# Install dependencies
+COPY requirements.txt .
+RUN uv pip install --no-cache-dir -r requirements.txt --system
+
+# Copy application code
+COPY main.py .
+
+# Run the script
+CMD ["python", "main.py"]

--- a/policyengine_api_v2/task_api/task_api/core/jobs/main/main.py
+++ b/policyengine_api_v2/task_api/task_api/core/jobs/main/main.py
@@ -1,0 +1,36 @@
+print("Starting job...")
+
+from pydantic import BaseModel
+from policyengine import Simulation
+import os
+from sqlmodel import Field, Session
+from dotenv import load_dotenv
+from policyengine_api_prototype import (
+    Job,
+    get_local_database_engine,
+    get_production_database_engine,
+)
+
+load_dotenv()
+
+if os.getenv("LOCAL_DATABASE"):
+    engine = get_local_database_engine()
+else:
+    engine = get_production_database_engine()
+
+
+def execute_job(parameters: dict):
+    simulation = Simulation(parameters)
+    result = simulation.calculate().model_dump()
+    return result
+
+
+def execute_job_from_id(job_id: int):
+    with Session(engine) as session:
+        job = session.get(Job, job_id)
+        job.result = execute_job(job.parameters)
+        session.add(job)
+        session.commit()
+
+
+execute_job_from_id(int(os.getenv("JOB_ID")))

--- a/policyengine_api_v2/task_api/task_api/core/jobs/main/requirements.txt
+++ b/policyengine_api_v2/task_api/task_api/core/jobs/main/requirements.txt
@@ -1,0 +1,5 @@
+policyengine>=2.5.0
+git+https://github.com/policyengine/policyengine-api-prototype
+python_dotenv
+cloud-sql-python-connector[pg8000]
+sqlmodel

--- a/policyengine_api_v2/task_api/task_api/core/workflows/main.yaml
+++ b/policyengine_api_v2/task_api/task_api/core/workflows/main.yaml
@@ -1,0 +1,21 @@
+main:
+  params: [input]
+  steps:
+    - run_function:
+        call: http.get
+        args:
+            url: https://us-central1-policyengine-api-prototype.cloudfunctions.net/simulate-function
+            query:
+              job_id: ${input.job_id}
+    - run_job:
+        call: googleapis.run.v1.namespaces.jobs.run
+        args:
+          name: namespaces/policyengine-api-prototype/jobs/simulate-job
+          location: us-central1
+          body:
+            overrides:
+              containerOverrides:
+                env:
+                  - name: JOB_ID
+                    value: ${input.job_id}
+    


### PR DESCRIPTION
Fixes #1 
Fixes #3 
Fixes #6 

This PR implements a monorepo by creating a new folder structure. It deprecates our old `requirements.txt` in favor of adding package reqs to `pyproject.toml`, updates the Makefile to properly use the debug db in debug, and fixes the debug database connector to work properly.