### PR TITLE
Alert policy in terraform for workflow failures

### DIFF
--- a/terraform/infra-policyengine-api/modules/fastapi_cloudrun/monitoring.tf
+++ b/terraform/infra-policyengine-api/modules/fastapi_cloudrun/monitoring.tf
@@ -117,7 +117,8 @@ resource "google_monitoring_alert_policy" "limit_alert" {
   }
 }
   
-resource "google_monitoring_alert_policy" "simulation_workflow_failure" {
+resource "google_monitoring_alert_policy" "simulation_workflow_failure_alert" {
+  project      = var.project_id
   display_name = "Simulation Workflow Failures (for tf test)"
   combiner     = "OR"
 


### PR DESCRIPTION
Fixes #254 

This PR introduces a Terraform-managed alerting policy to monitor the `simulation-workflow` workflow for failures. The alert triggers if any executions fail within a 5-minute window. It includes Slack notification support and helpful context links.
