### PR TITLE
full api now generates metrics and traces correctly.

### DIFF
--- a/projects/policyengine-api-full/Dockerfile
+++ b/projects/policyengine-api-full/Dockerfile
@@ -5,7 +5,12 @@ RUN pip install poetry==2.0.1
 ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
-    POETRY_CACHE_DIR=/tmp/poetry_cache
+    POETRY_CACHE_DIR=/tmp/poetry_cache \
+    ENVIRONMENT="production" \
+    JWT_ISSUER=https://your_production_issuer/ \
+    JWT_AUDIENCE=https://your_production_api/ \
+    OT_SERVICE_NAME=policyengine_full_api \
+    OT_SERVICE_INSTANCE_ID=instance
 
 WORKDIR app
 # This may copy some dependencies this app doesn't need, but source should

--- a/terraform/project-policyengine-api/main.tf
+++ b/terraform/project-policyengine-api/main.tf
@@ -40,7 +40,10 @@ module "project" {
     "cloudresourcemanager.googleapis.com",
     "serviceusage.googleapis.com",
     # to orchestrate our simulation runs
-    "workflows.googleapis.com"]
+    "workflows.googleapis.com",
+    # to support tracelogs and metrics from our services
+    "cloudtrace.googleapis.com",
+    "monitoring.googleapis.com"]
 }
 
 resource "google_storage_bucket" "logs" {


### PR DESCRIPTION
fixes #71
This fixes the docker file to set the environment to "production" so it generates metrics, etc. via gcp metrics/trace/etc. instead of just logging them.

It also updates the terraform settings to enable the correct APIs and permissions that will let the service use trace and metrics.