### PR TITLE
Generate openapi spec for full api at build time.

### DIFF
--- a/projects/policyengine-api-full/Makefile
+++ b/projects/policyengine-api-full/Makefile
@@ -20,6 +20,8 @@ deploy:
 
 build:
 	poetry install
+	mkdir -p artifacts
+	cd src && poetry run python -m policyengine_api_full.generate_openapi > ../artifacts/openapi.json
 	@echo "TODO: add back in the tests"
 
 dev:

--- a/projects/policyengine-api-full/src/policyengine_api_full/generate_openapi.py
+++ b/projects/policyengine-api-full/src/policyengine_api_full/generate_openapi.py
@@ -1,0 +1,4 @@
+from .main import app
+import json
+
+print(json.dumps(app.openapi(), indent=4))

--- a/projects/policyengine-api-full/src/policyengine_api_full/main.py
+++ b/projects/policyengine-api-full/src/policyengine_api_full/main.py
@@ -28,7 +28,7 @@ async def lifespan(app: FastAPI):
     SQLModel.metadata.create_all(engine)
     yield
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, title="policyengine-api-full", summary="External facing policyengineAPI containing all features")
 
 #attach the api defined in the app package
 initialize(app=app, 


### PR DESCRIPTION
related to PolicyEngine/issues#137

In order to generate a client that I can use in an integration test, first I have to actually generate the openapi spec from the service.

This change does that.