### PR TITLE
Updated simulation workflow to retry on 404

### DIFF
--- a/projects/policyengine-api-simulation/workflow.yaml
+++ b/projects/policyengine-api-simulation/workflow.yaml
@@ -60,7 +60,21 @@ main:
               Content-Type: "application/json"
             body: ${input}
           result: response
-        retry: ${http.default_retry}
+        retry:
+          predicate: ${custom_predicate}
+          max_retries: 5
+          backoff:
+            initial_delay: 1
+            max_delay: 60
+            multiplier: 1.25
     
     - returnResult:
         return: ${response.body}
+
+#retry on any failure. tag links may return 404 before traffic is routed
+#the pre-defined http retry strategies will ignore this.
+custom_predicate:
+  params: [e]
+  steps:
+    - retry_always:
+        return: true


### PR DESCRIPTION
To retry on anything actually.

The first time we tag a URL it may take a while to go active. Before that it will show as a 404.

The default retry rules will not retry on a 404, this change makes our client retry on any error.