### PR TITLE
Fix absolute path dependencies to relative

### DIFF
--- a/libs/policyengine-api/poetry.lock
+++ b/libs/policyengine-api/poetry.lock
@@ -35,6 +35,21 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "asgiref"
+version = "3.8.1"
+description = "ASGI specs, helper code, and adapters"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47"},
+    {file = "asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"},
+]
+
+[package.extras]
+tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
+
+[[package]]
 name = "cachetools"
 version = "5.5.1"
 description = "Extensible memoizing collections and decorators"
@@ -944,6 +959,50 @@ packaging = ">=18.0"
 wrapt = ">=1.0.0,<2.0.0"
 
 [[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.51b0"
+description = "ASGI instrumentation for OpenTelemetry"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_instrumentation_asgi-0.51b0-py3-none-any.whl", hash = "sha256:e8072993db47303b633c6ec1bc74726ba4d32bd0c46c28dfadf99f79521a324c"},
+    {file = "opentelemetry_instrumentation_asgi-0.51b0.tar.gz", hash = "sha256:b3fe97c00f0bfa934371a69674981d76591c68d937b6422a5716ca21081b4148"},
+]
+
+[package.dependencies]
+asgiref = ">=3.0,<4.0"
+opentelemetry-api = ">=1.12,<2.0"
+opentelemetry-instrumentation = "0.51b0"
+opentelemetry-semantic-conventions = "0.51b0"
+opentelemetry-util-http = "0.51b0"
+
+[package.extras]
+instruments = ["asgiref (>=3.0,<4.0)"]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.51b0"
+description = "OpenTelemetry FastAPI Instrumentation"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_instrumentation_fastapi-0.51b0-py3-none-any.whl", hash = "sha256:10513bbc11a1188adb9c1d2c520695f7a8f2b5f4de14e8162098035901cd6493"},
+    {file = "opentelemetry_instrumentation_fastapi-0.51b0.tar.gz", hash = "sha256:1624e70f2f4d12ceb792d8a0c331244cd6723190ccee01336273b4559bc13abc"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.12,<2.0"
+opentelemetry-instrumentation = "0.51b0"
+opentelemetry-instrumentation-asgi = "0.51b0"
+opentelemetry-semantic-conventions = "0.51b0"
+opentelemetry-util-http = "0.51b0"
+
+[package.extras]
+instruments = ["fastapi (>=0.58,<1.0)"]
+
+[[package]]
 name = "opentelemetry-instrumentation-logging"
 version = "0.51b0"
 description = "OpenTelemetry Logging instrumentation"
@@ -1011,6 +1070,18 @@ deprecated = ">=1.2.6"
 opentelemetry-api = "1.30.0"
 
 [[package]]
+name = "opentelemetry-util-http"
+version = "0.51b0"
+description = "Web util for OpenTelemetry"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_util_http-0.51b0-py3-none-any.whl", hash = "sha256:0561d7a6e9c422b9ef9ae6e77eafcfcd32a2ab689f5e801475cbb67f189efa20"},
+    {file = "opentelemetry_util_http-0.51b0.tar.gz", hash = "sha256:05edd19ca1cc3be3968b1e502fd94816901a365adbeaab6b6ddb974384d3a0b9"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 description = "Core utilities for Python packages"
@@ -1052,6 +1123,7 @@ develop = true
 fastapi = {version = ">=0.115.8,<0.116.0", extras = ["standard"]}
 opentelemetry-exporter-gcp-monitoring = ">=1.9.0a0,<2.0.0"
 opentelemetry-exporter-gcp-trace = ">=1.9.0,<2.0.0"
+opentelemetry-instrumentation-fastapi = ">=0.51b0,<0.52"
 opentelemetry-instrumentation-logging = ">=0.51b0,<0.52"
 opentelemetry-sdk = ">=1.30.0,<2.0.0"
 pyjwt = ">=2.10.1,<3.0.0"
@@ -2049,4 +2121,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "8c476acd59b67c69687642e5a9ad25c629e126cf4b870573705cb2650b7d7c8a"
+content-hash = "a58b4099cdc37c7267931cb4657b1139385a9dad419e37172b602cbc56fd2cd2"

--- a/libs/policyengine-api/pyproject.toml
+++ b/libs/policyengine-api/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "policyengine-fastapi @ file:///home/ec2-user/workspaces/policyengine-api-v2/libs/policyengine-fastapi"
+    "policyengine-fastapi @ ../policyengine-fastapi"
 ]
 
 

--- a/projects/policyengine-api-household/poetry.lock
+++ b/projects/policyengine-api-household/poetry.lock
@@ -1114,7 +1114,7 @@ files = []
 develop = true
 
 [package.dependencies]
-policyengine-fastapi = {path = "/home/ec2-user/workspaces/policyengine-api-v2/libs/policyengine-fastapi"}
+policyengine-fastapi = {path = "../policyengine-fastapi"}
 
 [package.source]
 type = "directory"
@@ -1134,6 +1134,7 @@ develop = false
 fastapi = {version = ">=0.115.8,<0.116.0", extras = ["standard"]}
 opentelemetry-exporter-gcp-monitoring = ">=1.9.0a0,<2.0.0"
 opentelemetry-exporter-gcp-trace = ">=1.9.0,<2.0.0"
+opentelemetry-instrumentation-fastapi = ">=0.51b0,<0.52"
 opentelemetry-instrumentation-logging = ">=0.51b0,<0.52"
 opentelemetry-sdk = ">=1.30.0,<2.0.0"
 pyjwt = ">=2.10.1,<3.0.0"
@@ -2131,4 +2132,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "49bea26e42c10db4d52ca8f1fe7b0dc42a6e53ed06445719c387e6a80e20c786"
+content-hash = "90d4a00b3867d4b0e0d12d543aaac039abd258c909746b66661f93829b6dd790"

--- a/projects/policyengine-api-household/pyproject.toml
+++ b/projects/policyengine-api-household/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy (>=0.51b0,<0.52)",
     "pydantic-settings (>=2.7.1,<3.0.0)",
     "opentelemetry-instrumentation-fastapi (>=0.51b0,<0.52)",
-    "policyengine-api @ file:///home/ec2-user/workspaces/policyengine-api-v2/libs/policyengine-api"
+    "policyengine-api @ ../../libs/policyengine-api"
 ]
 
 


### PR DESCRIPTION
Fixes #15

Changed the dependencies in pyproject.toml between local packages to be relative (otherwise they are absolute and break the make install in most environemtns)