### PR TITLE
Add PolicyEngineCountry.calculate() method tests

### DIFF
--- a/libs/policyengine-api/src/policyengine_api/api/data/examples/example_household_uk.py
+++ b/libs/policyengine-api/src/policyengine_api/api/data/examples/example_household_uk.py
@@ -1,0 +1,46 @@
+example_people_uk = {
+    "you": {"age": {"2024": 40}, "employment_income": {"2024": 29000}},
+    "your first dependent": {
+        "age": {"2024": 5},
+        "employment_income": {"2024": 0},
+        "is_child": {"2024": True},
+    },
+}
+
+# Note the difference below - inputs accept None to indicate the
+# user wants to calculate this variable, while outputs should never
+# contain None.
+example_benunits_input_uk = {
+    "your benunit": {
+        "members": ["you", "your first dependent"],
+        "universal_credit": {"2024": None},
+    }
+}
+
+example_benunits_output_uk = {
+    "your benunit": {
+        "members": ["you", "your first dependent"],
+        "universal_credit": {"2024": 5000.0},
+    }
+}
+
+example_households_uk = {
+    "your household": {
+        "members": ["you", "your first dependent"],
+        "country": {"2024": "ENGLAND"},
+    }
+}
+
+example_household_input_uk = {
+    "people": example_people_uk,
+    "benunits": example_benunits_input_uk,
+    "households": example_households_uk,
+}
+
+# Temporarily disabling axes to better understand schema
+example_household_output_uk = {
+    # "axes": None,
+    "people": example_people_uk,
+    "benunits": example_benunits_output_uk,
+    "households": example_households_uk,
+}

--- a/libs/policyengine-api/src/policyengine_api/api/data/examples/example_household_us.py
+++ b/libs/policyengine-api/src/policyengine_api/api/data/examples/example_household_us.py
@@ -59,8 +59,9 @@ example_household_input_us = {
     "marital_units": example_marital_units_us,
 }
 
+# Temporarily disabling axes to better understand schema
 example_household_output_us = {
-    "axes": None,
+    # "axes": None,
     "people": example_people_us,
     "families": example_families_us,
     "spm_units": example_spm_units_us,

--- a/libs/policyengine-api/src/policyengine_api/api/models/household.py
+++ b/libs/policyengine-api/src/policyengine_api/api/models/household.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, RootModel, Field
 from typing import Union, Any, Optional
-from policyengine_api.api.data.examples.example_household import (
+from policyengine_api.api.data.examples.example_household_us import (
     example_people_us,
     example_families_us,
     example_spm_units_us,
@@ -9,13 +9,13 @@ from policyengine_api.api.data.examples.example_household import (
     example_marital_units_us,
 )
 
-
-class HouseholdAxes(BaseModel):
-    name: str  # Variable over which to apply axes
-    period: int | str  # The month or year to which the axes apply
-    count: int  # The number of axes
-    min: int  # The lowest axis
-    max: int  # The highest axis
+# Temporarily disabling axes to better understand schema
+# class HouseholdAxes(BaseModel):
+#     name: str  # Variable over which to apply axes
+#     period: int | str  # The month or year to which the axes apply
+#     count: int  # The number of axes
+#     min: int  # The lowest axis
+#     max: int  # The highest axis
 
 
 class HouseholdVariable(RootModel):
@@ -31,7 +31,7 @@ class HouseholdGeneric(BaseModel):
         examples=[example_households_us]
     )
     people: dict[str, HouseholdEntity] = Field(examples=[example_people_us])
-    axes: Optional[dict[str, HouseholdAxes]] = None
+    # axes: Optional[HouseholdAxes] = None
 
 
 class HouseholdUS(HouseholdGeneric):

--- a/libs/policyengine-api/tests/fixtures/country.py
+++ b/libs/policyengine-api/tests/fixtures/country.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+
+def is_valid_household(household_dict: dict[str, Any]) -> bool:
+
+    # Surely there must be a better way of doing this, perhaps natively within
+    # the Pydantic model itself?
+    for entity_group in household_dict.keys():
+
+        # Skip axes; this isn't an entity group, only an info module at the same level
+        if entity_group == "axes":
+            continue
+        for entity in household_dict[entity_group].keys():
+            for variable in household_dict[entity_group][entity].keys():
+                # Members is an array that can contain any number of items, thus
+                # any format is valid
+                if variable == "members":
+                    continue
+                for period in household_dict[entity_group][entity][
+                    variable
+                ].keys():
+                    if (
+                        household_dict[entity_group][entity][variable][period]
+                        is None
+                    ):
+                        return False
+
+    return True

--- a/libs/policyengine-api/tests/unit/test_country.py
+++ b/libs/policyengine-api/tests/unit/test_country.py
@@ -1,0 +1,76 @@
+from policyengine_api.api.country import PolicyEngineCountry
+from policyengine_api.api.data.examples.example_household_us import (
+    example_household_input_us,
+)
+from policyengine_api.api.data.examples.example_household_uk import (
+    example_household_input_uk,
+)
+from policyengine_api.api.models.household import HouseholdUS, HouseholdUK
+from ..fixtures.country import is_valid_household
+
+
+class TestCalculate:
+
+    def test_given_valid_us_input__return_valid_output(self):
+        test_country_id = "us"
+
+        country = PolicyEngineCountry(
+            f"policyengine_{test_country_id}", test_country_id
+        )
+        valid_household = HouseholdUS(**example_household_input_us)
+        reform = None
+
+        result = country.calculate(valid_household, reform)
+
+        assert result is not None
+        assert type(result) == HouseholdUS
+
+        household_dict = result.model_dump()
+        assert is_valid_household(household_dict)
+
+    def test_given_valid_uk_input__return_valid_output(self):
+        test_country_id = "uk"
+
+        country = PolicyEngineCountry(
+            f"policyengine_{test_country_id}", test_country_id
+        )
+        valid_household = HouseholdUK(**example_household_input_uk)
+        reform = None
+
+        result = country.calculate(valid_household, reform)
+
+        assert result is not None
+        assert type(result) == HouseholdUK
+
+        household_dict = result.model_dump()
+        assert is_valid_household(household_dict)
+
+    # Temporarily disabling due to questions around our existing axes schema -
+    # when I emit a front-end request with axes, why is it the HouseholdAxes
+    # module defined in this package doubly nested inside two arrays?
+    # def test_given_household_with_axes__return_valid_output(self):
+    #     test_country_id = "us"
+
+    #     country = PolicyEngineCountry(
+    #         f"policyengine_{test_country_id}", test_country_id
+    #     )
+    #     valid_household = example_household_input_us
+    #     valid_axes = {
+    #         "name": "employment_income",
+    #         "period": "2024",
+    #         "count": 11,
+    #         "min": 0,
+    #         "max": 100000,
+    #     }
+    #     valid_household["axes"] = valid_axes
+    #     serialized_household = HouseholdUS(**valid_household)
+    #     reform = None
+
+    #     result = country.calculate(serialized_household, reform)
+
+    #     assert result is not None
+    #     assert type(result) == HouseholdUS
+
+    #     household_dict = result.model_dump()
+    #     assert is_valid_household(household_dict)
+    #     assert "axes" in household_dict.keys()


### PR DESCRIPTION
Fixes #78 

Adds tests for the `PolicyEngineCountry.calculate()` method. This also temporarily disables axes until I can speak with Nikhil about why their structure in API v1 is the expected key-value pairs that we already encoded into API v2, except doubly nested inside two arrays.