### PR TITLE
Added uptime check for full api

### DIFF
--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
@@ -78,6 +78,7 @@ data "google_iam_policy" "api" {
     role = "roles/run.invoker"
     members = [
       "serviceAccount:${var.test_account_email}",
+      "serviceAccount:service-${data.google_project.project.number}@gcp-sa-monitoring-notification.iam.gserviceaccount.com"
     ]
   }
 }

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/uptime.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/uptime.tf
@@ -1,0 +1,27 @@
+
+resource "google_monitoring_uptime_check_config" "cloudrun_health_check" {
+  display_name = "${var.name} Health Check"
+  # response time can be slower because of container spin up in beta.
+  timeout      = var.is_prod ? "1s" : "10s"
+  # don't waste resources waking up the beta container all the time. Just do it once a day.
+  period       = var.is_prod ? "300s" : "86400s"
+
+  http_check {
+    path         = "/ping/alive"
+    port         = "443"
+    use_ssl      = true
+    validate_ssl = true
+    service_agent_authentication {
+      type = "OIDC_TOKEN"
+      
+    }
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = var.project_id
+      host       =  regex("://([^/:]+)", google_cloud_run_v2_service.api.uri)[0]
+    }
+  }
+}

--- a/terraform/project-policyengine-api/main.tf
+++ b/terraform/project-policyengine-api/main.tf
@@ -48,6 +48,18 @@ module "project" {
     "secretmanager.googleapis.com"]
 }
 
+#Availability monitors optionally auth with ODIC, but you cannot configure
+#which service account they use, they HAVE to use the default service account
+#As of writing it won't complain when you tell it to auth and the default monitoring
+#SA doesn't exist, it will just not authenticate :/
+#Anyway, this is forcing creation according to https://cloud.google.com/iam/docs/create-service-agents#create-service-agent-terraform
+resource "google_project_service_identity" "mon_sa" {
+  provider = google-beta
+
+  project =  module.project.project_id
+  service = "monitoring.googleapis.com"
+}
+
 resource "google_storage_bucket" "logs" {
   project = module.project.project_id
   name = "${module.project.project_id}-buildlogs"


### PR DESCRIPTION
Related to PolicyEngine/issues#224

This change adds an uptime check to the fastapi_cloudrun module.

In order to do that I had to make sure the monitoring service account is created as part of project setup.