### PR TITLE
Fix metadata "revison" to be full path.

### DIFF
--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -167,7 +167,7 @@ resource "google_storage_bucket" "metadata" {
 locals {
   metadata = {
     uri      = module.cloud_run_simulation_api.uri
-    revision = module.cloud_run_simulation_api.revision
+    revision = "projects/${var.project_id}/locations/${var.region}/revisions/${module.cloud_run_simulation_api.revision}"
     models = {
       us = var.policyengine-us-package-version
       uk = var.policyengine-uk-package-version


### PR DESCRIPTION
fixes #247

When fixing the revison output by metadata I dropped the full services/.../location/..revisions/ thing. Added back in.