### PR TITLE
Update simulation api workflow timeout to 30 minutes.

### DIFF
--- a/projects/policyengine-api-simulation/workflow.yaml
+++ b/projects/policyengine-api-simulation/workflow.yaml
@@ -24,6 +24,7 @@ main:
           call: http.get
           args:
             url: ${taggerServiceUrl + "/tag"}
+            timeout: 1800
             auth:
               type: OIDC
             query:


### PR DESCRIPTION
By default the workflow will give up after 5 and then retry 5 times. For any simulation that takes longer than 5 minutes this means we just keep spawning new simulations and then fail.