### PR TITLE
Gracefully handle undefined routes

### DIFF
--- a/libs/policyengine-fastapi/src/policyengine_api/fastapi/opentelemetry/middleware.py
+++ b/libs/policyengine-fastapi/src/policyengine_api/fastapi/opentelemetry/middleware.py
@@ -34,11 +34,12 @@ class Middleware:
         )
 
     async def __call__(self, request: Request, call_next) -> Any:
-        route = next(
-            r
-            for r in self.routes
-            if r.route.matches(request.scope)[0] != Match.NONE
-        )
+        route:Route | None = None
+        for r in self.routes:
+            if r.route.matches(request.scope)[0] != Match.NONE:
+                route = r
+                break
+        
         start = time()
         if route:
             route.execution.add(amount=1)
@@ -46,4 +47,5 @@ class Middleware:
             return await call_next(request)
         finally:
             duration = time() - start
-            route.latency.record(amount=duration)
+            if route:
+                route.latency.record(amount=duration)


### PR DESCRIPTION
Fixes #188

In general we should not die with a 500 on an unknown path (404) and more specifically not all routes have to be defined in the application (i.e. docs)

This fix no longer assumes all routes must match a application route.