### PR TITLE
Run integration tests after beta deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,15 @@ env:
   BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
   COMMIT_TAG: ${{ github.sha }}
 jobs:
+  #api build steps are separated so they can run in parallel.
   build_simulation_api_image:
     # Any runner supporting Node 20 or newer
     runs-on: ubuntu-latest
     environment: beta
 
-    # Add "id-token" with the intended permissions.
     permissions:
       contents: "read"
+      # Required to auth against gcp
       id-token: "write"
 
     steps:
@@ -56,6 +57,7 @@ jobs:
     # Add "id-token" with the intended permissions.
     permissions:
       contents: "read"
+      #required to auth against GCP
       id-token: "write"
 
     steps:
@@ -71,27 +73,74 @@ jobs:
         version: ">= 363.0.0"
     - name: Build application
       run: make -f Makefile.deploy publish-full-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
+
   deploy_beta:
     needs: [build_simulation_api_image, build_full_api_image]
     runs-on: ubuntu-latest
+    outputs:
+      #This is required for the test step so it can authenticate and connect to
+      #the beta endpoint
+      full_api_url: ${{ steps.deploy_infra.outputs.full_api_url }}
     environment: beta
     env:
-        TF_VAR_stage: beta
-        TF_VAR_is_prod: false
+      TF_VAR_stage: beta
+      TF_VAR_is_prod: false
     
     permissions:
       contents: "read"
+      #required to auth against GCP
       id-token: "write"
 
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-    - uses: "google-github-actions/auth@v2"
+    - name: Authenticate as deploy SA in GCP
+      uses: "google-github-actions/auth@v2"
       with:
         workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
         service_account: "deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
     - uses: hashicorp/setup-terraform@v3
-    - name: Deploy gcp project
+    - name: Create/update GCP project
       run: make -f Makefile.deploy deploy-project
-    - name: Deploy actual services to the GCP project
-      run: make -f Makefile.deploy deploy-infra
+    - name: Deploy services into the GCP project
+      id: deploy_infra
+      run: |
+        make -f Makefile.deploy deploy-infra
+        #parse the resulting output variables and make them outputs of this step.
+        FULL_API_URL=$(cat terraform/infra-policyengine-api/terraform_output.json | jq -r .full_api_url.value)
+        echo "exporting full_api_url ${FULL_API_URL}"
+        echo "full_api_url=${FULL_API_URL}" >> "$GITHUB_OUTPUT"
+
+  integ_test_beta:
+    needs: [deploy_beta]
+    runs-on: ubuntu-latest
+    environment: beta
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+    - name: Set up poetry
+      run: uv pip install poetry --system
+    - name: Auth as tester SA in GCP
+      id: get-id-token
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "tester@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+        token_format: "id_token"
+        id_token_audience: ${{ needs.deploy_beta.outputs.full_api_url }}
+        id_token_include_email: true
+    - name: Mask id token to prevent accidental leak
+      run: echo "::add-mask::${{steps.get-id-token.outputs.id_token}}"
+    - name: run integ tests against deployed API
+      run: make -f Makefile.deploy integ-test  ACCESS_TOKEN=${{steps.get-id-token.outputs.id_token}} FULL_API_URL=${{needs.deploy_beta.outputs.full_api_url }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,6 @@ jobs:
     # Add "id-token" with the intended permissions.
     permissions:
       contents: "read"
-      id-token: "write"
 
     steps:
     - name: checkout repo
@@ -38,6 +37,7 @@ jobs:
         python-version: "3.11"
     - name: Set up poetry
       run: uv pip install poetry --system
+    #required to support python/typescript/etc. service client generation
     - name: Set up JDK 11 for x64
       uses: actions/setup-java@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ deploy-project: terraform/.bootstrap_settings
 	cd terraform/project-policyengine-api && make deploy
 
 deploy: deploy-project deploy-infra
+
+integ-test: 
+	cd projects/policyengine-api-full-integ && make integ-test

--- a/Makefile.deploy
+++ b/Makefile.deploy
@@ -10,12 +10,8 @@ deploy-project:
 deploy-infra:
 	cd terraform/infra-policyengine-api && make -f Makefile.deploy deploy
 
-deploy: publish-docker deploy-project deploy-infra
-
-plan-deploy-infra:
-	cd terraform/infra-policyengine-api && make -f Makefile.deploy plan-deploy
-
-plan-deploy-project:
-	cd terraform/project-policyengine-api && make -f Makefile.deploy plan-deploy
-
-plan-deploy: plan-deploy-project plan-deploy-infra
+integ-test:
+	# generate the service client
+	cd projects/policyengine-api-full && make build
+        # run the integration test using the client.
+	cd projects/policyengine-api-full-integ && make integ-test FULL_API_URL='$(FULL_API_URL)' ACCESS_TOKEN='$(ACCESS_TOKEN)'

--- a/projects/policyengine-api-full-integ/Makefile
+++ b/projects/policyengine-api-full-integ/Makefile
@@ -1,0 +1,5 @@
+integ-test:
+	poetry install
+	$(if $(ACCESS_TOKEN),INTEG_TEST_ACCESS_TOKEN='$(ACCESS_TOKEN)') \
+	$(if $(FULL_API_URL),INTEG_TEST_BASE_URL='$(FULL_API_URL)') \
+	poetry run pytest

--- a/projects/policyengine-api-full-integ/tests/test_ping.py
+++ b/projects/policyengine-api-full-integ/tests/test_ping.py
@@ -4,6 +4,7 @@ import pytest
 
 class Settings(BaseSettings):
     base_url:str = "http://localhost:8000"
+    access_token:str | None = None
     timeout_in_millis:int = 200
 
     model_config = SettingsConfigDict(env_prefix='integ_test_')
@@ -14,6 +15,7 @@ settings = Settings()
 def client()->policyengine_full_api_client.DefaultApi:
     config = policyengine_full_api_client.Configuration(host=settings.base_url)
     client = policyengine_full_api_client.ApiClient(config)
+    if settings.access_token: client.default_headers['Authorization'] = f"Bearer {settings.access_token}"
     return policyengine_full_api_client.DefaultApi(client)
 
 

--- a/terraform/infra-policyengine-api/.gitignore
+++ b/terraform/infra-policyengine-api/.gitignore
@@ -1,0 +1,1 @@
+terraform_output.json

--- a/terraform/infra-policyengine-api/Makefile.deploy
+++ b/terraform/infra-policyengine-api/Makefile.deploy
@@ -1,9 +1,12 @@
 plan-deploy: .terraform
 	terraform plan -input=false
 
+state: .terraform
+	terraform output -json
+
 deploy: .terraform
 	terraform apply -input=false -auto-approve
-
+	terraform output -json > terraform_output.json
 
 .terraform:
 	terraform init -backend-config="bucket=${TF_BACKEND_bucket}"

--- a/terraform/infra-policyengine-api/outputs.tf
+++ b/terraform/infra-policyengine-api/outputs.tf
@@ -1,9 +1,9 @@
 output "full_api_url" {
-  value = module.cloud_run_full_api.service_uri
+  value = google_cloud_run_v2_service.cloud_run_full_api.uri
 }
 
 output "simulation_api_url" {
-  value = module.cloud_run_simulation_api.service_uri
+  value = google_cloud_run_v2_service.cloud_run_simulation_api.uri
 }
 
 output "workflow_id" {

--- a/terraform/project-policyengine-api/outputs.tf
+++ b/terraform/project-policyengine-api/outputs.tf
@@ -28,6 +28,11 @@ output "deploy_service_account_email" {
     description = "Service account for deploying to the project"
 }
 
+output "tester_service_account_email" {
+    value = google_service_account.tester.email
+    description = "Service account for running tests"
+}
+
 output "docker_repository_namespace" {
     value = "${google_artifact_registry_repository.docker_repo.location}-docker.pkg.dev/${module.project.project_id}/${google_artifact_registry_repository.docker_repo.name}"
 }


### PR DESCRIPTION
Fixes  PolicyEngine/issues#135

This change
1. Updates the integration test to use (if provided) a bearer token
2. Updates the terraform deploy to give the tester service account the ability to invoke beta service deployments
3. Updates the deploy workflow to get an identity token for the tester service account
4. Updates the deploy workflow to have an integration test job that executes the integration test using that identity token.
