### PR TITLE
fix: Increase full API integration test timeout to 120s

### DIFF
--- a/projects/policyengine-apis-integ/tests/full/conftest.py
+++ b/projects/policyengine-apis-integ/tests/full/conftest.py
@@ -7,7 +7,7 @@ import httpx
 class Settings(BaseSettings):
     base_url: str = "http://localhost:8081"
     access_token: str | None = None
-    timeout_in_millis: int = 2_000
+    timeout_in_millis: int = 120_000
 
     model_config = SettingsConfigDict(env_prefix="full_integ_test_")
 


### PR DESCRIPTION
## Summary
- Increases the full API integration test timeout from 2 seconds to 120 seconds
- Aligns with the simulation API test which already uses 120 seconds

## Problem
The Deploy workflow was failing because the full API integration test was timing out during Cloud Run cold starts. Cold starts take ~8-10 seconds, but the timeout was only 2 seconds.

## Test plan
- [ ] Deploy workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)