### PR TITLE
Create workflow for checking country package versions.

### DIFF
--- a/terraform/infra-policyengine-api/workflows/wait_for_country_versions.yaml
+++ b/terraform/infra-policyengine-api/workflows/wait_for_country_versions.yaml
@@ -1,0 +1,83 @@
+main:
+  params: [input]
+  steps:
+    - init:
+        assign:
+          - bucket_name: ${input.bucket_name}
+          - us_package_name: ${"us." + input.us_country_package_version + ".json"}
+          - uk_package_name: ${"uk." + input.uk_country_package_version + ".json"}
+          - timeout_seconds: ${default(map.get(input, "timeout_seconds"), 300)}  # Default 5 minutes
+          - check_interval: ${default(map.get(input, "check_interval"), 10)}     # Check every 10 seconds
+          - start_time: ${sys.now()}
+    
+    - check_objects_loop:
+        steps:
+          - check_us_package:
+              try:
+                call: googleapis.storage.v1.objects.get
+                args:
+                  bucket: ${bucket_name}
+                  object: ${us_package_name}
+                result: us_package_exists
+              except:
+                as: e
+                steps:
+                  - handle_us_package_error:
+                      switch:
+                        - condition: ${e.code == 404}
+                          assign:
+                            - us_package_exists: null
+                        - condition: true
+                          raise: ${e}
+          
+          - check_uk_package:
+              try:
+                call: googleapis.storage.v1.objects.get
+                args:
+                  bucket: ${bucket_name}
+                  object: ${uk_package_name}
+                result: uk_package_exists
+              except:
+                as: e
+                steps:
+                  - handle_uk_package_error:
+                      switch:
+                        - condition: ${e.code == 404}
+                          assign:
+                            - uk_package_exists: null
+                        - condition: true
+                          raise: ${e}
+          
+          - check_both_exist:
+              switch:
+                - condition: ${us_package_exists != null and uk_package_exists != null}
+                  steps:
+                    - success:
+                        return:
+                          status: "SUCCESS"
+                          message: "Both objects found in bucket"
+                          us_package: ${us_package_name}
+                          uk_package: ${uk_package_name}
+                          bucket: ${bucket_name}
+                          found_at: ${sys.now()}
+          
+          - check_timeout:
+              assign:
+                - current_time: ${sys.now()}
+                - elapsed_seconds: ${current_time - start_time}
+              next: evaluate_timeout
+          
+          - evaluate_timeout:
+              switch:
+                - condition: ${elapsed_seconds >= timeout_seconds}
+                  steps:
+                    - timeout_failure:
+                        raise:
+                          code: "TIMEOUT"
+                          message: ${"Timeout"}
+          
+          - wait_before_retry:
+              call: sys.sleep
+              args:
+                seconds: ${check_interval}
+              next: check_objects_loop


### PR DESCRIPTION
related to PolicyEngine/issues#378

In order to block deployments to the api v1 we need some way to wait for the current country package versions to actually show up in the simulation api before actually deploying the service.

This workflow will check in a loop for the country package version s3 metadata files and fail if they don't show up after a timeout.