### PR TITLE
Fix typo in terraform

### DIFF
--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/main.tf
@@ -6,7 +6,7 @@ locals {
     { for k, v in var.env : k => { value = v } }
   )
 
-  revision_name = "${var.service_name}-${var.container_tag}-{formatdate("YYYYMMDD-hhmmss", timestamp())}"
+  revision_name = "${var.service_name}-${var.container_tag}-{formatdate('YYYYMMDD-hhmmss', timestamp())}"
 }
 
 # Create a custom service account


### PR DESCRIPTION
had a '"' within an interpolated string. Replaced with single '