### PR TITLE
Fix deployment action and related makefiles/etc.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
         workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
         service_account: "deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
     - uses: hashicorp/setup-terraform@v3
-    - name: Deploy services
-      run: make -f Makefile.deploy deploy_services
-    - name: Deploy project
-      run: make -f Makefile.deploy deploy_project
+    - name: Deploy gcp project
+      run: make -f Makefile.deploy deploy-project
+    - name: Deploy actual services to the GCP project
+      run: make -f Makefile.deploy deploy-infra

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ env:
   BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
   COMMIT_TAG: ${{ github.sha }}
 jobs:
-  build:
+  build_simulation_api_image:
     # Any runner supporting Node 20 or newer
     runs-on: ubuntu-latest
     environment: beta
@@ -39,9 +39,33 @@ jobs:
       with:
         version: ">= 363.0.0"
     - name: Build application
-      run: make -f Makefile.deploy publish-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
+      run: make -f Makefile.deploy publish-simulation-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
+
+  build_full_api_image:
+    # Any runner supporting Node 20 or newer
+    runs-on: ubuntu-latest
+    environment: beta
+
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v4
+    - uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+      with:
+        version: ">= 363.0.0"
+    - name: Build application
+      run: make -f Makefile.deploy publish-full-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
   deploy_beta:
-    needs: [build]
+    needs: [build_simulation_api_image, build_full_api_image]
     runs-on: ubuntu-latest
     environment: beta
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,8 @@ jobs:
       uses: actions/checkout@v4
     - uses: "google-github-actions/auth@v2"
       with:
-        credentials_json: ${{ secrets.GCP_SA_KEY}}
-        project_id: ${{ vars.PROJECT_ID }}
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
     - name: "Set up Cloud SDK"
       uses: "google-github-actions/setup-gcloud@v2"
       with:
@@ -81,12 +81,10 @@ jobs:
       uses: actions/checkout@v4
     - uses: "google-github-actions/auth@v2"
       with:
-        project_id: ${{ vars.PROJECT_ID }}
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
     - uses: hashicorp/setup-terraform@v3
     - name: Deploy services
       run: make -f Makefile.deploy deploy_services
     - name: Deploy project
       run: make -f Makefile.deploy deploy_project
-
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,8 @@ env:
   TF_VAR_github_repo: ${{ github.repository }}
   TF_VAR_project_id: ${{ vars.PROJECT_ID }}
   TF_VAR_region: ${{ vars.REGION }}
-  TF_VAR_container_tag: ${{ github.sha }}
+  TF_VAR_full_container_tag: ${{ github.sha }}
+  TF_VAR_simulation_container_tag: ${{ github.sha }}
   BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
   COMMIT_TAG: ${{ github.sha }}
 jobs:

--- a/Makefile.deploy
+++ b/Makefile.deploy
@@ -1,6 +1,8 @@
-publish-docker:
-	cd projects/policyengine-api-full && make -f Makefile.deploy deploy TAG=${TAG} PROJECT_ID=${PROJECT_ID} 
-	cd projects/policyengine-api-simulation && make -f Makefile.deploy deploy TAG=${TAG} PROJECT_ID=${PROJECT_ID} 
+publish-full-api-docker:
+	cd projects/policyengine-api-full && make -f Makefile.deploy deploy TAG=${TAG} PROJECT_ID=${PROJECT_ID}
+
+publish-simulation-api-docker:
+	cd projects/policyengine-api-simulation && make -f Makefile.deploy deploy TAG=${TAG} PROJECT_ID=${PROJECT_ID}
 
 deploy-project:
 	cd terraform/project-policyengine-api && make -f Makefile.deploy deploy

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ __NOTE: MOST development should be possible locally. Deployment is slow and hard
 * One time setup - this will create a new project in your GCP account you can deploy the api to.
   * Create a gcp account _with organization_
   * authenticate with gcloud as a user with permission to create projects.
+    * ``gcloud auth application-default login``
   * Have your organization ID and billing account number handy.
   * ``cd terraform/infra-policyengine-api && make bootstrap``
   * You should now have a terraform/.bootstrap_settings folder containing your project settings.
@@ -18,7 +19,7 @@ __NOTE: MOST development should be possible locally. Deployment is slow and hard
   * There should now be a new hash under the tag "desktop" in the project artifact repository.
 * deploy to the cloud
   * ``cd terraform/project-policyengine-api-full && make deploy``
-  * The cloudrun service should now be running using the latest image version of the tag "deksop" from your project artifact respository
+  * The cloudrun service should now be running using the latest image version of the tag "desksop" from your project artifact respository
 
 # Github Deploy to Cloud Quick Start
 
@@ -30,6 +31,7 @@ in a workspace at a time.
   * have your GCP organization id and billing account number ready
   * log into your gcp account via gcloud as a user able to create projects.
   * ``cd terraform/project-poicyengine-api && make bootstrap_beta``
+* WAIT FOR AT LEAST AN HOUR (permissions configuration sometimes takes up to an hour for the github federation.) You may get errors about lack of permission (or possibly resource) for thinkgs like the deployment state bucket.
 * configure github
   * create a new environment in your github repo settings called "beta" and, using the ouput of the bootstrap, configure the following values
     * REGION (generally us-central1)

--- a/projects/policyengine-api-full/Makefile.deploy
+++ b/projects/policyengine-api-full/Makefile.deploy
@@ -5,4 +5,4 @@ deploy:
 	#Environment variables are defined in the github worfklow and have the TF_VAR prefix
 	#because they are also used by terraform and loaded as variables.
 	#--gcs_log_dir is required because the github deployment role does not have access to the default bucket.
-	gcloud builds submit --region=${TF_VAR_region} --tag ${TF_VAR_region}-docker.pkg.dev/${TF_VAR_project_id}/api-v2/policyengine-api-full:${TF_VAR_container_tag} --gcs-log-dir ${LOG_DIR}
+	gcloud builds submit --region=${TF_VAR_region} --tag ${TF_VAR_region}-docker.pkg.dev/${TF_VAR_project_id}/api-v2/policyengine-api-full:${TF_VAR_full_container_tag} --gcs-log-dir ${LOG_DIR}

--- a/projects/policyengine-api-simulation/Makefile.deploy
+++ b/projects/policyengine-api-simulation/Makefile.deploy
@@ -5,4 +5,4 @@ deploy:
 	#Environment variables are defined in the github worfklow and have the TF_VAR prefix
 	#because they are also used by terraform and loaded as variables.
 	#--gcs_log_dir is required because the github deployment role does not have access to the default bucket.
-	gcloud builds submit --region=${TF_VAR_region} --tag ${TF_VAR_region}-docker.pkg.dev/${TF_VAR_project_id}/api-v2/policyengine-api-simulation:${TF_VAR_container_tag} --gcs-log-dir ${LOG_DIR}
+	gcloud builds submit --region=${TF_VAR_region} --tag ${TF_VAR_region}-docker.pkg.dev/${TF_VAR_project_id}/api-v2/policyengine-api-simulation:${TF_VAR_simulation_container_tag} --gcs-log-dir ${LOG_DIR}

--- a/terraform/infra-policyengine-api/Makefile
+++ b/terraform/infra-policyengine-api/Makefile
@@ -17,7 +17,7 @@ deploy: .terraform
 	@echo "Latest Full API SHA: ${FULL_SHA}"
 	@echo "Latest Simulation API SHA: ${SIM_SHA}"
 	@echo "Running terraform apply with ../.bootstrap_settings/apply.tfvars"
-	terraform apply -var-file ../.bootstrap_settings/apply.tfvars -var "full_container_tag=${FULL_SHA}" -var "simulation_container_tag=${SIM_SHA}"
+	terraform apply -var-file ../.bootstrap_settings/apply.tfvars -var "full_container_tag=${TAG}@${FULL_SHA}" -var "simulation_container_tag=${TAG}@${SIM_SHA}"
 
 .terraform: ../.bootstrap_settings/backend.tfvars
 	@echo "Initializing terraform"

--- a/terraform/infra-policyengine-api/Makefile.deploy
+++ b/terraform/infra-policyengine-api/Makefile.deploy
@@ -1,27 +1,9 @@
-# This makefile is for CI/CD deployment
-
-backend.tf:
-	cp backend.example_tf backend.tf
-
-.terraform:
-	# Setup environment from CI/CD variables or use defaults
-	$(eval TAG ?= latest)
-	$(eval REGION ?= us-central1)
-	$(eval PROJECT_ID_FROM_ENV := $(shell echo $$PROJECT_ID))
-	
-	# Get SHA for both containers
-	$(eval FULL_SHA := $(shell gcloud artifacts docker images describe $(REGION)-docker.pkg.dev/$(PROJECT_ID_FROM_ENV)/api-v2/policyengine-api-full:$(TAG) --format='value(image_summary.digest)'))
-	$(eval SIM_SHA := $(shell gcloud artifacts docker images describe $(REGION)-docker.pkg.dev/$(PROJECT_ID_FROM_ENV)/api-v2/policyengine-api-simulation:$(TAG) --format='value(image_summary.digest)'))
-	
-	# Initialize and apply terraform
-	terraform init -backend-config="bucket=${TF_BACKEND_bucket}"
+plan-deploy: .terraform
+	terraform plan -input=false
 
 deploy: .terraform
-	terraform apply -auto-approve \
-		-var="project_id=$(PROJECT_ID_FROM_ENV)" \
-		-var="region=$(REGION)" \
-		-var="full_container_tag=$(FULL_SHA)" \
-		-var="simulation_container_tag=$(SIM_SHA)"
+	terraform apply -input=false -auto-approve
 
-plan-deploy: .terraform
-	terraform plan
+
+.terraform:
+	terraform init -backend-config="bucket=${TF_BACKEND_bucket}"

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -16,8 +16,8 @@ locals {
     cpu_limit = var.is_prod ? "2" : null
     memory_limit = var.is_prod ? "1024Mi" : null
 
-    full_api_image = "${var.region}-docker.pkg.dev/${var.project_id}/api-v2/policyengine-api-full@${var.full_container_tag}"
-    simulation_api_image = "${var.region}-docker.pkg.dev/${var.project_id}/api-v2/policyengine-api-simulation@${var.simulation_container_tag}"
+    full_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-full:${var.full_container_tag}"
+    simulation_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-simulation:${var.simulation_container_tag}"
 }
 
 provider "google" {

--- a/terraform/infra-policyengine-api/variables.tf
+++ b/terraform/infra-policyengine-api/variables.tf
@@ -10,15 +10,13 @@ variable "region" {
 }
 
 variable "full_container_tag" {
-  description = "The container image tag for the full API. If not specified, defaults to 'desktop'"
+  description = "The container image tag for the full API"
   type        = string
-  default     = "desktop"
 }
 
 variable "simulation_container_tag" {
-  description = "The container image tag for the simulation API. If not specified, defaults to 'desktop'"
+  description = "The container image tag for the simulation API"
   type        = string
-  default     = "desktop"
 }
 
 variable "is_prod" {


### PR DESCRIPTION
related to #48

Got this working again in my fork with my GCP account. Addressed a number of issues with the GitHub actions and build targets.
1. Re-instated the federated token access for GitHub actions (Rather than storing a permanent secret)
2. fixed a few different issues with the way were were setting up the image tag URLs (missing ":" character and some other things)
3. fixed the infra-policyengine-api/Makefile.deploy - this had been converted to work as a desktop deploy and no longer worked with GitHub. converted it back.
4. Split up the GitHub build actions to build the two service images in parallel rather than in sequence (saves 2 minutes every build)
5. Updated the main README.md with a couple clarifiers based on redeploying everything from scratch again.