### PR TITLE
Use correct path when calling tagged urls from simulation workflow.

### DIFF
--- a/projects/policyengine-api-simulation/workflow.yaml
+++ b/projects/policyengine-api-simulation/workflow.yaml
@@ -4,11 +4,14 @@ main:
   steps:
     - init:
         assign:
-          # Default Cloud Run service URL ending with /simulate
+          # Default Cloud Run service URL (hostname only)
           - defaultCloudRunUrl: ${sys.get_env("service_url")}
+          # Service path
+          - servicePath: ${sys.get_env("service_path")}
           # Tagger service URL
           - taggerServiceUrl: ${sys.get_env("tagger_service_url")}
-          - cloudRunUrl: ${defaultCloudRunUrl}
+          # Full URL with path for default service
+          - cloudRunUrl: ${defaultCloudRunUrl + "/" + servicePath}
     
     - checkForTagging:
         switch:
@@ -40,7 +43,8 @@ main:
     
     - updateCloudRunUrl:
         assign:
-          - cloudRunUrl: ${taggerResponse.body}
+          # Assume taggerResponse.body returns a hostname, append the service path
+          - cloudRunUrl: ${taggerResponse.body + "/" + servicePath}
     
     - callCloudRun:
         try:
@@ -49,7 +53,7 @@ main:
             url: ${cloudRunUrl}
             auth:
               type: OIDC
-              # Annoyingly, cloudrun tagged URLs still expect the base url as the audience. See https://www.googlecloudcommunity.com/gc/Serverless/Cloud-Run-Auth-token-not-working-on-the-tagged-revision-url/m-p/402100#M256
+              # Use the base hostname for audience
               audience: ${defaultCloudRunUrl}
             headers:
               Content-Type: "application/json"

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -188,7 +188,8 @@ resource "google_workflows_workflow" "simulation_workflow" {
     env = var.is_prod ? "prod" : "test"
   }
   user_env_vars = {
-    service_url = "${module.cloud_run_simulation_api.uri}/simulate/economy/comparison"
+    service_url = module.cloud_run_simulation_api.uri  # Just the hostname now
+    service_path = "simulate/economy/comparison"        # Separate path
     tagger_service_url = "${module.cloud_run_tagger_api.uri}" 
   }
   source_contents = file("../../projects/policyengine-api-simulation/workflow.yaml")


### PR DESCRIPTION
Fixes #229

We were incorrectly using just the hostname path to call simulation api when using a tagged url instead of the full path.

This change updates the workflow to change the hostname, but use the same path regardless of if we use the default or tagged uri.