### PR TITLE
Publish service metadata on deployment.

### DIFF
--- a/.github/workflows/gcp-deploy.reusable.yml
+++ b/.github/workflows/gcp-deploy.reusable.yml
@@ -49,7 +49,17 @@ jobs:
       with:
         workload_identity_provider: "${{ vars._GITHUB_IDENTITY_POOL_PROVIDER_NAME }}"
         service_account: "deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com"
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
     - uses: hashicorp/setup-terraform@v3
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+    - name: Set up poetry
+      run: uv pip install poetry --system
     - name: Create/update GCP project
       run: make -f Makefile.deploy deploy-project
     - name: Deploy services into the GCP project

--- a/libs/policyengine-api/Makefile
+++ b/libs/policyengine-api/Makefile
@@ -2,7 +2,6 @@ build: test
 
 install:
 	poetry install
-	poetry update
 
 test: install
 	poetry run pytest

--- a/libs/policyengine-fastapi/Makefile
+++ b/libs/policyengine-fastapi/Makefile
@@ -2,7 +2,6 @@ build: test
 
 install:
 	poetry install
-	poetry update
 
 test: install
 	poetry run pytest

--- a/libs/policyengine-simulation-api/Makefile
+++ b/libs/policyengine-simulation-api/Makefile
@@ -2,7 +2,6 @@ build: test
 
 install:
 	poetry install
-	poetry update
 
 test: install
 	echo "Todo: add tests"

--- a/projects/policyengine-api-full/Makefile
+++ b/projects/policyengine-api-full/Makefile
@@ -20,7 +20,6 @@ deploy:
 
 build:
 	poetry install
-	poetry update
 	mkdir -p artifacts
 	cd src && poetry run python -m policyengine_api_full.generate_openapi > ../artifacts/openapi.json
 	mvn -f ./generate_clients.pom.xml clean generate-sources

--- a/projects/policyengine-api-simulation/Makefile
+++ b/projects/policyengine-api-simulation/Makefile
@@ -21,7 +21,6 @@ deploy:
 
 build:
 	poetry install
-	poetry update
 	mkdir -p artifacts
 	cd src && poetry run python -m policyengine_api_simulation.generate_openapi > ../artifacts/openapi.json
 	mvn -f ./generate_clients.pom.xml clean generate-sources

--- a/projects/policyengine-api-simulation/dump_package_version.sh
+++ b/projects/policyengine-api-simulation/dump_package_version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+script_dir=$(dirname "$0")
+cd ${script_dir}
+poetry install &> /dev/null
+poetry run python scripts/dump_package_version.py poetry.lock "$@"

--- a/projects/policyengine-api-simulation/scripts/dump_package_version.py
+++ b/projects/policyengine-api-simulation/scripts/dump_package_version.py
@@ -1,0 +1,24 @@
+import tomllib 
+import sys
+
+def get_package_version_from_lock(package_name, lock_file_path='poetry.lock'):
+    try:
+        with open(lock_file_path, 'rb') as f:
+            lock_data = tomllib.load(f)
+        
+        for package in lock_data.get('package', []):
+            if package.get('name') == package_name:
+                return package.get('version')
+        
+        return None
+    except FileNotFoundError:
+        return None
+
+
+version = get_package_version_from_lock(sys.argv[2], sys.argv[1])
+
+if version is None:
+ sys.exit(1)
+
+print(version)
+sys.exit(0)

--- a/projects/policyengine-household-api/Makefile
+++ b/projects/policyengine-household-api/Makefile
@@ -20,7 +20,6 @@ deploy:
 
 build:
 	poetry install
-	poetry update
 	@echo "TODO: add back in the tests"
 
 dev:

--- a/terraform/infra-policyengine-api/Makefile
+++ b/terraform/infra-policyengine-api/Makefile
@@ -21,7 +21,7 @@ deploy: .terraform
 	@echo "Latest Full API SHA: ${FULL_SHA}"
 	@echo "Latest Simulation API SHA: ${SIM_SHA}"
 	@echo "Running terraform apply with ../.bootstrap_settings/apply.tfvars"
-	terraform apply -var-file ../.bootstrap_settings/apply.tfvars -var "full_container_tag=${TAG}@${FULL_SHA}" -var "simulation_container_tag=${TAG}@${SIM_SHA}" -var "commit_url=${COMMIT_URL}"
+	terraform apply -var-file ../.bootstrap_settings/apply.tfvars -var "full_container_tag=${TAG}@${FULL_SHA}" -var "simulation_container_tag=${TAG}@${SIM_SHA}" -var "commit_url=${COMMIT_URL}" -var "policyengine-us-package-version=desktop" -var "policyengine-uk-package-version=desktop"
 
 .terraform: ../.bootstrap_settings/backend.tfvars
 	@echo "Initializing terraform"

--- a/terraform/infra-policyengine-api/Makefile.deploy
+++ b/terraform/infra-policyengine-api/Makefile.deploy
@@ -1,6 +1,11 @@
 REPO_URL := $(shell git remote get-url origin | sed 's/\.git$$//' | sed 's/git@github.com:/https:\/\/github.com\//')
 COMMIT_SHA := $(shell git rev-parse HEAD)
 COMMIT_URL := $(REPO_URL)/commit/$(COMMIT_SHA)
+SCRIPT_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+US_COUNTRY_PACKAGE_VERSION := $(shell ../../projects/policyengine-api-simulation/dump_package_version.sh policyengine-us)
+UK_COUNTRY_PACKAGE_VERSION := $(shell ../../projects/policyengine-api-simulation/dump_package_version.sh policyengine-uk)
+SERVICE_METADATA = $(shell terraform output -raw release_metadata)
+METADATA_BUCKET = $(shell terraform output -raw metadata_bucket_name)
 
 plan-deploy: .terraform
 	terraform plan -input=false
@@ -9,8 +14,11 @@ state: .terraform
 	terraform output -json
 
 deploy: .terraform
-	terraform apply -input=false -auto-approve -var "commit_url=${COMMIT_URL}"
+	terraform apply -input=false -auto-approve -var "commit_url=${COMMIT_URL}" -var "policyengine-us-package-version=${US_COUNTRY_PACKAGE_VERSION}" -var "policyengine-uk-package-version=${UK_COUNTRY_PACKAGE_VERSION}"
 	terraform output -json > terraform_output.json
+	echo "$(SERVICE_METADATA)" | gsutil cp - gs://$(METADATA_BUCKET)/live.json
+	echo "$(SERVICE_METADATA)" | gsutil cp - gs://$(METADATA_BUCKET)/us.$(US_COUNTRY_PACKAGE_VERSION).json
+	echo "$(SERVICE_METADATA)" | gsutil cp - gs://$(METADATA_BUCKET)/uk.$(UK_COUNTRY_PACKAGE_VERSION).json
 
 .terraform:
 	terraform init -backend-config="bucket=${TF_BACKEND_bucket}"

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -65,8 +65,6 @@ module "cloud_run_simulation_api" {
     memory = var.is_prod ? "32Gi" : "16Gi"
   }
 
-  
-
   project_id=var.project_id
   region=var.region
   slack_notification_channel_name=var.slack_notification_channel_name
@@ -85,6 +83,22 @@ module "cloud_run_simulation_api" {
   # This service can't really handle more than one request in a single container so
   # we don't use uptime check
   enable_uptime_check = false
+}
+
+
+# use google blobs to map versions of us and uk country packages.
+# this allows us to coordinate with other services that require a specific version
+# of these pacakges to be live before running.
+resource "google_storage_bucket" "metadata" {
+  name = "${var.project_id}-metadata"
+  location      = "US"
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+}
+
+locals {
+  metadata = "{\"uri\":\"${module.cloud_run_simulation_api.uri}\",\"revision\":\"${module.cloud_run_simulation_api.latest_ready_revision}\",\"policyengine-us\":\"${var.policyengine-us-package-version}\",\"policyengine-uk\":\"${var.policyengine-uk-package-version}\"}"
 }
 
 # Create a workflow

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
@@ -2,6 +2,10 @@ output "uri" {
     value = google_cloud_run_v2_service.api.uri
 }
 
+output "latest_ready_revision" {
+    value = google_cloud_run_v2_service.api.latest_ready_revision
+}
+
 output "location" {
     value = google_cloud_run_v2_service.api.location
 }

--- a/terraform/infra-policyengine-api/outputs.tf
+++ b/terraform/infra-policyengine-api/outputs.tf
@@ -14,3 +14,12 @@ output "workflow_service_account_email" {
   value = google_service_account.workflow_sa.email
   description = "Service account for running workflows"
 }
+
+output "release_metadata" {
+  value = local.metadata
+  description = "json blob that should be stored as metadata for this release of the api. Used to establish the right version of the cloudrun api for a given uk or us country package"
+}
+
+output "metadata_bucket_name" {
+  value = google_storage_bucket.metadata.name
+}

--- a/terraform/infra-policyengine-api/variables.tf
+++ b/terraform/infra-policyengine-api/variables.tf
@@ -42,3 +42,13 @@ variable "commit_url" {
   type = string
   description = "URL of the commit this deployment is associated with"
 }
+
+variable "policyengine-us-package-version"{
+  type = string
+  description = "version of policyengine uk package in the simulation api"
+}
+
+variable "policyengine-uk-package-version" {
+  type = string
+  description = "version of the policyengine us package in the simulation api"
+}


### PR DESCRIPTION
Related to PolicyEngine/issues#378

This change publishes marker files to a metadata bucket for the simulation api indicating
1. The revision of the service
2. The uri for that revision of the service.
3. The us country package version
4. the uk country package version.