### PR TITLE
Remove plan from pr action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+
 env:
   TF_BACKEND_bucket: ${{ vars.PROJECT_ID }}-state
   #TF_VAR_whatever will be picked up as terraform variables.
@@ -11,17 +12,17 @@ env:
   TF_VAR_billing_account: ${{ secrets.BILLING_ACCOUNT }}
   TF_VAR_github_repo_owner_id: ${{ github.repository_owner_id }}
   TF_VAR_github_repo: ${{ github.repository }}
-  TF_VAR_project_id: $${{ vars.PROJECT_ID }}
+  TF_VAR_project_id: ${{ vars.PROJECT_ID }}
   TF_VAR_region: ${{ vars.REGION }}
-  TF_VAR_container_tag: ${{ github.sha }}
+  TF_VAR_full_container_tag: ${{ github.sha }}
+  TF_VAR_simulation_container_tag: ${{ github.sha }}
   BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
   COMMIT_TAG: ${{ github.sha }}
-  PROJECT_ID: ${{ vars.PROJECT_ID }}
 jobs:
   build:
     # Any runner supporting Node 20 or newer
-    name: Build and test
     runs-on: ubuntu-latest
+    environment: beta
 
     # Add "id-token" with the intended permissions.
     permissions:
@@ -29,7 +30,7 @@ jobs:
       id-token: "write"
 
     steps:
-    - name: Checkout repo
+    - name: checkout repo
       uses: actions/checkout@v4
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -39,47 +40,5 @@ jobs:
         python-version: "3.11"
     - name: Set up poetry
       run: uv pip install poetry --system
-    - uses: "google-github-actions/auth@v2"
-      with:
-        project_id: ${{ vars.PROJECT_ID }}
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@v2"
-      with:
-        version: ">= 363.0.0"
-    - name: Build and test
+    - name: Build application
       run: make build
-  test_deploy:
-    runs-on: ubuntu-latest
-    name: Test deployment
-    environment: beta
-    env:
-        TF_VAR_stage: beta
-        TF_VAR_is_prod: false
-    
-    permissions:
-      contents: "read"
-      id-token: "write"
-
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.11"
-    - name: Set up poetry
-      run: uv pip install poetry --system
-    - uses: "google-github-actions/auth@v2"
-      with:
-        credentials_json: ${{ secrets.GCP_SA_KEY}}
-        project_id: ${{ vars.PROJECT_ID }}
-    - uses: hashicorp/setup-terraform@v3
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@v2"
-      with:
-        version: ">= 363.0.0"
-    - name: Test deployment
-      run: make -f Makefile.deploy plan-deploy TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }}


### PR DESCRIPTION
Fixes #48

It is not secure to expose broad user permissions to a PR action. Anyone can submit a PR and if it runs use those permissions to do whatever they like without actually being accepted/merged.