### PR TITLE
Refactor common cloudrun code into a reusable module.

### DIFF
--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -1,23 +1,9 @@
 locals {
-  full_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-full:${var.full_container_tag}"
   simulation_api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-simulation:${var.simulation_container_tag}"
 }
 
 provider "google" {
   project = var.project_id
-}
-
-# Enable required APIs
-resource "google_project_service" "secretmanager_api" {
-  project = var.project_id
-  service = "secretmanager.googleapis.com"
-  disable_on_destroy = false
-}
-
-# Create a custom service account
-resource "google_service_account" "cloudrun_full_api" {
-  account_id   = "full-api"
-  display_name = "Cloud Run Service Account for Full API"
 }
 
 # Create a dedicated service account for workflow
@@ -26,86 +12,22 @@ resource "google_service_account" "workflow_sa" {
   display_name = "Simulation Workflows Service Account"
 }
 
-resource "google_project_iam_member" "deploy_service_account_roles" {
-  for_each = toset(["roles/monitoring.metricWriter", "roles/logging.logWriter", "roles/cloudtrace.agent"])
-  project = var.project_id
-  role = each.key
-  member = "serviceAccount:${google_service_account.cloudrun_full_api.email}"
-}
+module "cloud_run_full_api" {
+  source = "./modules/fastapi_cloudrun"
 
-# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service
-resource "google_cloud_run_v2_service" "cloud_run_full_api" {
-  provider = google-beta
-  project = var.project_id
-  name     = "api-full"
-  location = var.region
-  deletion_protection = false
-  ingress = "INGRESS_TRAFFIC_ALL"
+  name = "full-api"
+  description = "Full api containing all routes"
+  container_tag = var.full_container_tag
+  test_account_email = "tester@${var.project_id}.iam.gserviceaccount.com"
 
-  description = "PolicyEngine Full API"
-
-  template {
-    service_account = google_service_account.cloudrun_full_api.email
-    # Assumption from cost estimate.
-    max_instance_request_concurrency = var.is_prod ? 80 : null
-    containers {
-      image = local.full_api_image
-      resources {
-        #default to whatever the cheapest instance is unless in prod in which
-        # case values are again based on the cost esitmate.
-        limits = {
-          cpu    = var.is_prod ? 2 : null
-          memory = var.is_prod ? "1024Mi" : null
-        }
-      }
-      startup_probe {
-        initial_delay_seconds = 0
-        timeout_seconds = 1
-        period_seconds = 5
-        failure_threshold = 4
-        http_get {
-          path = "/ping/started"
-        }
-      }
-      # Only include liveness_probe in production environment so we don't
-      # waste money running beta containers.
-      dynamic "liveness_probe" {
-        for_each = var.is_prod ? [1] : []
-        content {
-          period_seconds = 30 
-          timeout_seconds = 1 
-          failure_threshold = 2
-          http_get {
-            path = "/ping/alive"
-          }
-        }
-      }
-    }
-    scaling {
-      # always keep one instance hot in prod
-      min_instance_count = var.is_prod ? 1 : 0
-      # in beta don't create a bunch of containers
-      # max in prod based on assumptions from cost estimate
-      max_instance_count = var.is_prod ? 10 : 1
-    }
+  limits = {
+    cpu    = var.is_prod ? 2 : null
+    memory = var.is_prod ? "1024Mi" : null
   }
-}
 
-data "google_iam_policy" "full_api" {
-  binding {
-    role = "roles/run.invoker"
-    members = [
-      "serviceAccount:tester@${var.project_id}.iam.gserviceaccount.com",
-    ]
-  }
-}
-
-resource "google_cloud_run_service_iam_policy" "full_api" {
-  location = google_cloud_run_v2_service.cloud_run_full_api.location
-  project  = google_cloud_run_v2_service.cloud_run_full_api.project
-  service  = google_cloud_run_v2_service.cloud_run_full_api.name
-
-  policy_data = data.google_iam_policy.full_api.policy_data
+  project_id=var.project_id
+  region=var.region
+  is_prod=var.is_prod
 }
 
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
@@ -1,0 +1,91 @@
+locals {
+  api_image = "${var.region}-docker.pkg.dev/${ var.project_id }/api-v2/policyengine-api-full:${var.container_tag}"
+}
+
+# Create a custom service account
+resource "google_service_account" "api" {
+  account_id   = "${var.name}"
+  display_name = "Cloud Run Service Account for ${var.name} api"
+}
+
+resource "google_project_iam_member" "api_roles" {
+  for_each = toset(["roles/monitoring.metricWriter", "roles/logging.logWriter", "roles/cloudtrace.agent"])
+  project = var.project_id
+  role = each.key
+  member = "serviceAccount:${google_service_account.api.email}"
+}
+
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service
+resource "google_cloud_run_v2_service" "api" {
+  provider = google-beta
+  project = var.project_id
+  name     = var.name
+  location = var.region
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  description = var.description
+
+  template {
+    service_account = google_service_account.api.email
+    # Assumption from cost estimate.
+    max_instance_request_concurrency = var.is_prod ? 80 : null
+    containers {
+      image = local.api_image
+      resources {
+        #default to whatever the cheapest instance is unless in prod in which
+        # case values are again based on the cost esitmate.
+        limits = {
+          cpu    = var.limits.cpu
+          memory = var.limits.memory
+        }
+      }
+      startup_probe {
+        initial_delay_seconds = 0
+        timeout_seconds = 1
+        period_seconds = 5
+        failure_threshold = 4
+        http_get {
+          path = "/ping/started"
+        }
+      }
+      # Only include liveness_probe in production environment so we don't
+      # waste money running beta containers.
+      dynamic "liveness_probe" {
+        for_each = var.is_prod ? [1] : []
+        content {
+          period_seconds = 30 
+          timeout_seconds = 1 
+          failure_threshold = 2
+          http_get {
+            path = "/ping/alive"
+          }
+        }
+      }
+    }
+    scaling {
+      # always keep one instance hot in prod
+      min_instance_count = var.is_prod ? 1 : 0
+      # in beta don't create a bunch of containers
+      # max in prod based on assumptions from cost estimate
+      max_instance_count = var.is_prod ? 10 : 1
+    }
+  }
+}
+
+data "google_iam_policy" "api" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "serviceAccount:${var.test_account_email}",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "api" {
+  location = google_cloud_run_v2_service.api.location
+  project  = google_cloud_run_v2_service.api.project
+  service  = google_cloud_run_v2_service.api.name
+
+  policy_data = data.google_iam_policy.api.policy_data
+}

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
@@ -1,0 +1,3 @@
+output "uri" {
+    value = google_cloud_run_v2_service.api.uri
+}

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/variables.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/variables.tf
@@ -1,0 +1,39 @@
+variable "is_prod" {
+  description = "Whether this is a production deployment"
+  type        = bool
+}
+
+variable "project_id" {
+  description = "The GCP project to deploy to"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to deploy the cloud run service to."
+  type        = string
+}
+
+variable "container_tag" {
+  description = "The container image tag to deploy."
+  type        = string
+}
+
+variable limits {
+  type = object({
+    cpu    = number
+    memory = string
+  })
+}
+
+variable "description" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+
+variable "test_account_email" {
+  type = string
+}

--- a/terraform/infra-policyengine-api/outputs.tf
+++ b/terraform/infra-policyengine-api/outputs.tf
@@ -1,5 +1,5 @@
 output "full_api_url" {
-  value = google_cloud_run_v2_service.cloud_run_full_api.uri
+  value = module.cloud_run_full_api.uri
 }
 
 output "simulation_api_url" {

--- a/terraform/project-policyengine-api/main.tf
+++ b/terraform/project-policyengine-api/main.tf
@@ -43,7 +43,9 @@ module "project" {
     "workflows.googleapis.com",
     # to support tracelogs and metrics from our services
     "cloudtrace.googleapis.com",
-    "monitoring.googleapis.com"]
+    "monitoring.googleapis.com",
+    # to store microdata token for pulling data
+    "secretmanager.googleapis.com"]
 }
 
 resource "google_storage_bucket" "logs" {


### PR DESCRIPTION
This change refactors the common cloudrun service code we use into a reusable module so we can transition the simulation API and get all the same benefits (monitors, metrics, service accounts, etc.)