### PR TITLE
Corretly capture the current revision in metadata.

### DIFF
--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -167,7 +167,7 @@ resource "google_storage_bucket" "metadata" {
 locals {
   metadata = {
     uri      = module.cloud_run_simulation_api.uri
-    revision = module.cloud_run_simulation_api.latest_ready_revision
+    revision = module.cloud_run_simulation_api.revision
     models = {
       us = var.policyengine-us-package-version
       uk = var.policyengine-uk-package-version

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
@@ -5,6 +5,8 @@ locals {
     { for k, v in var.environment_secrets : k => { secret = v } },
     { for k, v in var.env : k => { value = v } }
   )
+
+  revision_name = "${var.service_name}-${var.container_tag}-{formatdate("YYYYMMDD-hhmmss", timestamp())}"
 }
 
 # Create a custom service account
@@ -34,6 +36,7 @@ resource "google_cloud_run_v2_service" "api" {
   description = var.description
 
   template {
+    revision = local.revision_name
     service_account = google_service_account.api.email
     max_instance_request_concurrency = var.max_instance_request_concurrency
     containers {

--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/outputs.tf
@@ -2,8 +2,8 @@ output "uri" {
     value = google_cloud_run_v2_service.api.uri
 }
 
-output "latest_ready_revision" {
-    value = google_cloud_run_v2_service.api.latest_ready_revision
+output "revision" {
+    value = local.revision_name
 }
 
 output "location" {


### PR DESCRIPTION
Fixes #237

This fixes an issue where we were recording metadata associated with the previous revision of the simulation api instead of the one we just deployed.

This was happening because the cloud_run_api_v2 module will resolve the currently live revision name instead of the one it's deployed.

Change to explicitly defining the new revision name and then referencing that instead.