### PR TITLE
Lower tagged versions from 40 to 5

### DIFF
--- a/.github/workflows/gcp-deploy.reusable.yml
+++ b/.github/workflows/gcp-deploy.reusable.yml
@@ -198,7 +198,7 @@ jobs:
         python ../../../scripts/cleanup_old_revisions.py \
           "$TAGGER_URL" \
           "${{ steps.tagger-token.outputs.id_token }}" \
-          40
+          5
 
   integ_test:
     name: Run integration test

--- a/projects/policyengine-api-tagger/src/policyengine_api_tagger/api/revision_cleanup.py
+++ b/projects/policyengine-api-tagger/src/policyengine_api_tagger/api/revision_cleanup.py
@@ -274,7 +274,7 @@ class RevisionCleanup:
             errors,
         )
 
-    async def preview(self, keep_count: int = 40) -> CleanupResult:
+    async def preview(self, keep_count: int = 5) -> CleanupResult:
         """
         Preview what cleanup would do without making changes.
 
@@ -313,7 +313,7 @@ class RevisionCleanup:
             errors=errors,
         )
 
-    async def cleanup(self, keep_count: int = 40) -> CleanupResult:
+    async def cleanup(self, keep_count: int = 5) -> CleanupResult:
         """
         Clean up old traffic tags, keeping the specified number.
 


### PR DESCRIPTION
Fixes #380 

Lowers number of versions we keep tagged at any given point from 40 to 5 in order to shut down unneeded containers.