### PR TITLE
Added integration test for calculating cliff impacts

### DIFF
--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate_cliffs.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate_cliffs.py
@@ -11,12 +11,18 @@ def test_calculation_cliffs(client: policyengine_simulation_api_client.DefaultAp
             },
             include_cliffs=True,
             subsample=200, # reduce the number of households to speed things up.
-            data=policyengine_simulation_api_client.Data("gs://policyengine-us-data/cps_2023.h5") # force the service to use google storage (policyengine.py defaults to huggingface)
+            data=policyengine_simulation_api_client.Data("gs://policyengine-us-data/cps_2023.h5") # force the service to use google storage
         )
     response = client.simulate_simulate_economy_comparison_post(
         options
     )
     result = response.to_dict()
-    # Check for cliffs
+    # Check that cliff impact data is present in the simulation result
     cliffs = result.get('cliff_impact')
-    assert cliffs is not None, "Expected cliffs to be present in the output."
+    assert cliffs is not None, "Expected 'cliff_impact' to be present in the output."
+
+    # Assert that cliff impact is non-zero in both baseline and reform scenarios
+    assert cliffs["baseline"]["cliff_gap"] > 0
+    assert cliffs["baseline"]["cliff_share"] > 0
+    assert cliffs["reform"]["cliff_gap"] > 0
+    assert cliffs["reform"]["cliff_share"] > 0

--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate_cliffs.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate_cliffs.py
@@ -1,0 +1,22 @@
+import policyengine_simulation_api_client
+
+def test_calculation_cliffs(client: policyengine_simulation_api_client.DefaultApi):
+    options = policyengine_simulation_api_client.SimulationOptions(
+            country="us", # don't use uk. It will try to load extra stuff from huggingface
+            scope="macro",
+            reform = {
+                "gov.irs.credits.eitc.max[0].amount": policyengine_simulation_api_client.ParametricReformValue.from_dict({
+                    "2026-01-01.2100-12-31": 0
+                })
+            },
+            include_cliffs=True,
+            subsample=200, # reduce the number of households to speed things up.
+            data=policyengine_simulation_api_client.Data("gs://policyengine-us-data/cps_2023.h5") # force the service to use google storage (policyengine.py defaults to huggingface)
+        )
+    response = client.simulate_simulate_economy_comparison_post(
+        options
+    )
+    result = response.to_dict()
+    # Check for cliffs
+    cliffs = result.get('cliff_impact')
+    assert cliffs is not None, "Expected cliffs to be present in the output."


### PR DESCRIPTION
Fixes #204 

This PR adds a new integration test to the `policyengine-apis-integ` project that verifies simulations with cliff_impacts=True run successfully. It extends existing coverage beyond the default US simulation test, ensuring regressions in cliff-related behavior are caught early.