### PR TITLE
Generate python/typscript clients from openapi spec.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,12 @@ jobs:
       with:
         workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
         service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
     - name: "Set up Cloud SDK"
       uses: "google-github-actions/setup-gcloud@v2"
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,5 +40,11 @@ jobs:
         python-version: "3.11"
     - name: Set up poetry
       run: uv pip install poetry --system
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
     - name: Build application
       run: make build

--- a/projects/policyengine-api-full/Makefile
+++ b/projects/policyengine-api-full/Makefile
@@ -22,6 +22,7 @@ build:
 	poetry install
 	mkdir -p artifacts
 	cd src && poetry run python -m policyengine_api_full.generate_openapi > ../artifacts/openapi.json
+	mvn -f ./generate_clients.pom.xml clean generate-sources
 	@echo "TODO: add back in the tests"
 
 dev:

--- a/projects/policyengine-api-full/generate_clients.pom.xml
+++ b/projects/policyengine-api-full/generate_clients.pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- this is a maven project definition used to execute the openapi generator against our openapi spec.
+     There is some python integration for openapi-generator, but maven seemed like an easier integration than
+     poetry -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <!-- Required Maven Project Information -->
+    <groupId>com.example</groupId>
+    <artifactId>openapi-client-generator</artifactId>
+    <version>1.0.0</version>
+    
+    <build>
+        <plugins>
+            <!-- OpenAPI Generator Plugin -->
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.12.0</version> <!-- Use the latest version available -->
+                <executions>
+                    <!-- Python Client Generation -->
+                    <execution>
+                        <id>generate-python-client</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/artifacts/openapi.json</inputSpec>
+                            <generatorName>python</generatorName>
+                            <output>${project.basedir}/artifacts/clients/python</output>
+                            <configOptions>
+                                <packageName>policyengine_full_api_client</packageName>
+                                <projectName>openapi-client-python</projectName>
+                                <packageVersion>1.0.0</packageVersion>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-typescript-client</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/artifacts/openapi.json</inputSpec>
+                            <generatorName>typescript-fetch</generatorName>
+                            <output>${project.basedir}/artifacts/clients/typescript</output>
+                            <configOptions>
+                                <npmName>policyengine-full-api-typescript-client</npmName>
+                                <npmVersion>1.0.0</npmVersion>
+                                <supportsES6>true</supportsES6>
+                                <typescriptThreePlus>true</typescriptThreePlus>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
related to PolicyEngine/issues#137

Updated policyengine-api-full to generate python and typescript clients from the openapi spec.