### PR TITLE
Add client generation for integration tests to fix the failing update-dependencies workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           python-version: "3.13"
       
+      - name: Generate API clients
+        run: |
+          # Generate clients with correct naming before updating dependencies
+          ./scripts/generate-clients.sh
+      
       - name: Update dependencies
         id: update
         run: |


### PR DESCRIPTION
## Problem

  The `update-dependencies` workflow has been failing when trying to update dependencies for the `policyengine-apis-integ` package. The workflow fails
  with package resolution errors like:
- (in the CI) Distribution not found at: file:///home/runner/work/policyengine-api-v2/policyengine-api-v2/projects/policyengine-api-full/artifacts/clients/python
- (sometimes locally) Package metadata name policyengine_simulation_api_client does not match given name policyengine-api-simulation-client

## Timeline & Root Cause

This issue likely started after directory names in the integration were renamed . The integration package depends on locally-generated API clients that:
  1. Are stored in `artifacts/` directories (which are git-ignored)
  2. Don't exist in the CI environment unless explicitly generated (so packages unavailable for the newly generated directories)

## Proposed Solution

  Add the `generate-clients.sh` script execution before running `make update`. This ensures the required client packages exist when `uv lock --upgrade` attempts to resolve the integration package dependencies.

## Testing

  This fix has been validated locally by:
  1. Deleting all artifacts
  2. Running the generate-clients script
  3. Successfully running make update
  4. Confirming integration tests pass with generated clients

Since this is a scheduled workflow that runs in GitHub Actions, merging this PR will provide the definitive test of whether the fix resolves the issue in the CI environment.