### PR TITLE
Add IS_DEV_FORK github variable to prevent full prod deploy

### DIFF
--- a/.github/workflows/gcp-deploy.reusable.yml
+++ b/.github/workflows/gcp-deploy.reusable.yml
@@ -31,7 +31,7 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       TF_VAR_stage: ${{ inputs.environment }}
-      TF_VAR_is_prod: ${{ inputs.environment == 'prod' }}
+      TF_VAR_is_prod: ${{ inputs.environment == 'prod' && (vars.IS_DEV_FORK == 'false') }}
     
     permissions:
       contents: "read"

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -73,7 +73,7 @@ resource "google_cloud_run_v2_service" "cloud_run_full_api" {
       min_instance_count = var.is_prod ? 1 : 0
       # in beta don't create a bunch of containers
       # max in prod based on assumptions from cost estimate
-      max_instance_count = var.is_prod ? 1 : 10
+      max_instance_count = var.is_prod ? 10 : 1
     }
   }
 }


### PR DESCRIPTION
Fixes #88

To actually deploy real prod resources this has to exist and be false.

Otherwise we deploy beta level resources to the prod stage (it's expensive otherwise)

Also fixed a typo in the terraform that caused us to incorrectly set max instances of the main service container in prod vs beta.