### PR TITLE
Simulation workflow uses tagger api.

### DIFF
--- a/projects/policyengine-api-simulation/workflow.yaml
+++ b/projects/policyengine-api-simulation/workflow.yaml
@@ -4,8 +4,44 @@ main:
   steps:
     - init:
         assign:
-          # Replace with your Cloud Run service URL ending with /simulate.
-          - cloudRunUrl: ${sys.get_env("service_url")}
+          # Default Cloud Run service URL ending with /simulate
+          - defaultCloudRunUrl: ${sys.get_env("service_url")}
+          # Tagger service URL
+          - taggerServiceUrl: ${sys.get_env("tagger_service_url")}
+          - cloudRunUrl: ${defaultCloudRunUrl}
+    
+    - checkForTagging:
+        switch:
+          - condition: ${"country" in input and "model_version" in input}
+            next: callTaggerService
+        next: callCloudRun
+    
+    - callTaggerService:
+        try:
+          call: http.get
+          args:
+            url: ${taggerServiceUrl + "/tag"}
+            auth:
+              type: OIDC
+            query:
+              country: ${input.country}
+              model_version: ${input.model_version}
+          result: taggerResponse
+        retry: ${http.default_retry}
+        except:
+          as: e
+          steps:
+            - handleTaggerError:
+                switch:
+                  - condition: ${e.code == 404}
+                    raise: ${"Model version " + input.model_version + " not found for country " + input.country}
+                  - condition: true
+                    raise: ${e}
+    
+    - updateCloudRunUrl:
+        assign:
+          - cloudRunUrl: ${taggerResponse.body}
+    
     - callCloudRun:
         try:
           call: http.post
@@ -13,10 +49,13 @@ main:
             url: ${cloudRunUrl}
             auth:
               type: OIDC
+              # Annoyingly, cloudrun tagged URLs still expect the base url as the audience. See https://www.googlecloudcommunity.com/gc/Serverless/Cloud-Run-Auth-token-not-working-on-the-tagged-revision-url/m-p/402100#M256
+              audience: ${defaultCloudRunUrl}
             headers:
               Content-Type: "application/json"
             body: ${input}
           result: response
         retry: ${http.default_retry}
+    
     - returnResult:
         return: ${response.body}

--- a/projects/policyengine-api-tagger/src/policyengine_api_tagger/api/revision_tagger.py
+++ b/projects/policyengine-api-tagger/src/policyengine_api_tagger/api/revision_tagger.py
@@ -84,6 +84,7 @@ class RevisionTagger:
             f"country-{country}-model-{model_version.replace('.','-')}"
         )
 
+        log.info(f"Getting tagged url for service {cloudrun_service_name}, revision {revision_name}, tag {tag_string}")
         service_uri = await self.cloudrun_client.tag_revision(
             cloudrun_service_name, revision_name, tag_string
         )

--- a/projects/policyengine-api-tagger/src/policyengine_api_tagger/api/routes.py
+++ b/projects/policyengine-api-tagger/src/policyengine_api_tagger/api/routes.py
@@ -2,7 +2,9 @@ from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRouter
 
 from policyengine_api_tagger.api.revision_tagger import RevisionTagger
+import logging
 
+log = logging.getLogger(__file__)
 
 def create_router(tagger: RevisionTagger) -> APIRouter:
     router = APIRouter()
@@ -11,7 +13,9 @@ def create_router(tagger: RevisionTagger) -> APIRouter:
     async def get_tag_uri(country: str, model_version: str) -> str:
         uri = await tagger.tag(country, model_version)
         if uri is None:
+            log.info(f"No tag url for country {country}, model_version {model_version}")
             raise HTTPException(status_code=404, detail="Item not found")
+        log.info(f"Got URI {uri} for country {country} model_version {model_version}")
         return uri
 
     return router

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
@@ -17,3 +17,11 @@ output "name" {
 output "project" {
     value = google_cloud_run_v2_service.api.project
 }
+
+output "sa_email" {
+    value = google_service_account.api.email
+}
+
+output "sa_account_id" {
+    value = google_service_account.api.unique_id
+}

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/variables.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/variables.tf
@@ -59,6 +59,12 @@ variable "environment_secrets" {
   default = {}
 }
 
+variable "env" {
+  description = "Environment variables directly assigned to string values"
+  type = map(string)
+  default = {}
+}
+
 variable "timeout" {
   description = "Max time a container can take to respond to a request up to 1 hour"
   type = string


### PR DESCRIPTION
related to PolicyEngine/issues#378

1. Updated the tagging service terraform to pass the bucket env variable in.
2. Updated the tagging service with the right permissions to allow it to tag revisions of simulation service.
3. Added some more logging
4. Updated the simulation workflow to, if model_version is provided, use it to get the tagged url from tagging service and call it.