### PR TITLE
Do PR workflow for all pull requests.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,6 @@ name: Pull request
 
 on:
   pull_request:
-    branches:
-      - main
 
 env:
   TF_BACKEND_bucket: ${{ vars.PROJECT_ID }}-state


### PR DESCRIPTION
Fixes #59

Currently we're limited to those targeting main, but this means we don't run a PR workflow on stacked PRs (i.e. where one PR has to branch from another PR branch)