### PR TITLE
Reduce concurrent sim processes to 2

### DIFF
--- a/projects/policyengine-api-simulation/Dockerfile
+++ b/projects/policyengine-api-simulation/Dockerfile
@@ -24,6 +24,6 @@ RUN poetry install --with main --no-root
 
 EXPOSE 8080
 # bottlenck is memory
-# two workers to handle external reuqests (max allowed = 2)
+# one worker to handle external reuqests (max allowed = 1)
 # one worker to do the liveness check
-CMD ["poetry", "run", "uvicorn", "src.policyengine_api_simulation.main:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "3"]
+CMD ["poetry", "run", "uvicorn", "src.policyengine_api_simulation.main:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "2"]

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -77,8 +77,8 @@ module "cloud_run_simulation_api" {
   min_instance_count = var.is_prod ? 1: 0
   #arbitrary number. May need to tweak
   max_instance_count = var.is_prod ? 10 : 1
-  #we are currently memory bound. internally it runs 3 handlers. keep one open for liveness checks.
-  max_instance_request_concurrency = 2
+  #we are currently memory bound. internally it runs 2 handlers. keep one open for liveness checks.
+  max_instance_request_concurrency = 1
   #permit max timeout since we run entire population simulations.
   timeout = "3600s"
 


### PR DESCRIPTION
fixes #147

We're still running out of container memory running simulations. This change
1. Reduces the maximum number of processes per container to 2
2. Reduces the maximum number of external requests per container to 1 (leaving 1 process to handle live checks)