### PR TITLE
Associate the correct route with autogenerated metrics.

### DIFF
--- a/libs/policyengine-fastapi/src/policyengine_api/fastapi/opentelemetry/middleware.py
+++ b/libs/policyengine-fastapi/src/policyengine_api/fastapi/opentelemetry/middleware.py
@@ -37,7 +37,7 @@ class Middleware:
         route = next(
             r
             for r in self.routes
-            if r.route.matches(request.scope) != Match.NONE
+            if r.route.matches(request.scope)[0] != Match.NONE
         )
         start = time()
         if route:


### PR DESCRIPTION
Fixes #91

Due to a typo the fastapi/OT route metrics (i.e. count and latency per route) were all attributed to the first route regardless of the actual route a request was being processed by.

This fixes that typo