### PR TITLE
fullapi flushes opentelemetry on exit

### DIFF
--- a/libs/policyengine-fastapi/poetry.lock
+++ b/libs/policyengine-fastapi/poetry.lock
@@ -1364,6 +1364,25 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3"},
+    {file = "pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -2096,4 +2115,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "7e1b4c67f71c9b728c265ecf119f291bdf9d028729f554f1875e87b0d1827d44"
+content-hash = "6f9d14e8cbd96713990b02861a980fa20885d89855172f56da2bad8fc24fab4b"

--- a/libs/policyengine-fastapi/pyproject.toml
+++ b/libs/policyengine-fastapi/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "opentelemetry-instrumentation-logging (>=0.51b0,<0.52)",
     "opentelemetry-exporter-gcp-trace (>=1.9.0,<2.0.0)",
     "opentelemetry-exporter-gcp-monitoring (>=1.9.0a0,<2.0.0)",
-    "opentelemetry-instrumentation-fastapi (>=0.51b0,<0.52)"
+    "opentelemetry-instrumentation-fastapi (>=0.51b0,<0.52)",
 ]
 
 
@@ -32,6 +32,7 @@ packages = [
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.4"
+pytest-asyncio = "^0.25.3"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/libs/policyengine-fastapi/src/policyengine_api/fastapi/exit.py
+++ b/libs/policyengine-fastapi/src/policyengine_api/fastapi/exit.py
@@ -1,0 +1,37 @@
+"""
+atexit does not work with uvicorn/fastapi for whatever reason and fastapi does not provide
+a middleware-style way to register lifecycle events so I'm writing this
+"""
+import logging
+from contextlib import asynccontextmanager
+from functools import wraps
+from typing import Any, Callable, TypeVar, cast
+
+from fastapi import FastAPI
+
+log = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=Callable[..., Any])
+
+class AppExit:
+    def __init__(self):
+        self.callbacks:list[Callable[[],None]] = []
+
+    def __call__(self, *args: Any, **kwargs: Any):
+        def accept(func:T)->T:
+            self.callbacks.append(lambda : func(*args, **kwargs))
+            return func
+        return accept
+    
+    def _exit(self):
+        log.info("Executing exit callbacks")
+        for cb in self.callbacks:
+            cb()
+        log.info("Exit callbacks executed")
+    
+    @asynccontextmanager
+    async def lifespan(self):
+        yield
+        self._exit()
+    
+exit = AppExit()

--- a/libs/policyengine-fastapi/tests/test_exit.py
+++ b/libs/policyengine-fastapi/tests/test_exit.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock, call
+from policyengine_api.fastapi.exit import exit
+import pytest
+
+@pytest.mark.asyncio
+async def test_lifecycle_executes_callbacks__when_app_ends():
+    app = Mock()
+    callback = Mock()
+
+    parent = Mock()
+    parent.app = app
+    parent.callback = callback
+    
+    exit()(callback)
+
+    async with exit.lifespan() as resource:
+        app()
+
+    parent.assert_has_calls([call.app(), call.callback()])
+    

--- a/projects/policyengine-api-full/logs
+++ b/projects/policyengine-api-full/logs
@@ -1,0 +1,1493 @@
+poetry run fastapi dev src/policyengine_api_full/main.py
+
+   FastAPI   Starting development server 🚀
+ 
+             Searching for package file structure from directories with __init__.py files
+             Importing from /home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full/src
+ 
+    module   📁 policyengine_api_full
+             ├── 🐍 __init__.py
+             └── 🐍 main.py
+ 
+      code   Importing the FastAPI app object from the module with the following code:
+ 
+             from policyengine_api_full.main import app
+ 
+       app   Using import string: policyengine_api_full.main:app
+ 
+    server   Server started at http://127.0.0.1:8000
+    server   Documentation at http://127.0.0.1:8000/docs
+ 
+       tip   Running in development mode, for production use: fastapi run
+ 
+             Logs:
+ 
+      INFO   Will watch for changes in these directories: ['/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full']
+{"timestamp": "2025-03-19T11:30:36Z", "severity": "INFO", "message": "Will watch for changes in these directories: ['/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full']", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+{"timestamp": "2025-03-19T11:30:36Z", "severity": "INFO", "message": "Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Uvicorn running on \u001b[1m%s://%s:%d\u001b[0m (Press CTRL+C to quit)"}
+      INFO   Started reloader process [13157] using WatchFiles
+{"timestamp": "2025-03-19T11:30:36Z", "severity": "INFO", "message": "Started reloader process [13157] using WatchFiles", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Started reloader process [\u001b[36m\u001b[1m13157\u001b[0m] using \u001b[36m\u001b[1mWatchFiles\u001b[0m"}
+      INFO   Started server process [13164]
+{"timestamp": "2025-03-19T11:30:39Z", "severity": "INFO", "message": "Started server process [13164]", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Started server process [\u001b[36m%d\u001b[0m]"}
+      INFO   Waiting for application startup.
+{"timestamp": "2025-03-19T11:30:39Z", "severity": "INFO", "message": "Waiting for application startup.", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Application startup complete.
+{"timestamp": "2025-03-19T11:30:39Z", "severity": "INFO", "message": "Application startup complete.", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:39Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:40Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:40Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:40Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:41Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:41Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:41Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:42Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:42Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   127.0.0.1:37638 - "GET /docs HTTP/1.1" 200
+{"timestamp": "2025-03-19T11:30:42Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:43Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:43Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:44Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full/.venv/lib/python3.11/site-packages/pydantic/json_schema.py:2279: PydanticJsonSchemaWarning: Default value User.username is not JSON serializable; excluding default from JSON schema [non-serializable-default]
+  warnings.warn(message, PydanticJsonSchemaWarning)
+/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full/.venv/lib/python3.11/site-packages/pydantic/json_schema.py:2279: PydanticJsonSchemaWarning: Default value User.id is not JSON serializable; excluding default from JSON schema [non-serializable-default]
+  warnings.warn(message, PydanticJsonSchemaWarning)
+/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full/.venv/lib/python3.11/site-packages/pydantic/json_schema.py:2279: PydanticJsonSchemaWarning: Default value User.auth0_sub is not JSON serializable; excluding default from JSON schema [non-serializable-default]
+  warnings.warn(message, PydanticJsonSchemaWarning)
+      INFO   127.0.0.1:37638 - "GET /openapi.json HTTP/1.1" 200
+{"timestamp": "2025-03-19T11:30:44Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{
+    "name": "connect",
+    "context": {
+        "trace_id": "0x483f83cafa8e7111753333cd9fc2fc96",
+        "span_id": "0x338795dfe1f4ff24",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.715792Z",
+    "end_time": "2025-03-19T18:30:39.718523Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.name": ":memory:",
+        "db.system": "sqlite"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0xc05dacfb88aa847a7f88fa8016702b76",
+        "span_id": "0x2dad9cc8166f7414",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.719000Z",
+    "end_time": "2025-03-19T18:30:39.720148Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA main.table_info(\"household\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0x7d0f9240478f21720b9c14ec7bb77a73",
+        "span_id": "0xa272af6888cd54cc",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.720578Z",
+    "end_time": "2025-03-19T18:30:39.721295Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA temp.table_info(\"household\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0xd74f3706d1de35d2192c3e4adc4520cc",
+        "span_id": "0x8d1c62eed478d1f9",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.721594Z",
+    "end_time": "2025-03-19T18:30:39.721830Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA main.table_info(\"user\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0xdfea3ba68205f4bebae80db70211349e",
+        "span_id": "0x40df95ee0a858680",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.722052Z",
+    "end_time": "2025-03-19T18:30:39.722238Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA temp.table_info(\"user\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "CREATE :memory:",
+    "context": {
+        "trace_id": "0xd977000ab149cc70cc2398d7d22386b9",
+        "span_id": "0xe6b870ad922a1102",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.723314Z",
+    "end_time": "2025-03-19T18:30:39.724233Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "\nCREATE TABLE household (\n\tid INTEGER NOT NULL, \n\tPRIMARY KEY (id)\n)\n\n",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "CREATE :memory:",
+    "context": {
+        "trace_id": "0x615d7d4294417c363e0dcbccb3335e03",
+        "span_id": "0xede5188faf805bda",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:39.725108Z",
+    "end_time": "2025-03-19T18:30:39.725519Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "\nCREATE TABLE user (\n\tusername VARCHAR NOT NULL, \n\tid INTEGER NOT NULL, \n\tauth0_sub VARCHAR NOT NULL, \n\tPRIMARY KEY (id)\n)\n\n",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /docs http send",
+    "context": {
+        "trace_id": "0xe644d4dec1b0ebbd62e05c701927f181",
+        "span_id": "0x040f93f207e2ed58",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0xc9fc86594b3d59d8",
+    "start_time": "2025-03-19T18:30:42.624608Z",
+    "end_time": "2025-03-19T18:30:42.624739Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.start",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /docs http send",
+    "context": {
+        "trace_id": "0xe644d4dec1b0ebbd62e05c701927f181",
+        "span_id": "0x9901096f3b1a2ace",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0xc9fc86594b3d59d8",
+    "start_time": "2025-03-19T18:30:42.625156Z",
+    "end_time": "2025-03-19T18:30:42.625181Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.body"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /docs",
+    "context": {
+        "trace_id": "0xe644d4dec1b0ebbd62e05c701927f181",
+        "span_id": "0xc9fc86594b3d59d8",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.SERVER",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:42.624104Z",
+    "end_time": "2025-03-19T18:30:42.627498Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "http.scheme": "http",
+        "http.host": "127.0.0.1:8000",
+        "net.host.port": 8000,
+        "http.flavor": "1.1",
+        "http.target": "/docs",
+        "http.url": "http://127.0.0.1:8000/docs",
+        "http.method": "GET",
+        "http.server_name": "127.0.0.1:8000",
+        "http.user_agent": "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        "net.peer.ip": "127.0.0.1",
+        "net.peer.port": 37638,
+        "http.route": "/docs",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /openapi.json http send",
+    "context": {
+        "trace_id": "0xd53c9dc8f6c35ad0030dd7fa50d2b312",
+        "span_id": "0xb6f349636848201a",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x080bc72826dda699",
+    "start_time": "2025-03-19T18:30:44.264567Z",
+    "end_time": "2025-03-19T18:30:44.264724Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.start",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /openapi.json http send",
+    "context": {
+        "trace_id": "0xd53c9dc8f6c35ad0030dd7fa50d2b312",
+        "span_id": "0x85e7dabca104a145",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x080bc72826dda699",
+    "start_time": "2025-03-19T18:30:44.265341Z",
+    "end_time": "2025-03-19T18:30:44.265530Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.body"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /openapi.json",
+    "context": {
+        "trace_id": "0xd53c9dc8f6c35ad0030dd7fa50d2b312",
+        "span_id": "0x080bc72826dda699",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.SERVER",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:44.210904Z",
+    "end_time": "2025-03-19T18:30:44.274141Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "http.scheme": "http",
+        "http.host": "127.0.0.1:8000",
+        "net.host.port": 8000,
+        "http.flavor": "1.1",
+        "http.target": "/openapi.json",
+        "http.url": "http://127.0.0.1:8000/openapi.json",
+        "http.method": "GET",
+        "http.server_name": "127.0.0.1:8000",
+        "http.user_agent": "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        "net.peer.ip": "127.0.0.1",
+        "net.peer.port": 37638,
+        "http.route": "/openapi.json",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{"timestamp": "2025-03-19T11:30:44Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:45Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:45Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:45Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:46Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:46Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:46Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:47Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:47Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:47Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:48Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:48Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:48Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:49Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:49Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   127.0.0.1:37652 - "GET /ping/alive HTTP/1.1" 200
+{"timestamp": "2025-03-19T11:30:50Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:50Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:50Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:51Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:51Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   127.0.0.1:37656 - "GET /ping/alive HTTP/1.1" 200
+{"timestamp": "2025-03-19T11:30:51Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:52Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   127.0.0.1:37656 - "GET /ping/alive HTTP/1.1" 200
+{"timestamp": "2025-03-19T11:30:52Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:52Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:53Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:53Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:53Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:54Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:54Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0x918078fee8184f76cb3237a1f8a65533",
+        "span_id": "0x587af89748dfc491",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x1275e0cb2aab88f2",
+    "start_time": "2025-03-19T18:30:49.737989Z",
+    "end_time": "2025-03-19T18:30:49.738081Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.start",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0x918078fee8184f76cb3237a1f8a65533",
+        "span_id": "0x00e7177ab412d904",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x1275e0cb2aab88f2",
+    "start_time": "2025-03-19T18:30:49.738602Z",
+    "end_time": "2025-03-19T18:30:49.738635Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.body"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive",
+    "context": {
+        "trace_id": "0x918078fee8184f76cb3237a1f8a65533",
+        "span_id": "0x1275e0cb2aab88f2",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.SERVER",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:49.736886Z",
+    "end_time": "2025-03-19T18:30:49.741976Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "http.scheme": "http",
+        "http.host": "127.0.0.1:8000",
+        "net.host.port": 8000,
+        "http.flavor": "1.1",
+        "http.target": "/ping/alive",
+        "http.url": "http://127.0.0.1:8000/ping/alive",
+        "http.method": "GET",
+        "http.server_name": "127.0.0.1:8000",
+        "http.user_agent": "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        "net.peer.ip": "127.0.0.1",
+        "net.peer.port": 37652,
+        "http.route": "/ping/alive",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0x0e793ac0d85b23da7abd388522da2db4",
+        "span_id": "0x1ff4fe2bc0f5cb68",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0xbabe2b55b0efadca",
+    "start_time": "2025-03-19T18:30:51.579390Z",
+    "end_time": "2025-03-19T18:30:51.579459Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.start",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0x0e793ac0d85b23da7abd388522da2db4",
+        "span_id": "0xa53665d9cd73ff28",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0xbabe2b55b0efadca",
+    "start_time": "2025-03-19T18:30:51.579805Z",
+    "end_time": "2025-03-19T18:30:51.579830Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.body"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive",
+    "context": {
+        "trace_id": "0x0e793ac0d85b23da7abd388522da2db4",
+        "span_id": "0xbabe2b55b0efadca",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.SERVER",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:51.578094Z",
+    "end_time": "2025-03-19T18:30:51.581806Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "http.scheme": "http",
+        "http.host": "127.0.0.1:8000",
+        "net.host.port": 8000,
+        "http.flavor": "1.1",
+        "http.target": "/ping/alive",
+        "http.url": "http://127.0.0.1:8000/ping/alive",
+        "http.method": "GET",
+        "http.server_name": "127.0.0.1:8000",
+        "http.user_agent": "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        "net.peer.ip": "127.0.0.1",
+        "net.peer.port": 37656,
+        "http.route": "/ping/alive",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0xc2f44b15ca6d4e06698b5573f8f7c2b8",
+        "span_id": "0xdfb42ca101d1f49e",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x7e353ce3880ed9dd",
+    "start_time": "2025-03-19T18:30:52.443127Z",
+    "end_time": "2025-03-19T18:30:52.443210Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.start",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0xc2f44b15ca6d4e06698b5573f8f7c2b8",
+        "span_id": "0x0795ca45ce117a1e",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x7e353ce3880ed9dd",
+    "start_time": "2025-03-19T18:30:52.443764Z",
+    "end_time": "2025-03-19T18:30:52.443807Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.body"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive",
+    "context": {
+        "trace_id": "0xc2f44b15ca6d4e06698b5573f8f7c2b8",
+        "span_id": "0x7e353ce3880ed9dd",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.SERVER",
+    "parent_id": null,
+    "start_time": "2025-03-19T18:30:52.441973Z",
+    "end_time": "2025-03-19T18:30:52.446213Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "http.scheme": "http",
+        "http.host": "127.0.0.1:8000",
+        "net.host.port": 8000,
+        "http.flavor": "1.1",
+        "http.target": "/ping/alive",
+        "http.url": "http://127.0.0.1:8000/ping/alive",
+        "http.method": "GET",
+        "http.server_name": "127.0.0.1:8000",
+        "http.user_agent": "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+        "net.peer.ip": "127.0.0.1",
+        "net.peer.port": 37656,
+        "http.route": "/ping/alive",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{"timestamp": "2025-03-19T11:30:54Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:55Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:55Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:56Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:56Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:56Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:57Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:57Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:57Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:58Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:58Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:58Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:59Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:59Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:30:59Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:00Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:00Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:01Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:01Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:01Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:02Z", "severity": "INFO", "message": "5 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:02Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:02Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:03Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:03Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:03Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:04Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:04Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:04Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:05Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:05Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:05Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:06Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:06Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:07Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:07Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:07Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:08Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:08Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:08Z", "severity": "INFO", "message": "2 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:09Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:09Z", "severity": "INFO", "message": "5 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:09Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:10Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:10Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:10Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:11Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:11Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:11Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:12Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:12Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:13Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:13Z", "severity": "INFO", "message": "2 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:13Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:14Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:14Z", "severity": "INFO", "message": "5 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:14Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:15Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:15Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:15Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:16Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:16Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:16Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:17Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:17Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:17Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:18Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:18Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:19Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:19Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:19Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:20Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:20Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:20Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:21Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:21Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:21Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:22Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:22Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:22Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:23Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:23Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:23Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:24Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:24Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:25Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:25Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:25Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:26Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:26Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:26Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:27Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:27Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:27Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:28Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:28Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:28Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:29Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:29Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:30Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:30Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:30Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:31Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:31Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:31Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:32Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:32Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:32Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:33Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:33Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:33Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:34Z", "severity": "INFO", "message": "2 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:34Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:34Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:35Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:35Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:36Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:36Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:36Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:37Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:37Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:37Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:38Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:38Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:38Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:39Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:39Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{
+    "resource_metrics": [
+        {
+            "resource": {
+                "attributes": {
+                    "telemetry.sdk.language": "python",
+                    "telemetry.sdk.name": "opentelemetry",
+                    "telemetry.sdk.version": "1.30.0",
+                    "service.name": "YOUR_OT_SERVICE_NAME",
+                    "service.instance.id": "YOUR_OT_INSTANCE_ID"
+                },
+                "schema_url": ""
+            },
+            "scope_metrics": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.sqlalchemy",
+                        "version": "0.51b0",
+                        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+                        "attributes": null
+                    },
+                    "metrics": [
+                        {
+                            "name": "db.client.connections.usage",
+                            "description": "The number of connections that are currently in state described by the state attribute.",
+                            "unit": "connections",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {
+                                            "pool.name": "sqlite://:/:memory:",
+                                            "state": "idle"
+                                        },
+                                        "start_time_unix_nano": 1742409039718196254,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "value": 1,
+                                        "exemplars": [
+                                            {
+                                                "filtered_attributes": {},
+                                                "value": 1,
+                                                "time_unix_nano": 1742409039718024038,
+                                                "span_id": 3713101206591438628,
+                                                "trace_id": 96034203475891997111067169326188657814
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": {
+                                            "pool.name": "sqlite://:/:memory:",
+                                            "state": "used"
+                                        },
+                                        "start_time_unix_nano": 1742409039718353421,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "value": 0,
+                                        "exemplars": [
+                                            {
+                                                "filtered_attributes": {},
+                                                "value": 1,
+                                                "time_unix_nano": 1742409039718338075,
+                                                "span_id": 3713101206591438628,
+                                                "trace_id": 96034203475891997111067169326188657814
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "aggregation_temporality": 2,
+                                "is_monotonic": false
+                            }
+                        }
+                    ],
+                    "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+                },
+                {
+                    "scope": {
+                        "name": "policyengine",
+                        "version": "",
+                        "schema_url": "",
+                        "attributes": null
+                    },
+                    "metrics": [
+                        {
+                            "name": "create_houshold_count",
+                            "description": "",
+                            "unit": "",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {},
+                                        "start_time_unix_nano": 1742409042623323991,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "value": 5,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2,
+                                "is_monotonic": true
+                            }
+                        },
+                        {
+                            "name": "create_houshold_latency",
+                            "description": "",
+                            "unit": "",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {},
+                                        "start_time_unix_nano": 1742409042625468691,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "count": 5,
+                                        "sum": 0.06561660766601562,
+                                        "bucket_counts": [
+                                            0,
+                                            5,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ],
+                                        "explicit_bounds": [
+                                            0.0,
+                                            5.0,
+                                            10.0,
+                                            25.0,
+                                            50.0,
+                                            75.0,
+                                            100.0,
+                                            250.0,
+                                            500.0,
+                                            750.0,
+                                            1000.0,
+                                            2500.0,
+                                            5000.0,
+                                            7500.0,
+                                            10000.0
+                                        ],
+                                        "min": 0.002053976058959961,
+                                        "max": 0.05581212043762207,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2
+                            }
+                        }
+                    ],
+                    "schema_url": ""
+                },
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.fastapi",
+                        "version": "0.51b0",
+                        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+                        "attributes": null
+                    },
+                    "metrics": [
+                        {
+                            "name": "http.server.active_requests",
+                            "description": "Number of active HTTP server requests.",
+                            "unit": "{request}",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {
+                                            "http.scheme": "http",
+                                            "http.host": "127.0.0.1:8000",
+                                            "http.flavor": "1.1",
+                                            "http.method": "GET",
+                                            "http.server_name": "127.0.0.1:8000"
+                                        },
+                                        "start_time_unix_nano": 1742409042624170837,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "value": 0,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2,
+                                "is_monotonic": false
+                            }
+                        },
+                        {
+                            "name": "http.server.duration",
+                            "description": "Measures the duration of inbound HTTP requests.",
+                            "unit": "ms",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {
+                                            "http.scheme": "http",
+                                            "http.host": "127.0.0.1:8000",
+                                            "net.host.port": 8000,
+                                            "http.flavor": "1.1",
+                                            "http.method": "GET",
+                                            "http.server_name": "127.0.0.1:8000",
+                                            "http.status_code": 200
+                                        },
+                                        "start_time_unix_nano": 1742409042627873970,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "count": 2,
+                                        "sum": 68,
+                                        "bucket_counts": [
+                                            0,
+                                            1,
+                                            0,
+                                            0,
+                                            0,
+                                            1,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ],
+                                        "explicit_bounds": [
+                                            0.0,
+                                            5.0,
+                                            10.0,
+                                            25.0,
+                                            50.0,
+                                            75.0,
+                                            100.0,
+                                            250.0,
+                                            500.0,
+                                            750.0,
+                                            1000.0,
+                                            2500.0,
+                                            5000.0,
+                                            7500.0,
+                                            10000.0
+                                        ],
+                                        "min": 4,
+                                        "max": 64,
+                                        "exemplars": []
+                                    },
+                                    {
+                                        "attributes": {
+                                            "http.scheme": "http",
+                                            "http.host": "127.0.0.1:8000",
+                                            "net.host.port": 8000,
+                                            "http.flavor": "1.1",
+                                            "http.method": "GET",
+                                            "http.server_name": "127.0.0.1:8000",
+                                            "http.status_code": 200,
+                                            "http.target": "/ping/alive"
+                                        },
+                                        "start_time_unix_nano": 1742409049742245955,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "count": 3,
+                                        "sum": 15,
+                                        "bucket_counts": [
+                                            0,
+                                            2,
+                                            1,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ],
+                                        "explicit_bounds": [
+                                            0.0,
+                                            5.0,
+                                            10.0,
+                                            25.0,
+                                            50.0,
+                                            75.0,
+                                            100.0,
+                                            250.0,
+                                            500.0,
+                                            750.0,
+                                            1000.0,
+                                            2500.0,
+                                            5000.0,
+                                            7500.0,
+                                            10000.0
+                                        ],
+                                        "min": 4,
+                                        "max": 6,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2
+                            }
+                        },
+                        {
+                            "name": "http.server.response.size",
+                            "description": "measures the size of HTTP response messages (compressed).",
+                            "unit": "By",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {
+                                            "http.scheme": "http",
+                                            "http.host": "127.0.0.1:8000",
+                                            "net.host.port": 8000,
+                                            "http.flavor": "1.1",
+                                            "http.method": "GET",
+                                            "http.server_name": "127.0.0.1:8000",
+                                            "http.status_code": 200
+                                        },
+                                        "start_time_unix_nano": 1742409042627989554,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "count": 2,
+                                        "sum": 7750,
+                                        "bucket_counts": [
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            1,
+                                            0,
+                                            0,
+                                            1,
+                                            0,
+                                            0
+                                        ],
+                                        "explicit_bounds": [
+                                            0.0,
+                                            5.0,
+                                            10.0,
+                                            25.0,
+                                            50.0,
+                                            75.0,
+                                            100.0,
+                                            250.0,
+                                            500.0,
+                                            750.0,
+                                            1000.0,
+                                            2500.0,
+                                            5000.0,
+                                            7500.0,
+                                            10000.0
+                                        ],
+                                        "min": 945,
+                                        "max": 6805,
+                                        "exemplars": []
+                                    },
+                                    {
+                                        "attributes": {
+                                            "http.scheme": "http",
+                                            "http.host": "127.0.0.1:8000",
+                                            "net.host.port": 8000,
+                                            "http.flavor": "1.1",
+                                            "http.method": "GET",
+                                            "http.server_name": "127.0.0.1:8000",
+                                            "http.status_code": 200,
+                                            "http.target": "/ping/alive"
+                                        },
+                                        "start_time_unix_nano": 1742409049742433624,
+                                        "time_unix_nano": 1742409099706761858,
+                                        "count": 3,
+                                        "sum": 222,
+                                        "bucket_counts": [
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            3,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ],
+                                        "explicit_bounds": [
+                                            0.0,
+                                            5.0,
+                                            10.0,
+                                            25.0,
+                                            50.0,
+                                            75.0,
+                                            100.0,
+                                            250.0,
+                                            500.0,
+                                            750.0,
+                                            1000.0,
+                                            2500.0,
+                                            5000.0,
+                                            7500.0,
+                                            10000.0
+                                        ],
+                                        "min": 74,
+                                        "max": 74,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2
+                            }
+                        }
+                    ],
+                    "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+                }
+            ],
+            "schema_url": ""
+        }
+    ]
+}
+{"timestamp": "2025-03-19T11:31:39Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:40Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:40Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:40Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:41Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:41Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:42Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:42Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:42Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:43Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:43Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:43Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:44Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:44Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:44Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:45Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:45Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:45Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:46Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:46Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:47Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:47Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:47Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:48Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:48Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:48Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:49Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:49Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:49Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:50Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:50Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:50Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:51Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:51Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:51Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:52Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:52Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:53Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:53Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:53Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:54Z", "severity": "INFO", "message": "2 changes detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:54Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:54Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:55Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:55Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:55Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:56Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:56Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:56Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:57Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:57Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:57Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:58Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:58Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:59Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:59Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:31:59Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:00Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:00Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:00Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:01Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:01Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:01Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:02Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:02Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:02Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:03Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:03Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:03Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:04Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:04Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:05Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:05Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:05Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:06Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:06Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:06Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:07Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:07Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:07Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:08Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:08Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:08Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:09Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:09Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:10Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:10Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:10Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:11Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:11Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:11Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:12Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:12Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:12Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:13Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:13Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:13Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:14Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:14Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T11:32:14Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Shutting down
+{"timestamp": "2025-03-19T11:32:15Z", "severity": "INFO", "message": "Shutting down", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Finished server process [13164]
+{"timestamp": "2025-03-19T11:32:15Z", "severity": "INFO", "message": "Finished server process [13164]", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Finished server process [\u001b[36m%d\u001b[0m]"}
+      INFO   Stopping reloader process [13157]
+{"timestamp": "2025-03-19T11:32:15Z", "severity": "INFO", "message": "Stopping reloader process [13157]", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Stopping reloader process [\u001b[36m\u001b[1m13157\u001b[0m]"}
+
+make: *** [Makefile:29: dev] Interrupt

--- a/projects/policyengine-api-full/out
+++ b/projects/policyengine-api-full/out
@@ -1,0 +1,536 @@
+poetry run fastapi dev src/policyengine_api_full/main.py
+
+   FastAPI   Starting development server 🚀
+ 
+             Searching for package file structure from directories with __init__.py files
+             Importing from /home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full/src
+ 
+    module   📁 policyengine_api_full
+             ├── 🐍 __init__.py
+             └── 🐍 main.py
+ 
+      code   Importing the FastAPI app object from the module with the following code:
+ 
+             from policyengine_api_full.main import app
+ 
+       app   Using import string: policyengine_api_full.main:app
+ 
+    server   Server started at http://127.0.0.1:8000
+    server   Documentation at http://127.0.0.1:8000/docs
+ 
+       tip   Running in development mode, for production use: fastapi run
+ 
+             Logs:
+ 
+      INFO   Will watch for changes in these directories: ['/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full']
+{"timestamp": "2025-03-19T14:47:26Z", "severity": "INFO", "message": "Will watch for changes in these directories: ['/home/namidim/projects/fork/policyengine-api-v2/projects/policyengine-api-full']", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+{"timestamp": "2025-03-19T14:47:26Z", "severity": "INFO", "message": "Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Uvicorn running on \u001b[1m%s://%s:%d\u001b[0m (Press CTRL+C to quit)"}
+      INFO   Started reloader process [3884] using WatchFiles
+{"timestamp": "2025-03-19T14:47:26Z", "severity": "INFO", "message": "Started reloader process [3884] using WatchFiles", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Started reloader process [\u001b[36m\u001b[1m3884\u001b[0m] using \u001b[36m\u001b[1mWatchFiles\u001b[0m"}
+      INFO   Started server process [3891]
+{"timestamp": "2025-03-19T14:47:28Z", "severity": "INFO", "message": "Started server process [3891]", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Started server process [\u001b[36m%d\u001b[0m]"}
+      INFO   Waiting for application startup.
+{"timestamp": "2025-03-19T14:47:28Z", "severity": "INFO", "message": "Waiting for application startup.", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Application startup complete.
+{"timestamp": "2025-03-19T14:47:28Z", "severity": "INFO", "message": "Application startup complete.", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:28Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{
+    "name": "connect",
+    "context": {
+        "trace_id": "0xf088873ff34fef811f35d73445aeb217",
+        "span_id": "0xbb207e437b3a3e9c",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.861147Z",
+    "end_time": "2025-03-19T21:47:28.863489Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.name": ":memory:",
+        "db.system": "sqlite"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0x8911303703615c7406cffdb6a9977c79",
+        "span_id": "0x4fc390b4b5acd071",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.863928Z",
+    "end_time": "2025-03-19T21:47:28.864939Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA main.table_info(\"household\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0xf830a2f0430f47875c815f1e873e9521",
+        "span_id": "0xfd1bfa3ff2370227",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.865379Z",
+    "end_time": "2025-03-19T21:47:28.865726Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA temp.table_info(\"household\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0x3b226ca05113f8fc735ebbbac44b6485",
+        "span_id": "0xbd6d014edc3de98f",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.865957Z",
+    "end_time": "2025-03-19T21:47:28.866127Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA main.table_info(\"user\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "PRAGMA :memory:",
+    "context": {
+        "trace_id": "0x11f551b56b44b7ff2f02d4c9dba80f34",
+        "span_id": "0x25e5b2b89b0a147b",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.866314Z",
+    "end_time": "2025-03-19T21:47:28.866506Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "PRAGMA temp.table_info(\"user\")",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "CREATE :memory:",
+    "context": {
+        "trace_id": "0xf7ccd5229e35ad379f4229f3debffaa8",
+        "span_id": "0x48a4b70a21c401e2",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.867866Z",
+    "end_time": "2025-03-19T21:47:28.868877Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "\nCREATE TABLE household (\n\tid INTEGER NOT NULL, \n\tPRIMARY KEY (id)\n)\n\n",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "CREATE :memory:",
+    "context": {
+        "trace_id": "0xdf938ab2ddf221c8ec25bc821fbfe25f",
+        "span_id": "0xeb339382e2197ce9",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.CLIENT",
+    "parent_id": null,
+    "start_time": "2025-03-19T21:47:28.870123Z",
+    "end_time": "2025-03-19T21:47:28.870829Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "db.statement": "\nCREATE TABLE user (\n\tusername VARCHAR NOT NULL, \n\tid INTEGER NOT NULL, \n\tauth0_sub VARCHAR NOT NULL, \n\tPRIMARY KEY (id)\n)\n\n",
+        "db.system": "sqlite",
+        "db.name": ":memory:"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0xa83d9ca873a947ba779c98f8eae4be85",
+        "span_id": "0xf04427c21446954a",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x32570011185d1546",
+    "start_time": "2025-03-19T21:47:29.076914Z",
+    "end_time": "2025-03-19T21:47:29.077142Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.start",
+        "http.status_code": 200
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "name": "GET /ping/alive http send",
+    "context": {
+        "trace_id": "0xa83d9ca873a947ba779c98f8eae4be85",
+        "span_id": "0xb61edbfb2fed6620",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": "0x32570011185d1546",
+    "start_time": "2025-03-19T21:47:29.077874Z",
+    "end_time": "2025-03-19T21:47:29.077936Z",
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {
+        "asgi.event.type": "http.response.body"
+    },
+    "events": [],
+    "links": [],
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.30.0",
+            "service.name": "YOUR_OT_SERVICE_NAME",
+            "service.instance.id": "YOUR_OT_INSTANCE_ID"
+        },
+        "schema_url": ""
+    }
+}
+{
+    "resource_metrics": [
+        {
+            "resource": {
+                "attributes": {
+                    "telemetry.sdk.language": "python",
+                    "telemetry.sdk.name": "opentelemetry",
+                    "telemetry.sdk.version": "1.30.0",
+                    "service.name": "YOUR_OT_SERVICE_NAME",
+                    "service.instance.id": "YOUR_OT_INSTANCE_ID"
+                },
+                "schema_url": ""
+            },
+            "scope_metrics": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.sqlalchemy",
+                        "version": "0.51b0",
+                        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+                        "attributes": null
+                    },
+                    "metrics": [
+                        {
+                            "name": "db.client.connections.usage",
+                            "description": "The number of connections that are currently in state described by the state attribute.",
+                            "unit": "connections",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {
+                                            "pool.name": "sqlite://:/:memory:",
+                                            "state": "idle"
+                                        },
+                                        "start_time_unix_nano": 1742420848863208674,
+                                        "time_unix_nano": 1742420849086661468,
+                                        "value": 1,
+                                        "exemplars": [
+                                            {
+                                                "filtered_attributes": {},
+                                                "value": 1,
+                                                "time_unix_nano": 1742420848863015331,
+                                                "span_id": 13483916112642588316,
+                                                "trace_id": 319723614553112770982359082207359709719
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": {
+                                            "pool.name": "sqlite://:/:memory:",
+                                            "state": "used"
+                                        },
+                                        "start_time_unix_nano": 1742420848863387847,
+                                        "time_unix_nano": 1742420849086661468,
+                                        "value": 0,
+                                        "exemplars": [
+                                            {
+                                                "filtered_attributes": {},
+                                                "value": 1,
+                                                "time_unix_nano": 1742420848863357346,
+                                                "span_id": 13483916112642588316,
+                                                "trace_id": 319723614553112770982359082207359709719
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "aggregation_temporality": 2,
+                                "is_monotonic": false
+                            }
+                        }
+                    ],
+                    "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+                },
+                {
+                    "scope": {
+                        "name": "policyengine",
+                        "version": "",
+                        "schema_url": "",
+                        "attributes": null
+                    },
+                    "metrics": [
+                        {
+                            "name": "alive_count",
+                            "description": "",
+                            "unit": "",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {},
+                                        "start_time_unix_nano": 1742420849074153429,
+                                        "time_unix_nano": 1742420849086661468,
+                                        "value": 1,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2,
+                                "is_monotonic": true
+                            }
+                        },
+                        {
+                            "name": "alive_latency",
+                            "description": "",
+                            "unit": "",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {},
+                                        "start_time_unix_nano": 1742420849078332196,
+                                        "time_unix_nano": 1742420849086661468,
+                                        "count": 1,
+                                        "sum": 0.0040416717529296875,
+                                        "bucket_counts": [
+                                            0,
+                                            1,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ],
+                                        "explicit_bounds": [
+                                            0.0,
+                                            5.0,
+                                            10.0,
+                                            25.0,
+                                            50.0,
+                                            75.0,
+                                            100.0,
+                                            250.0,
+                                            500.0,
+                                            750.0,
+                                            1000.0,
+                                            2500.0,
+                                            5000.0,
+                                            7500.0,
+                                            10000.0
+                                        ],
+                                        "min": 0.0040416717529296875,
+                                        "max": 0.0040416717529296875,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2
+                            }
+                        }
+                    ],
+                    "schema_url": ""
+                },
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.fastapi",
+                        "version": "0.51b0",
+                        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+                        "attributes": null
+                    },
+                    "metrics": [
+                        {
+                            "name": "http.server.active_requests",
+                            "description": "Number of active HTTP server requests.",
+                            "unit": "{request}",
+                            "data": {
+                                "data_points": [
+                                    {
+                                        "attributes": {
+                                            "http.scheme": "http",
+                                            "http.host": "127.0.0.1:8000",
+                                            "http.flavor": "1.1",
+                                            "http.method": "GET",
+                                            "http.server_name": "localhost:8000"
+                                        },
+                                        "start_time_unix_nano": 1742420849075488020,
+                                        "time_unix_nano": 1742420849086661468,
+                                        "value": 1,
+                                        "exemplars": []
+                                    }
+                                ],
+                                "aggregation_temporality": 2,
+                                "is_monotonic": false
+                            }
+                        }
+                    ],
+                    "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+                }
+            ],
+            "schema_url": ""
+        }
+    ]
+}
+      INFO   127.0.0.1:40430 - "GET /ping/alive HTTP/1.1" 200
+{"timestamp": "2025-03-19T14:47:29Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:29Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:29Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:30Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:30Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:31Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:31Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:31Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:32Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:32Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+{"timestamp": "2025-03-19T14:47:32Z", "severity": "INFO", "message": "1 change detected", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Shutting down
+{"timestamp": "2025-03-19T14:47:33Z", "severity": "INFO", "message": "Shutting down", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": ""}
+      INFO   Finished server process [3891]
+{"timestamp": "2025-03-19T14:47:33Z", "severity": "INFO", "message": "Finished server process [3891]", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Finished server process [\u001b[36m%d\u001b[0m]"}
+      INFO   Stopping reloader process [3884]
+{"timestamp": "2025-03-19T14:47:33Z", "severity": "INFO", "message": "Stopping reloader process [3884]", "logging.googleapis.com/trace": "projects/NO_PROJECT_SPECIFIED/traces/0", "logging.googleapis.com/spanId": "0", "logging.googleapis.com/trace_sampled": false, "otelServiceName": "", "color_message": "Stopping reloader process [\u001b[36m\u001b[1m3884\u001b[0m]"}
+

--- a/projects/policyengine-api-full/src/policyengine_api_full/main.py
+++ b/projects/policyengine-api-full/src/policyengine_api_full/main.py
@@ -5,6 +5,7 @@ from sqlmodel import SQLModel
 from policyengine_api.fastapi.database import create_sqlite_engine
 from policyengine_api.fastapi import ping
 from policyengine_api.fastapi.health import HealthRegistry, HealthSystemReporter
+from policyengine_api.fastapi.exit import exit
 from .settings import get_settings, Environment
 from policyengine_api.fastapi.opentelemetry import (
     GCPLoggingInstrumentor,
@@ -38,7 +39,8 @@ engine = create_sqlite_engine()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     SQLModel.metadata.create_all(engine)
-    yield
+    async with exit.lifespan():
+        yield
 
 
 app = FastAPI(


### PR DESCRIPTION
fixes #90

Since gcp containers can be scaled at any time, we need to make sure any pending traces and metrics are flushed before the process exits.

1. fastapi doesn't provide any direct middleware way to add lifecycle events
2. for whatever reason "atexit" doesn't work in the context of fastapi

so this change adds a new policyengine fastapi extension 'exit' for registering things that need to happen on exit.