### PR TITLE
Remove code that deletes cached files.

### DIFF
--- a/libs/policyengine-simulation-api/src/policyengine_api/simulation_api/simulation.py
+++ b/libs/policyengine-simulation-api/src/policyengine_api/simulation_api/simulation.py
@@ -21,13 +21,6 @@ def create_router():
         simulation = Simulation(**model.model_dump())
         print("Calculating")
         result = simulation.calculate_economy_comparison()
-        # Clear data files
-
-        for file in Path(".").glob("*.csv"):
-            file.unlink()
-
-        for file in Path(".").glob("*.h5"):
-            file.unlink()
 
         return result
 


### PR DESCRIPTION
Related to PolicyEngine/issues#350
In combination with changes to correctly cache our gcs downloads we don't need this workaround any more.