### PR TITLE
Add production deploy/test to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,143 +4,30 @@ on:
   push:
     branches:
       - main
-env:
-  TF_BACKEND_bucket: ${{ vars.PROJECT_ID }}-state
-  #TF_VAR_whatever will be picked up as terraform variables.
-  TF_VAR_org_id: ${{ secrets.ORG_ID }}
-  TF_VAR_billing_account: ${{ secrets.BILLING_ACCOUNT }}
-  TF_VAR_github_repo_owner_id: ${{ github.repository_owner_id }}
-  TF_VAR_github_repo: ${{ github.repository }}
-  TF_VAR_project_id: ${{ vars.PROJECT_ID }}
-  TF_VAR_region: ${{ vars.REGION }}
-  TF_VAR_full_container_tag: ${{ github.sha }}
-  TF_VAR_simulation_container_tag: ${{ github.sha }}
-  BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
-  COMMIT_TAG: ${{ github.sha }}
+
+concurrency:
+  group: deploy-main
+
 jobs:
-  #api build steps are separated so they can run in parallel.
-  build_simulation_api_image:
-    # Any runner supporting Node 20 or newer
-    runs-on: ubuntu-latest
-    environment: beta
-
-    permissions:
-      contents: "read"
-      # Required to auth against gcp
-      id-token: "write"
-
-    steps:
-    - name: checkout repo
-      uses: actions/checkout@v4
-    - uses: "google-github-actions/auth@v2"
-      with:
-        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
-        service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
-    - name: Set up JDK 11 for x64
-      uses: actions/setup-java@v4
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        architecture: x64
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@v2"
-      with:
-        version: ">= 363.0.0"
-    - name: Build application
-      run: make -f Makefile.deploy publish-simulation-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
-
-  build_full_api_image:
-    # Any runner supporting Node 20 or newer
-    runs-on: ubuntu-latest
-    environment: beta
-
-    # Add "id-token" with the intended permissions.
-    permissions:
-      contents: "read"
-      #required to auth against GCP
-      id-token: "write"
-
-    steps:
-    - name: checkout repo
-      uses: actions/checkout@v4
-    - uses: "google-github-actions/auth@v2"
-      with:
-        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
-        service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@v2"
-      with:
-        version: ">= 363.0.0"
-    - name: Build application
-      run: make -f Makefile.deploy publish-full-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
-
+  build_beta:
+    uses: ./.github/workflows/gcp-build.reusable.yml
+    with:
+      environment: beta
+    secrets: inherit
+  build_prod:
+    uses: ./.github/workflows/gcp-build.reusable.yml
+    with:
+      environment: prod
+    secrets: inherit
   deploy_beta:
-    needs: [build_simulation_api_image, build_full_api_image]
-    runs-on: ubuntu-latest
-    outputs:
-      #This is required for the test step so it can authenticate and connect to
-      #the beta endpoint
-      full_api_url: ${{ steps.deploy_infra.outputs.full_api_url }}
-    environment: beta
-    env:
-      TF_VAR_stage: beta
-      TF_VAR_is_prod: false
-    
-    permissions:
-      contents: "read"
-      #required to auth against GCP
-      id-token: "write"
-
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-    - name: Authenticate as deploy SA in GCP
-      uses: "google-github-actions/auth@v2"
-      with:
-        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
-        service_account: "deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
-    - uses: hashicorp/setup-terraform@v3
-    - name: Create/update GCP project
-      run: make -f Makefile.deploy deploy-project
-    - name: Deploy services into the GCP project
-      id: deploy_infra
-      run: |
-        make -f Makefile.deploy deploy-infra
-        #parse the resulting output variables and make them outputs of this step.
-        FULL_API_URL=$(cat terraform/infra-policyengine-api/terraform_output.json | jq -r .full_api_url.value)
-        echo "exporting full_api_url ${FULL_API_URL}"
-        echo "full_api_url=${FULL_API_URL}" >> "$GITHUB_OUTPUT"
-
-  integ_test_beta:
-    needs: [deploy_beta]
-    runs-on: ubuntu-latest
-    environment: beta
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-
-    steps:
-    - name: checkout repo
-      uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.11"
-    - name: Set up poetry
-      run: uv pip install poetry --system
-    - name: Auth as tester SA in GCP
-      id: get-id-token
-      uses: "google-github-actions/auth@v2"
-      with:
-        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
-        service_account: "tester@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
-        token_format: "id_token"
-        id_token_audience: ${{ needs.deploy_beta.outputs.full_api_url }}
-        id_token_include_email: true
-    - name: Mask id token to prevent accidental leak
-      run: echo "::add-mask::${{steps.get-id-token.outputs.id_token}}"
-    - name: run integ tests against deployed API
-      run: make -f Makefile.deploy integ-test  ACCESS_TOKEN=${{steps.get-id-token.outputs.id_token}} FULL_API_URL=${{needs.deploy_beta.outputs.full_api_url }}
+    needs: [build_beta]
+    uses: ./.github/workflows/gcp-deploy.reusable.yml
+    with:
+      environment: beta
+    secrets: inherit
+  deploy_prod:
+    needs: [deploy_beta, build_prod]
+    uses: ./.github/workflows/gcp-deploy.reusable.yml
+    with:
+      environment: prod
+    secrets: inherit

--- a/.github/workflows/gcp-build.reusable.yml
+++ b/.github/workflows/gcp-build.reusable.yml
@@ -1,0 +1,79 @@
+name: Reusable deploy to gcp workflow
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: 'The environment to deploy to (e.g., beta, prod)'
+
+env:
+  TF_BACKEND_bucket: ${{ vars.PROJECT_ID }}-state
+  #TF_VAR_whatever will be picked up as terraform variables.
+  TF_VAR_org_id: ${{ secrets.ORG_ID }}
+  TF_VAR_billing_account: ${{ secrets.BILLING_ACCOUNT }}
+  TF_VAR_github_repo_owner_id: ${{ github.repository_owner_id }}
+  TF_VAR_github_repo: ${{ github.repository }}
+  TF_VAR_project_id: ${{ vars.PROJECT_ID }}
+  TF_VAR_region: ${{ vars.REGION }}
+  TF_VAR_full_container_tag: ${{ github.sha }}
+  TF_VAR_simulation_container_tag: ${{ github.sha }}
+  BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
+  COMMIT_TAG: ${{ github.sha }}
+jobs:
+  #api build steps are separated so they can run in parallel.
+  build_simulation_api_image:
+    # Any runner supporting Node 20 or newer
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    permissions:
+      contents: "read"
+      # Required to auth against gcp
+      id-token: "write"
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v4
+    - uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+      with:
+        version: ">= 363.0.0"
+    - name: Build application
+      run: make -f Makefile.deploy publish-simulation-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs
+
+  build_full_api_image:
+    # Any runner supporting Node 20 or newer
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: "read"
+      #required to auth against GCP
+      id-token: "write"
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v4
+    - uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "builder@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+      with:
+        version: ">= 363.0.0"
+    - name: Build application
+      run: make -f Makefile.deploy publish-full-api-docker TAG=${{ github.sha }} PROJECT_ID=${{ vars.PROJECT_ID }} LOG_DIR=gs://${{ vars.PROJECT_ID }}-buildlogs

--- a/.github/workflows/gcp-deploy.reusable.yml
+++ b/.github/workflows/gcp-deploy.reusable.yml
@@ -1,0 +1,93 @@
+name: Reusable deploy to gcp workflow
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: 'The environment to deploy to (e.g., beta, prod)'
+
+env:
+  TF_BACKEND_bucket: ${{ vars.PROJECT_ID }}-state
+  #TF_VAR_whatever will be picked up as terraform variables.
+  TF_VAR_org_id: ${{ secrets.ORG_ID }}
+  TF_VAR_billing_account: ${{ secrets.BILLING_ACCOUNT }}
+  TF_VAR_github_repo_owner_id: ${{ github.repository_owner_id }}
+  TF_VAR_github_repo: ${{ github.repository }}
+  TF_VAR_project_id: ${{ vars.PROJECT_ID }}
+  TF_VAR_region: ${{ vars.REGION }}
+  TF_VAR_full_container_tag: ${{ github.sha }}
+  TF_VAR_simulation_container_tag: ${{ github.sha }}
+  BUILD_TAG: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
+  COMMIT_TAG: ${{ github.sha }}
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      #This is required for the test step so it can authenticate and connect to
+      #the beta endpoint
+      full_api_url: ${{ steps.deploy_infra.outputs.full_api_url }}
+    environment: ${{ inputs.environment }}
+    env:
+      TF_VAR_stage: ${{ inputs.environment }}
+      TF_VAR_is_prod: ${{ inputs.environment == 'prod' }}
+    
+    permissions:
+      contents: "read"
+      #required to auth against GCP
+      id-token: "write"
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - name: Authenticate as deploy SA in GCP
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+    - uses: hashicorp/setup-terraform@v3
+    - name: Create/update GCP project
+      run: make -f Makefile.deploy deploy-project
+    - name: Deploy services into the GCP project
+      id: deploy_infra
+      run: |
+        make -f Makefile.deploy deploy-infra
+        #parse the resulting output variables and make them outputs of this step.
+        FULL_API_URL=$(cat terraform/infra-policyengine-api/terraform_output.json | jq -r .full_api_url.value)
+        echo "exporting full_api_url ${FULL_API_URL}"
+        echo "full_api_url=${FULL_API_URL}" >> "$GITHUB_OUTPUT"
+
+  integ_test:
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+    - name: Set up poetry
+      run: uv pip install poetry --system
+    - name: Auth as tester SA in GCP
+      id: get-id-token
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
+        service_account: "tester@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+        token_format: "id_token"
+        id_token_audience: ${{ needs.deploy.outputs.full_api_url }}
+        id_token_include_email: true
+    - name: Mask id token to prevent accidental leak
+      run: echo "::add-mask::${{steps.get-id-token.outputs.id_token}}"
+    - name: run integ tests against deployed API
+      run: make -f Makefile.deploy integ-test  ACCESS_TOKEN=${{steps.get-id-token.outputs.id_token}} FULL_API_URL=${{needs.deploy.outputs.full_api_url }}

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -1,19 +1,6 @@
 locals {
-    # Assumption from cost estimate. May need to tweak based on real performance.
-    max_instance_request_concurrency = var.is_prod ? 80 : null
-    # API is reachable if production otherwise internal-only.
-    members = var.is_prod ? ["allUsers"] : []
-    # keep one instance running at all times in production for responsiveness.
-    # in other environments don't waste the money
-    min_instance_count = var.is_prod ? 1 : 0
-    max_instance_count = var.is_prod ? 10 : 1
-    
-    # minimum instance specs only apply in production
-    cpu_limit = var.is_prod ? "2" : null
-    memory_limit = var.is_prod ? "1024Mi" : null
-
-    full_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-full:${var.full_container_tag}"
-    simulation_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-simulation:${var.simulation_container_tag}"
+  full_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-full:${var.full_container_tag}"
+  simulation_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-simulation:${var.simulation_container_tag}"
 }
 
 provider "google" {
@@ -25,30 +12,37 @@ resource "google_cloud_run_v2_service" "cloud_run_full_api" {
   provider = google-beta
   project = var.project_id
   name     = "api-full"
-  location = "us-central1"
+  location = var.region
   deletion_protection = false
   ingress = "INGRESS_TRAFFIC_ALL"
 
   description = "PolicyEngine Full API"
 
   template {
+    # Assumption from cost estimate.
+    max_instance_request_concurrency = var.is_prod ? 80 : null
     containers {
       image = local.full_api_image
       resources {
+        #default to whatever the cheapest instance is unless in prod in which
+        # case values are again based on the cost esitmate.
         limits = {
-          cpu    = local.cpu_limit
-          memory = local.memory_limit
+          cpu    = var.is_prod ? 2 : null
+          memory = var.is_prod ? "1024Mi" : null
         }
       }
     }
     scaling {
-      min_instance_count = local.min_instance_count
-      max_instance_count = local.max_instance_count
+      # always keep one instance hot in prod
+      min_instance_count = var.is_prod ? 0 : 1
+      # in beta don't create a bunch of containers
+      # max in prod based on assumptions from cost estimate
+      max_instance_count = var.is_prod ? 1 : 10
     }
   }
 }
 
-data "google_iam_policy" "private" {
+data "google_iam_policy" "full_api" {
   binding {
     role = "roles/run.invoker"
     members = [
@@ -57,12 +51,12 @@ data "google_iam_policy" "private" {
   }
 }
 
-resource "google_cloud_run_service_iam_policy" "full_api_test_access" {
+resource "google_cloud_run_service_iam_policy" "full_api" {
   location = google_cloud_run_v2_service.cloud_run_full_api.location
   project  = google_cloud_run_v2_service.cloud_run_full_api.project
   service  = google_cloud_run_v2_service.cloud_run_full_api.name
 
-  policy_data = data.google_iam_policy.private.policy_data
+  policy_data = data.google_iam_policy.full_api.policy_data
 }
 
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service
@@ -70,7 +64,7 @@ resource "google_cloud_run_v2_service" "cloud_run_simulation_api" {
   provider = google-beta
   project = var.project_id
   name     = "api-simulation"
-  location = "us-central1"
+  location = var.region
   deletion_protection = false
   ingress = "INGRESS_TRAFFIC_ALL"
 
@@ -81,28 +75,41 @@ resource "google_cloud_run_v2_service" "cloud_run_simulation_api" {
       image = local.simulation_api_image
       resources {
         limits = {
+          # Need to tune. This process currently eats memory
           cpu    = 1
           memory =  "4Gi"
         }
       }
     }
     scaling {
-      min_instance_count = local.min_instance_count
-      max_instance_count = local.max_instance_count
+      min_instance_count = var.is_prod ? 1 : 0
+      max_instance_count = var.is_prod ? 10 : 1
     }
   }
 }
 
-resource "google_cloud_run_service_iam_policy" "simulation_api_test_access" {
+# Workflow and tester can both invoke the cloudrun service
+data "google_iam_policy" "simulation_api" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "serviceAccount:tester@${var.project_id}.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.workflow_sa.email}"
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "simulation_api" {
   location = google_cloud_run_v2_service.cloud_run_simulation_api.location
   project  = google_cloud_run_v2_service.cloud_run_simulation_api.project
   service  = google_cloud_run_v2_service.cloud_run_simulation_api.name
 
-  policy_data = data.google_iam_policy.private.policy_data
+  policy_data = data.google_iam_policy.simulation_api.policy_data
 }
 
 # Create a workflow
 resource "google_workflows_workflow" "simulation_workflow" {
+  depends_on = [ google_service_account.workflow_sa ]
   name            = "simulation-workflow"
   region          = var.region
   description     = "Simulation workflow"
@@ -117,18 +124,10 @@ resource "google_workflows_workflow" "simulation_workflow" {
     service_url = "${google_cloud_run_v2_service.cloud_run_simulation_api.uri}/simulate"
   }
   source_contents = file("../../projects/policyengine-api-simulation/workflow.yaml")
-
-  depends_on = [google_project_service.workflows_api]
 }
 
 # Create a dedicated service account for workflow
 resource "google_service_account" "workflow_sa" {
   account_id   = "simulation-workflows-sa"
   display_name = "Simulation Workflows Service Account"
-}
-
-# Enable Workflows API
-resource "google_project_service" "workflows_api" {
-  service            = "workflows.googleapis.com"
-  disable_on_destroy = false
 }

--- a/terraform/project-policyengine-api/Makefile
+++ b/terraform/project-policyengine-api/Makefile
@@ -5,6 +5,9 @@ bootstrap:
 bootstrap_beta:
 	scripts/bootstrap.sh beta
 
+bootstrap_prod:
+	scripts/bootstrap.sh prod
+
 deploy:
 	@echo "Attempting to deploy project using bootstrap settings in ../.bootstrap_settings/apply.tfvars"
 	terraform apply --var-file=../.bootstrap_settings/apply.tfvars

--- a/terraform/project-policyengine-api/main.tf
+++ b/terraform/project-policyengine-api/main.tf
@@ -38,7 +38,9 @@ module "project" {
     "run.googleapis.com",
     # required to deploy terraform
     "cloudresourcemanager.googleapis.com",
-    "serviceusage.googleapis.com"]
+    "serviceusage.googleapis.com",
+    # to orchestrate our simulation runs
+    "workflows.googleapis.com"]
 }
 
 resource "google_storage_bucket" "logs" {


### PR DESCRIPTION
Fixes PolicyEngine/issues#142

This change
1. Refactors the existing deployment workflow into a reusable gcp-build and gcp-deploy workflow
2. Changes the deploy workflow to use them
3. Build for both prod and beta is in parallel, but
4. deploy to prod only happens after beta integ test have passed and prod build has completed.