### PR TITLE
Add full probe support to full API

### DIFF
--- a/libs/policyengine-fastapi/src/policyengine_api/fastapi/health/__init__.py
+++ b/libs/policyengine-fastapi/src/policyengine_api/fastapi/health/__init__.py
@@ -1,0 +1,51 @@
+from typing import Callable, Optional
+from pydantic import BaseModel, Field
+
+class ProbeStatus(BaseModel):
+    name: str
+    healthy: bool
+    message: Optional[str] = None
+
+class SystemStatus(BaseModel):
+    name: str
+    healthy: bool
+    detail: list[ProbeStatus]
+
+class HealthStatus(BaseModel):
+    healthy: bool
+    systems: list[SystemStatus]
+
+HealthProbe = Callable[[], ProbeStatus]
+
+class HealthSystemReporter:
+    def __init__(self, name:str, probes:dict[str, HealthProbe]):
+        self.name = name
+        self.probes = probes
+    
+    def report(self)->SystemStatus:
+        detail = [ self.probes[key]() for key in self.probes.keys() ]
+        first_unhealthy = next( (d for d in detail if d.healthy is not True), None)
+        return SystemStatus(name=self.name,
+                            healthy = first_unhealthy is None,
+                            detail=detail)
+
+class HealthRegistry:
+    """
+    Mechanism for collecting and reporting sevice health.
+    NOTE: any error will result in the service being restarted
+    so only report real errors.
+    """
+    systems:dict[str, HealthSystemReporter]
+
+    def __init__(self):
+        self.systems = {}
+
+    def register(self, reporter:HealthSystemReporter):
+        self.systems[reporter.name] = reporter
+
+    def report(self)->HealthStatus:
+        system_status = [ self.systems[key].report() for key in self.systems.keys()]
+        first_unhealthy = next( (s for s in system_status if s.healthy is not True), None)
+        return HealthStatus(
+            healthy = first_unhealthy is None,
+            systems = system_status)

--- a/libs/policyengine-fastapi/src/policyengine_api/fastapi/ping/__init__.py
+++ b/libs/policyengine-fastapi/src/policyengine_api/fastapi/ping/__init__.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI, APIRouter
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from policyengine_api.fastapi.health import HealthRegistry, HealthStatus
 
 
 class PingRequest(BaseModel):
@@ -10,18 +12,36 @@ class PingResponse(BaseModel):
     incremented: int
 
 
-def create_router() -> APIRouter:
+def create_router(health_registry: HealthRegistry) -> APIRouter:
     router = APIRouter()
 
     @router.post("/ping")
     async def ping(request: PingRequest) -> PingResponse:
         """
-        verify the api is able to recieve and process unauthenticated requests.
+        Verify the api is able to recieve and process unauthenticated requests.
         """
         return PingResponse(incremented=request.value + 1)
+
+    @router.get("/ping/started", response_model=str)
+    async def started():
+        """
+        Verify the api is running.
+        """
+        return "alive"
+
+    @router.get("/ping/alive", response_model=HealthStatus)
+    async def alive():
+        """
+        Check if the service is healthy. This will always return 
+        data, but will return a 503 response code if the service is
+        unhealthy.
+        """
+        content = health_registry.report()
+        return JSONResponse(content=content.model_dump(exclude_none=True),
+                            status_code=200 if content.healthy else 503)
 
     return router
 
 
-def include_all_routers(api: FastAPI):
-    api.include_router(create_router())
+def include_all_routers(api: FastAPI, health_registry: HealthRegistry):
+    api.include_router(create_router(health_registry))

--- a/libs/policyengine-fastapi/tests/ping/conftest.py
+++ b/libs/policyengine-fastapi/tests/ping/conftest.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from fastapi import FastAPI
+from policyengine_api.fastapi import ping
+from policyengine_api.fastapi.health import HealthRegistry
+
+
+@pytest.fixture
+def health_registry() -> HealthRegistry:
+    return HealthRegistry()
+
+
+@pytest.fixture
+def client(health_registry: HealthRegistry) -> TestClient:
+    api = FastAPI()
+    ping.include_all_routers(api, health_registry)
+    return TestClient(api)

--- a/libs/policyengine-fastapi/tests/ping/test_alive.py
+++ b/libs/policyengine-fastapi/tests/ping/test_alive.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+from policyengine_api.fastapi.health import HealthRegistry, HealthSystemReporter, ProbeStatus
+import pytest
+
+
+def test_when_healthy__success_response(client: TestClient, health_registry: HealthRegistry):
+    health_registry.register(HealthSystemReporter(
+        name="test_system",
+        probes={
+            "check1": lambda: ProbeStatus(name="check1", healthy=True)
+        }
+    ))
+    response = client.get("/ping/alive")
+
+    assert response.json() == {
+        "healthy": True,
+        "systems": [
+            {
+                "name": "test_system",
+                "healthy": True,
+                "detail": [
+                    {
+                        "name": "check1",
+                        "healthy": True
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert response.status_code == 200
+
+
+def test_when_unhealthy_probe___generates_503(client: TestClient, health_registry: HealthRegistry):
+    health_registry.register(HealthSystemReporter(
+        name="test_system",
+        probes={
+            "check1": lambda: ProbeStatus(name="check1", healthy=True),
+            "check2": lambda: ProbeStatus(name="check2", healthy=False)
+        }
+    ))
+    response = client.get("/ping/alive")
+
+    assert response.json() == {
+        "healthy": False,
+        "systems": [
+            {
+                "name": "test_system",
+                "healthy": False,
+                "detail": [
+                    {
+                        "name": "check1",
+                        "healthy": True
+                    },
+                    {
+                        "name": "check2",
+                        "healthy": False
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert response.status_code == 503

--- a/libs/policyengine-fastapi/tests/ping/test_ping.py
+++ b/libs/policyengine-fastapi/tests/ping/test_ping.py
@@ -1,16 +1,4 @@
 from fastapi.testclient import TestClient
-import pytest
-
-from fastapi import FastAPI
-from policyengine_api.fastapi import ping
-
-
-@pytest.fixture
-def client() -> TestClient:
-    api = FastAPI()
-    ping.include_all_routers(api)
-    return TestClient(api)
-
 
 def test_execute_ping_increments_request_value(client: TestClient):
     response = client.post("/ping", json={"value": 10})

--- a/libs/policyengine-fastapi/tests/ping/test_started.py
+++ b/libs/policyengine-fastapi/tests/ping/test_started.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+
+
+def test_started__returns_alive(client: TestClient):
+    response = client.get("/ping/started")
+
+    assert response.json() == 'alive'
+    assert response.status_code == 200

--- a/projects/policyengine-api-full/src/policyengine_api_full/main.py
+++ b/projects/policyengine-api-full/src/policyengine_api_full/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from sqlmodel import SQLModel
 from policyengine_api.fastapi.database import create_sqlite_engine
 from policyengine_api.fastapi import ping
+from policyengine_api.fastapi.health import HealthRegistry, HealthSystemReporter
 from .settings import get_settings, Environment
 from policyengine_api.fastapi.opentelemetry import (
     GCPLoggingInstrumentor,
@@ -49,7 +50,12 @@ initialize(
     jwt_audience=get_settings().jwt_audience,
 )
 
-ping.include_all_routers(app)
+health_registry = HealthRegistry()
+#TODO: we can use this to verify the db connection, etc.
+#For now, we don't register any probes and it will just report
+# healthy all the time.
+health_registry.register(HealthSystemReporter("general", {}))
+ping.include_all_routers(app, health_registry)
 
 #configure tracing and metrics
 GCPLoggingInstrumentor().instrument()


### PR DESCRIPTION
Fixes #67 

1. Updated the "ping" route from policyengine_api.fast_api to include probe endpoints.
2. Updated the terraform cloudrun service config to use them.