### PR TITLE
Clarify integ-test build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,5 @@ deploy-project: terraform/.bootstrap_settings
 deploy: deploy-project deploy-infra
 
 integ-test: 
-	cd projects/policyengine-apis-integ && make integ-test
+	echo "Running integration tests"
+	$(MAKE) -C projects/policyengine-apis-integ

--- a/common.mk
+++ b/common.mk
@@ -1,12 +1,15 @@
 build: remove_artifacts install checkformat pyright generate test 
 
 remove_artifacts:
+	echo "Removing artifacts directory"
 	rm -rf artifacts
 
 install:
+	echo "Downloading dependencies including test and build"
 	uv sync --extra test --extra build
 
 checkformat:
+	echo "Checking python code formatting"
 	@dirs=""; \
 	[ -d "src" ] && dirs="$$dirs src"; \
 	[ -d "tests" ] && dirs="$$dirs tests"; \
@@ -17,6 +20,7 @@ checkformat:
 	fi
 
 format:
+	echo "Updating python code formatting"
 	@dirs=""; \
 	[ -d "src" ] && dirs="$$dirs src"; \
 	[ -d "tests" ] && dirs="$$dirs tests"; \
@@ -28,9 +32,11 @@ format:
 	fi
 
 pyright:
+	echo "Checking python type usage"
 	uv run pyright 
 
 test:
+	echo "Running unit tests"
 	uv run pytest
 
 generate:

--- a/projects/policyengine-apis-integ/Makefile
+++ b/projects/policyengine-apis-integ/Makefile
@@ -1,7 +1,9 @@
 include ../../common.mk
 test: integ-test
+	echo "Skipping default test target in favor of integ-test"
 
 integ-test:
+	echo "Running integration tests"
 	$(if $(FULL_API_ACCESS_TOKEN),FULL_INTEG_TEST_ACCESS_TOKEN='$(FULL_API_ACCESS_TOKEN)') \
 	$(if $(SIMULATION_API_ACCESS_TOKEN),SIMULATION_INTEG_TEST_ACCESS_TOKEN='$(SIMULATION_API_ACCESS_TOKEN)') \
 	$(if $(FULL_API_URL),FULL_INTEG_TEST_BASE_URL='$(FULL_API_URL)') \

--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate_cliffs.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate_cliffs.py
@@ -10,7 +10,7 @@ def test_calculation_cliffs(client: policyengine_simulation_api_client.DefaultAp
                 {"2026-01-01.2100-12-31": 0}
             )
         },
-        include_cliffs=True,
+        include_cliffs=True,  # type: ignore
         subsample=200,  # reduce the number of households to speed things up.
         data=policyengine_simulation_api_client.Data(
             "gs://policyengine-us-data/cps_2023.h5"

--- a/server_common.mk
+++ b/server_common.mk
@@ -10,7 +10,9 @@ PROJECT_ID?=PROJECT_ID_NOT_SPECIFIED
 WORKER_COUNT?=1
 
 deploy:
+	echo "Building ${SERVICE_NAME} docker image"
 	cd ../../ && gcloud builds submit --region=${REGION} --substitutions=_IMAGE_TAG=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${SERVICE_NAME}:${TAG},_SERVICE_NAME=${SERVICE_NAME},_MODULE_NAME=${MODULE_NAME},_WORKER_COUNT=${WORKER_COUNT} ${BUILD_ARGS}
 
 dev:
+	echo "Running ${SERVICE_NAME} dev instance"
 	cd src && uv run uvicorn ${MODULE_NAME}:app --reload --port ${DEV_PORT} --workers ${WORKER_COUNT}


### PR DESCRIPTION
1. Added logs This should make it easier to understand what build targets are executing and why.

2. Changed target. Just use the default target instead of integ-test.