### PR TITLE
Don't use build as a make target and directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ database.db
 .dockerfile
 .terraform
 build/
+artifacts/
 .swp
 .bootstrap_settings
 apply.tfvars

--- a/projects/policyengine-api-household/Dockerfile
+++ b/projects/policyengine-api-household/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR app
 # This may copy some dependencies this app doesn't need, but source should
 # not be very large
 #.dockerignore will exclude .venv and .git
-COPY build/staging .
+COPY artifacts/staging .
 COPY pyproject.toml poetry.lock projects/app/
 RUN touch README.md
 

--- a/projects/policyengine-api-household/Makefile
+++ b/projects/policyengine-api-household/Makefile
@@ -10,9 +10,9 @@ endif
 include ../../terraform/.bootstrap_settings/project.env
 
 deploy:
-	rm -rf build/staging
-	mkdir -p build/staging/libs
-	cp -R ../../libs/* build/staging/libs/
+	rm -rf artifacts/staging
+	mkdir -p artifacts/staging/libs
+	cp -R ../../libs/* artifacts/staging/libs/
 	gcloud builds submit --region=${REGION} --tag ${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/policyengine-api-household:${TAG} ${BUILD_ARGS}
 
 build:


### PR DESCRIPTION
fixes #35

I have a make build and also create a "build" directory. Make things that's the target and opts to do nothing on build.

Changed the build directory to "artifacts"