### PR TITLE
Fix "desktop" cloud deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,15 @@ dev:
 
 bootstrap:
 	cd terraform/project-policyengine-api && make bootstrap
-	
+
+attach:
+	$(MAKE) -C terraform/project-policyengine-api attach
+	$(MAKE) -C terraform/infra-policyengine-api attach
+
+detach:
+	$(MAKE) -C terraform/project-policyengine-api detach
+	$(MAKE) -C terraform/infra-policyengine-api detach
+
 deploy-infra: terraform/.bootstrap_settings
 	echo "Publishing API images"
 	cd projects/policyengine-api-full && make deploy

--- a/terraform/infra-policyengine-api/Makefile
+++ b/terraform/infra-policyengine-api/Makefile
@@ -6,7 +6,7 @@ COMMIT_SHA := $(shell git rev-parse HEAD)
 COMMIT_URL := $(REPO_URL)/commit/$(COMMIT_SHA)
 
 # get the project ID
-include ../.bootstrap_settings/project.env
+-include ../.bootstrap_settings/project.env
 TAG?=desktop
 REPO?=api-v2
 REGION?=us-central1
@@ -23,6 +23,16 @@ deploy: .terraform
 	@echo "Latest Simulation API SHA: ${SIM_SHA}"
 	@echo "Running terraform apply with ../.bootstrap_settings/apply.tfvars"
 	terraform apply -var-file ../.bootstrap_settings/apply.tfvars -var "full_container_tag=${TAG}@${FULL_SHA}" -var "simulation_container_tag=${TAG}@${SIM_SHA}" -var "tagger_container_tag=${TAG}@${TAGGER_SHA}" -var "commit_url=${COMMIT_URL}" -var "policyengine-us-package-version=desktop" -var "policyengine-uk-package-version=desktop"
+
+attach: .terraform
+	@echo "attached"
+
+detach:
+	rm -rf .terraform
+
+destroy:
+	terraform plan -destroy -var-file ../.bootstrap_settings/apply.tfvars --var "full_container_tag=IGNORED" -var "simulation_container_tag=IGNORED" -var "tagger_container_tag=IGNORE" -var "commit_url=IGNORE" -var "policyengine-us-package-version=IGNORED" -var "policyengine-uk-package-version=IGNORED"
+	@echo 'please confirm this IS NOT a production project and then run terraform destroy -var-file ../.bootstrap_settings/apply.tfvars --var "full_container_tag=IGNORED" -var "simulation_container_tag=IGNORED" -var "tagger_container_tag=IGNORE" -var "commit_url=IGNORE" -var "policyengine-us-package-version=IGNORED" -var "policyengine-uk-package-version=IGNORED"'
 
 .terraform: ../.bootstrap_settings/backend.tfvars
 	@echo "Initializing terraform"

--- a/terraform/infra-policyengine-api/main.tf
+++ b/terraform/infra-policyengine-api/main.tf
@@ -31,7 +31,7 @@ module "cloud_run_full_api" {
   slack_notification_channel_name=var.slack_notification_channel_name
   commit_url = var.commit_url
 
-  uptime_timeout = var.is_prod ? "1s" : "30s"
+  uptime_timeout = "1s"
   min_instance_count = var.is_prod ? 1: 0
   max_instance_count = 2
   #guessing. Need to tune.
@@ -39,7 +39,7 @@ module "cloud_run_full_api" {
   #this service should return basically immediately to all requests.
   timeout = "1s"
 
-  enable_uptime_check = true
+  enable_uptime_check = var.is_prod ? true : false
 }
 
 module "cloud_run_tagger_api" {
@@ -65,7 +65,7 @@ module "cloud_run_tagger_api" {
   slack_notification_channel_name=var.slack_notification_channel_name
   commit_url = var.commit_url
 
-  uptime_timeout = var.is_prod ? "1s" : "30s"
+  uptime_timeout = "1s"
   min_instance_count = var.is_prod ? 1: 0
   max_instance_count = 1
   #guessing. Need to tune.
@@ -73,7 +73,7 @@ module "cloud_run_tagger_api" {
   #this service should return basically immediately to all requests.
   timeout = "1s"
 
-  enable_uptime_check = true
+  enable_uptime_check = var.is_prod ? true : false
 }
 
 #give the tagger api access to the bucket
@@ -163,6 +163,7 @@ resource "google_storage_bucket" "metadata" {
   storage_class = "STANDARD"
 
   uniform_bucket_level_access = true
+  force_destroy = true
 }
 
 locals {

--- a/terraform/project-policyengine-api/Makefile
+++ b/terraform/project-policyengine-api/Makefile
@@ -6,6 +6,12 @@ attach:
 	scripts/attach.sh
 	terraform init
 
+detach:
+	rm -f backend.tf
+	rm -rf ../.bootstrap_settings
+	rm -rf .terraform
+	rm -rf terraform.tfstate*
+
 bootstrap_beta:
 	scripts/bootstrap.sh beta
 
@@ -15,3 +21,7 @@ bootstrap_prod:
 deploy:
 	@echo "Attempting to deploy project using bootstrap settings in ../.bootstrap_settings/apply.tfvars"
 	terraform apply --var-file=../.bootstrap_settings/apply.tfvars
+
+destroy:
+	terraform plan -destroy --var-file=../.bootstrap_settings/apply.tfvars
+	@echo "In order to _actually_ destroy the resources please MAKE SURE THIS IS NOT A PRODUCTION ACCOUNT and run: terraform destroy --var-file=../.bootstrap_settings/apply.tfvars"

--- a/terraform/project-policyengine-api/scripts/attach.sh
+++ b/terraform/project-policyengine-api/scripts/attach.sh
@@ -16,6 +16,11 @@ case "$project_id" in
         echo "stage is beta"
         stage="beta"
         ;;
+    desk-*)
+	echo "stage is desktop"
+        # Extract desk-username from the beginning
+        stage="${project_id%-*}"
+        ;;
     *)
         echo "Unable to determine stage from project name"
         exit 1

--- a/terraform/project-policyengine-api/scripts/bootstrap.sh
+++ b/terraform/project-policyengine-api/scripts/bootstrap.sh
@@ -21,7 +21,8 @@ is_desktop=false
 
 # Set stage to current user if desktop
 if [ "$stage" == "desktop" ]; then
-    read -p "Enter username (used for stage): " stage
+    read -p "Enter username (used for stage): " username
+    stage="desk-$username"
     is_desktop=true
 fi
 


### PR DESCRIPTION
If you fork the repo you can create a complete deployment in your forked repo, but if you just want to test deployment to the cloud the "desktop" deploy to cloud just deploys a single stage.

This update fixes that setup and support for attach/detach.

related to PolicyEngine/issues#385