### PR TITLE
Update simulation API to use new api module.

### DIFF
--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
@@ -1,3 +1,15 @@
 output "uri" {
     value = google_cloud_run_v2_service.api.uri
 }
+
+output "location" {
+    value = google_cloud_run_v2_service.api.location
+}
+
+output "name" {
+    value = google_cloud_run_v2_service.api.name
+}
+
+output "project" {
+    value = google_cloud_run_v2_service.api.project
+}

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/variables.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/variables.tf
@@ -13,6 +13,11 @@ variable "region" {
   type        = string
 }
 
+variable "docker_repo" {
+  description = "The name of the repo to get the image from"
+  type = string
+}
+
 variable "container_tag" {
   description = "The container image tag to deploy."
   type        = string
@@ -23,6 +28,12 @@ variable limits {
     cpu    = number
     memory = string
   })
+}
+
+variable "environment_secrets" {
+  description = "Map of environment variable names to their corresponding secret IDs in Google Secret Manager"
+  type = map(string)
+  default = {}
 }
 
 variable "description" {
@@ -38,11 +49,19 @@ variable "slack_notification_channel_name" {
   default = ""
 }
 
-variable "test_account_email" {
-  type = string
-}
-
 variable "commit_url" {
   type = string
   description = "URL of the commit this deployment is associated with"
+}
+
+variable "members_can_invoke" {
+  type = list(string)
+  description = "entities to add to the invoke policy for this service"
+  default = []
+}
+
+variable "service_roles" {
+  type = list(string)
+  description = "roles to give the service account for this clodurun service"
+  default = []
 }

--- a/terraform/infra-policyengine-api/outputs.tf
+++ b/terraform/infra-policyengine-api/outputs.tf
@@ -3,7 +3,7 @@ output "full_api_url" {
 }
 
 output "simulation_api_url" {
-  value = google_cloud_run_v2_service.cloud_run_simulation_api.uri
+  value = module.cloud_run_simulation_api.uri
 }
 
 output "workflow_id" {

--- a/terraform/infra-policyengine-api/variables.tf
+++ b/terraform/infra-policyengine-api/variables.tf
@@ -29,6 +29,7 @@ variable "hugging_face_token" {
   description = "The Hugging Face API token for the simulation API"
   type        = string
   sensitive   = true
+  default = ""
 }
 
 variable "slack_notification_channel_name" {


### PR DESCRIPTION
Related to PolicyEngine/issues#224

1. Added the ping api support routes
2. Switched the terraform to use the new module which
  1. Updates the health and live checks to use ping endpoints
  2. Adds an uptime check for the service.
  3. Adds an alerti if the uptime check fails.