### PR TITLE
Update memory for simulation api to max

### DIFF
--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -61,8 +61,8 @@ module "cloud_run_simulation_api" {
   } : {}
   
   limits = {
-    cpu = 4
-    memory = "16Gi"
+    cpu = var.is_prod ? 8 : 4
+    memory = var.is_prod ? "32Gi" : "16Gi"
   }
 
   


### PR DESCRIPTION
Fixes #180
Updating to 32 GB memory for the simulation API due to ongoing memory failures. This is the biggst it goes although currently memory usage is technically unbounded.