### PR TITLE
Fix 12 bugs from audit (security + correctness + tests)

### DIFF
--- a/projects/policyengine-api-simulation/fixtures/gateway/shared.py
+++ b/projects/policyengine-api-simulation/fixtures/gateway/shared.py
@@ -4,17 +4,26 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from src.modal.gateway.auth import require_auth
 from src.modal.gateway.endpoints import router
 
 
-def create_gateway_app() -> FastAPI:
-    """Create a FastAPI app with the gateway router for testing."""
+def create_gateway_app(*, authenticate: bool = True) -> FastAPI:
+    """Create a FastAPI app with the gateway router for testing.
+
+    By default the auth dependency is overridden with a no-op callable so
+    individual tests don't need to stage JWT material. Tests that exercise
+    the auth failure path can pass ``authenticate=False`` to keep the real
+    dependency wired up.
+    """
     app = FastAPI(
         title="Test PolicyEngine Simulation API",
         description="Test instance for unit tests",
         version="0.0.1",
     )
     app.include_router(router)
+    if authenticate:
+        app.dependency_overrides[require_auth] = lambda: None
     return app
 
 

--- a/projects/policyengine-api-simulation/pyproject.toml
+++ b/projects/policyengine-api-simulation/pyproject.toml
@@ -41,3 +41,10 @@ pythonpath = [
 ]
 
 testpaths = ["tests"]
+
+# Skip real-Modal integration smoke tests unless the operator explicitly
+# opts in with ``-m integration``. The default test run stays hermetic.
+addopts = "-m 'not integration'"
+markers = [
+  "integration: runs against a real (ephemeral) Modal deployment",
+]

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -11,6 +11,7 @@ import modal
 import os
 
 from src.modal._image_setup import snapshot_models
+from src.modal.logging_redaction import redact_params_for_logging
 
 # Get versions from environment or use defaults
 US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.562.3")
@@ -94,14 +95,18 @@ def run_simulation(params: dict) -> dict:
 
     configure_logfire()
 
+    # We deliberately avoid sending full ``params`` or ``result`` blobs to
+    # Logfire: both can embed signed URLs, reform parameter trees with
+    # sensitive policy details, or result payloads large enough to blow the
+    # span attribute size budget. The redacted summary keeps correlation
+    # traceability via run_id while leaving the heavy payload in memory.
+    redacted_params = redact_params_for_logging(params)
     try:
         with logfire.span(
             "run_simulation",
-            input_params=params,
-        ) as span:
-            result = run_simulation_impl(params)
-            span.set_attribute("output_result", result)
-            return result
+            **redacted_params,
+        ):
+            return run_simulation_impl(params)
     finally:
         logfire.force_flush()
 
@@ -123,13 +128,12 @@ def run_budget_window_batch(params: dict) -> dict:
 
     configure_logfire()
 
+    redacted_params = redact_params_for_logging(params)
     try:
         with logfire.span(
             "run_budget_window_batch",
-            input_params=params,
-        ) as span:
-            result = run_budget_window_batch_impl(params)
-            span.set_attribute("output_result", result)
-            return result
+            **redacted_params,
+        ):
+            return run_budget_window_batch_impl(params)
     finally:
         logfire.force_flush()

--- a/projects/policyengine-api-simulation/src/modal/budget_window_results.py
+++ b/projects/policyengine-api-simulation/src/modal/budget_window_results.py
@@ -11,12 +11,16 @@ from src.modal.gateway.models import (
     BudgetWindowTotals,
 )
 
+# The UK microsimulation has no state/province fiscal layer, so worker child
+# results for ``country="uk"`` never emit ``state_tax_revenue_impact``. The
+# parent aggregator treats it as optional with a zero default; US results are
+# expected to supply it as a real number. All other keys remain mandatory.
 REQUIRED_BUDGET_KEYS = (
     "tax_revenue_impact",
-    "state_tax_revenue_impact",
     "benefit_spending_impact",
     "budgetary_impact",
 )
+OPTIONAL_BUDGET_KEYS = ("state_tax_revenue_impact",)
 
 
 def _as_decimal(value: float | int) -> Decimal:
@@ -48,8 +52,13 @@ def extract_annual_impact(
             f"Malformed budget-window child result: missing numeric {missing}"
         )
 
-    state_tax_revenue_impact = budget["state_tax_revenue_impact"]
     tax_revenue_impact = budget["tax_revenue_impact"]
+    # UK worker results omit the state fiscal layer entirely; coerce to 0.0
+    # so the parent aggregator can still report federal/state splits with a
+    # uniform shape across countries.
+    state_tax_revenue_impact = budget.get("state_tax_revenue_impact")
+    if not isinstance(state_tax_revenue_impact, int | float):
+        state_tax_revenue_impact = 0.0
 
     return BudgetWindowAnnualImpact(
         year=simulation_year,

--- a/projects/policyengine-api-simulation/src/modal/budget_window_results.py
+++ b/projects/policyengine-api-simulation/src/modal/budget_window_results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 from src.modal.gateway.models import (
@@ -16,6 +17,15 @@ REQUIRED_BUDGET_KEYS = (
     "benefit_spending_impact",
     "budgetary_impact",
 )
+
+
+def _as_decimal(value: float | int) -> Decimal:
+    """Convert an annual impact float to Decimal without reintroducing
+    binary-float quantisation noise. ``Decimal(str(...))`` is the canonical
+    idiom because it serialises the float to its shortest round-trippable
+    decimal form before parsing."""
+
+    return Decimal(str(value))
 
 
 def extract_annual_impact(
@@ -54,22 +64,40 @@ def extract_annual_impact(
 def sum_annual_impacts(
     annual_impacts: list[BudgetWindowAnnualImpact],
 ) -> BudgetWindowTotals:
-    totals = {
-        "taxRevenueImpact": 0,
-        "federalTaxRevenueImpact": 0,
-        "stateTaxRevenueImpact": 0,
-        "benefitSpendingImpact": 0,
-        "budgetaryImpact": 0,
+    """Sum per-year impacts using Decimal accumulators.
+
+    Binary-float addition accumulates rounding error for long budget windows
+    (10-year sums over billion-dollar baselines quickly drift by ``1e-6`` or
+    more). Accumulating in :class:`decimal.Decimal` keeps the answer exact
+    to the input precision; we cast back to ``float`` at the serialisation
+    boundary so the JSON schema stays numeric and clients that parse the
+    response as ``number`` continue to work unchanged. Clients that need
+    bit-exact accounting should request the individual per-year impacts and
+    sum them in their preferred numeric type.
+    """
+
+    totals: dict[str, Decimal] = {
+        "taxRevenueImpact": Decimal(0),
+        "federalTaxRevenueImpact": Decimal(0),
+        "stateTaxRevenueImpact": Decimal(0),
+        "benefitSpendingImpact": Decimal(0),
+        "budgetaryImpact": Decimal(0),
     }
 
     for annual_impact in annual_impacts:
-        totals["taxRevenueImpact"] += annual_impact.taxRevenueImpact
-        totals["federalTaxRevenueImpact"] += annual_impact.federalTaxRevenueImpact
-        totals["stateTaxRevenueImpact"] += annual_impact.stateTaxRevenueImpact
-        totals["benefitSpendingImpact"] += annual_impact.benefitSpendingImpact
-        totals["budgetaryImpact"] += annual_impact.budgetaryImpact
+        totals["taxRevenueImpact"] += _as_decimal(annual_impact.taxRevenueImpact)
+        totals["federalTaxRevenueImpact"] += _as_decimal(
+            annual_impact.federalTaxRevenueImpact
+        )
+        totals["stateTaxRevenueImpact"] += _as_decimal(
+            annual_impact.stateTaxRevenueImpact
+        )
+        totals["benefitSpendingImpact"] += _as_decimal(
+            annual_impact.benefitSpendingImpact
+        )
+        totals["budgetaryImpact"] += _as_decimal(annual_impact.budgetaryImpact)
 
-    return BudgetWindowTotals(**totals)
+    return BudgetWindowTotals(**{key: float(value) for key, value in totals.items()})
 
 
 def build_budget_window_result(

--- a/projects/policyengine-api-simulation/src/modal/budget_window_scheduler.py
+++ b/projects/policyengine-api-simulation/src/modal/budget_window_scheduler.py
@@ -29,6 +29,7 @@ from src.modal.budget_window_state import (
     put_batch_job_seed,
     put_batch_job_state,
 )
+from src.modal.gateway.errors import log_and_redact_exception
 
 # Polling tuning. The runner busy-loops across child FunctionCall.get(timeout=0)
 # probes; when no child resolved we sleep before the next probe to stop the
@@ -151,9 +152,17 @@ class BudgetWindowBatchRunner:
             except TimeoutError:
                 continue
             except Exception as exc:
+                redacted = log_and_redact_exception(
+                    exc,
+                    scope="budget_window_child_call",
+                    context={
+                        "batch_job_id": self.context.batch_job_id,
+                        "simulation_year": simulation_year,
+                    },
+                )
                 self.fail_batch_for_child_error(
                     simulation_year=simulation_year,
-                    error=str(exc),
+                    error=redacted,
                 )
                 return False
 
@@ -163,9 +172,17 @@ class BudgetWindowBatchRunner:
                     child_result=child_result,
                 )
             except Exception as exc:
+                redacted = log_and_redact_exception(
+                    exc,
+                    scope="budget_window_child_result_parsing",
+                    context={
+                        "batch_job_id": self.context.batch_job_id,
+                        "simulation_year": simulation_year,
+                    },
+                )
                 self.fail_batch_for_child_error(
                     simulation_year=simulation_year,
-                    error=str(exc),
+                    error=redacted,
                 )
                 return False
 

--- a/projects/policyengine-api-simulation/src/modal/budget_window_scheduler.py
+++ b/projects/policyengine-api-simulation/src/modal/budget_window_scheduler.py
@@ -30,7 +30,21 @@ from src.modal.budget_window_state import (
     put_batch_job_state,
 )
 
-POLL_INTERVAL_SECONDS = 0.1
+# Polling tuning. The runner busy-loops across child FunctionCall.get(timeout=0)
+# probes; when no child resolved we sleep before the next probe to stop the
+# Modal control-plane from getting hammered. We start aggressive (0.5s) so
+# fast child runs don't inflate end-to-end latency, then double up to 30s so a
+# sluggish child doesn't keep the parent container hot polling. A blocking
+# FunctionCall.get(timeout=...) would be even better, but its interaction with
+# max_parallel means we'd have to juggle per-year deadlines and give up early
+# termination on child failure; the exponential walk keeps the control flow
+# simple while matching Modal's recommended polling cadence.
+POLL_INTERVAL_INITIAL_SECONDS = 0.5
+POLL_INTERVAL_MAX_SECONDS = 30.0
+POLL_INTERVAL_BACKOFF_FACTOR = 2.0
+# Retained for backward compatibility with callers that imported the original
+# constant; new code should use the initial/max pair above.
+POLL_INTERVAL_SECONDS = POLL_INTERVAL_INITIAL_SECONDS
 
 
 def serialize_batch_status(state) -> dict[str, Any]:
@@ -59,10 +73,16 @@ class BudgetWindowBatchRunner:
         context: BudgetWindowBatchContext,
         *,
         modal_module=None,
-        poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
+        poll_interval_seconds: float = POLL_INTERVAL_INITIAL_SECONDS,
+        poll_interval_max_seconds: float = POLL_INTERVAL_MAX_SECONDS,
+        poll_interval_backoff_factor: float = POLL_INTERVAL_BACKOFF_FACTOR,
     ):
         self.context = context
         self.modal = modal if modal_module is None else modal_module
+        self.poll_interval_initial_seconds = poll_interval_seconds
+        self.poll_interval_max_seconds = poll_interval_max_seconds
+        self.poll_interval_backoff_factor = poll_interval_backoff_factor
+        # Kept for tests that still read this attribute.
         self.poll_interval_seconds = poll_interval_seconds
         self.state = load_or_create_batch_state(context)
         self.child_func = self.modal.Function.from_name(
@@ -75,13 +95,22 @@ class BudgetWindowBatchRunner:
         mark_batch_running(self.state)
         put_batch_job_state(self.state)
 
+        # Exponential backoff: reset on any progress, double on empty polls.
+        current_sleep = self.poll_interval_initial_seconds
+
         while self.has_pending_work():
             self.spawn_until_capacity()
             progress_made = self.poll_running_children_once()
             if self.state.status == "failed":
                 return serialize_batch_status(self.state)
             if self.state.running_years and not progress_made:
-                time.sleep(self.poll_interval_seconds)
+                time.sleep(current_sleep)
+                current_sleep = min(
+                    current_sleep * self.poll_interval_backoff_factor,
+                    self.poll_interval_max_seconds,
+                )
+            elif progress_made:
+                current_sleep = self.poll_interval_initial_seconds
 
         return self.complete_batch()
 

--- a/projects/policyengine-api-simulation/src/modal/budget_window_state.py
+++ b/projects/policyengine-api-simulation/src/modal/budget_window_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 import modal
@@ -15,6 +16,10 @@ from src.modal.gateway.models import (
     BudgetWindowResult,
     PolicyEngineBundle,
 )
+
+logger = logging.getLogger(__name__)
+
+_UNKNOWN_CHILD_JOB_ID = "unknown"
 
 BUDGET_WINDOW_JOB_DICT_NAME = "simulation-api-budget-window-jobs"
 BUDGET_WINDOW_JOB_SEED_DICT_NAME = "simulation-api-budget-window-job-seeds"
@@ -129,6 +134,34 @@ def mark_child_started(
     return _touch(state)
 
 
+def _existing_child_or_sentinel(
+    state: BudgetWindowBatchState, *, year: str
+) -> BatchChildJobStatus:
+    """Return the tracked child for ``year`` or synthesise a sentinel.
+
+    Callers (``mark_child_completed`` / ``mark_child_failed``) used to index
+    ``state.child_jobs[year]`` directly which would raise ``KeyError`` if
+    transition helpers were invoked out of order (e.g., after recovery from
+    a dropped ``mark_child_started`` due to a crash between spawn and seed
+    persistence). In that unusual case we'd rather surface a redacted
+    terminal state with a synthetic job id than abort the whole batch. The
+    anomaly is logged at WARNING so operators can investigate separately.
+    """
+    child = state.child_jobs.get(year)
+    if child is not None:
+        return child
+
+    logger.warning(
+        "Transitioning child state for year %s with no prior child_jobs entry;"
+        " synthesising a sentinel job id",
+        year,
+        extra={"year": year, "batch_job_id": state.batch_job_id},
+    )
+    sentinel = BatchChildJobStatus(job_id=_UNKNOWN_CHILD_JOB_ID, status="pending")
+    state.child_jobs[year] = sentinel
+    return sentinel
+
+
 def mark_child_completed(
     state: BudgetWindowBatchState,
     *,
@@ -140,7 +173,7 @@ def mark_child_completed(
     if year not in state.completed_years:
         state.completed_years.append(year)
 
-    child = state.child_jobs[year]
+    child = _existing_child_or_sentinel(state, year=year)
     state.child_jobs[year] = BatchChildJobStatus(
         job_id=child.job_id,
         status="complete",
@@ -160,7 +193,7 @@ def mark_child_failed(
     if year not in state.failed_years:
         state.failed_years.append(year)
 
-    child = state.child_jobs[year]
+    child = _existing_child_or_sentinel(state, year=year)
     state.child_jobs[year] = BatchChildJobStatus(
         job_id=child.job_id,
         status="failed",

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -19,8 +19,14 @@ gateway_image = (
     .pip_install(
         "fastapi>=0.115.0",
         "pydantic>=2.0",
+        # PyJWT powers the bearer-token decoder in gateway.auth.
+        "pyjwt>=2.10.1,<3.0.0",
+        # JWTDecoder lives in the policyengine-fastapi lib; it only needs
+        # the auth module at runtime here.
+        "cryptography>=41.0.0",
     )
     .add_local_python_source("src.modal", copy=True)
+    .add_local_python_source("policyengine_fastapi", copy=True)
 )
 
 

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -44,7 +44,15 @@ def web_app():
     """
     from fastapi import FastAPI
 
+    from src.modal.gateway.auth import enforce_production_auth_guard
     from src.modal.gateway.endpoints import router
+
+    # Startup guard: crash the container if GATEWAY_AUTH_DISABLED is set in
+    # a production-equivalent Modal environment, or set without the
+    # explicit acknowledgement env var. This prevents the bypass from
+    # accidentally shipping to prod if a dev deploy grabs the wrong secret
+    # bundle. See gateway.auth.enforce_production_auth_guard for the rules.
+    enforce_production_auth_guard()
 
     api = FastAPI(
         title="PolicyEngine Simulation Gateway",

--- a/projects/policyengine-api-simulation/src/modal/gateway/auth.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/auth.py
@@ -1,0 +1,92 @@
+"""Gateway authentication primitives.
+
+The gateway is a public-facing ASGI app that routes simulation submission and
+polling requests to versioned worker apps. Every write/mutation endpoint and
+every read endpoint that exposes per-job state must require a valid bearer
+token issued by the PolicyEngine identity provider. This module exposes a
+FastAPI dependency (:func:`require_auth`) that callers attach with
+``Depends(require_auth)``.
+
+Configuration is read from the environment at import time so that Modal's
+runtime container picks up the values injected via ``modal.Secret``:
+
+- ``GATEWAY_AUTH_ISSUER`` - Auth0 issuer URL (must end with ``/``)
+- ``GATEWAY_AUTH_AUDIENCE`` - Auth0 API identifier the gateway accepts
+
+For local development and unit tests the dependency can be bypassed by
+setting ``GATEWAY_AUTH_DISABLED=1``. Production deployments must leave this
+unset; the gateway returns ``503`` to callers if it is started without the
+issuer/audience configured.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from policyengine_fastapi.auth import JWTDecoder
+
+logger = logging.getLogger(__name__)
+
+
+GATEWAY_AUTH_ISSUER_ENV = "GATEWAY_AUTH_ISSUER"
+GATEWAY_AUTH_AUDIENCE_ENV = "GATEWAY_AUTH_AUDIENCE"
+GATEWAY_AUTH_DISABLED_ENV = "GATEWAY_AUTH_DISABLED"
+
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _auth_disabled() -> bool:
+    return os.environ.get(GATEWAY_AUTH_DISABLED_ENV, "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _get_decoder() -> JWTDecoder:
+    issuer = os.environ.get(GATEWAY_AUTH_ISSUER_ENV)
+    audience = os.environ.get(GATEWAY_AUTH_AUDIENCE_ENV)
+    if not issuer or not audience:
+        raise RuntimeError(
+            "Gateway auth misconfigured: set "
+            f"{GATEWAY_AUTH_ISSUER_ENV} and {GATEWAY_AUTH_AUDIENCE_ENV} or "
+            f"{GATEWAY_AUTH_DISABLED_ENV}=1 for local/test use."
+        )
+    return JWTDecoder(issuer=issuer, audience=audience, auto_error=True)
+
+
+def require_auth(
+    token: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> dict | None:
+    """FastAPI dependency gating an endpoint behind a bearer JWT.
+
+    Resolution rules:
+    1. If ``GATEWAY_AUTH_DISABLED`` is truthy, accept the request without
+       any token inspection so tests and local reruns don't need to wire
+       fake JWT material.
+    2. Otherwise, validate the bearer token via :class:`JWTDecoder`. A
+       missing or invalid token produces a 403 (matching the underlying
+       decoder's contract).
+
+    If issuer/audience env configuration is missing the dependency returns
+    503 so operators see a clear misconfiguration instead of silent bypass.
+    """
+
+    if _auth_disabled():
+        return None
+
+    try:
+        decoder = _get_decoder()
+    except RuntimeError as exc:
+        logger.error("Gateway auth misconfigured: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Gateway authentication is not configured.",
+        )
+
+    return decoder(token)

--- a/projects/policyengine-api-simulation/src/modal/gateway/auth.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/auth.py
@@ -21,6 +21,7 @@ issuer/audience configured.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 
@@ -48,7 +49,26 @@ def _auth_disabled() -> bool:
     }
 
 
+@functools.lru_cache(maxsize=8)
+def _build_decoder(issuer: str, audience: str) -> JWTDecoder:
+    """Construct and cache a ``JWTDecoder`` keyed by issuer/audience.
+
+    The decoder wraps a ``PyJWKClient`` that caches JWKS responses internally.
+    Rebuilding the decoder on every request defeats that cache and forces a
+    live JWKS fetch per call (see PR #458 review). Caching here with
+    ``functools.lru_cache`` keeps a single decoder instance per
+    (issuer, audience) pair for the lifetime of the process, so the JWKS
+    client's own LRU cache is reused across requests.
+
+    The cache is keyed on the resolved env values so that test suites that
+    mutate ``GATEWAY_AUTH_ISSUER`` / ``GATEWAY_AUTH_AUDIENCE`` still observe
+    the right decoder without a stale instance bleeding across tests.
+    """
+    return JWTDecoder(issuer=issuer, audience=audience, auto_error=True)
+
+
 def _get_decoder() -> JWTDecoder:
+    """Resolve the cached ``JWTDecoder`` for the current env configuration."""
     issuer = os.environ.get(GATEWAY_AUTH_ISSUER_ENV)
     audience = os.environ.get(GATEWAY_AUTH_AUDIENCE_ENV)
     if not issuer or not audience:
@@ -57,7 +77,12 @@ def _get_decoder() -> JWTDecoder:
             f"{GATEWAY_AUTH_ISSUER_ENV} and {GATEWAY_AUTH_AUDIENCE_ENV} or "
             f"{GATEWAY_AUTH_DISABLED_ENV}=1 for local/test use."
         )
-    return JWTDecoder(issuer=issuer, audience=audience, auto_error=True)
+    return _build_decoder(issuer, audience)
+
+
+def reset_decoder_cache() -> None:
+    """Clear the cached decoder. Intended for tests and process restarts."""
+    _build_decoder.cache_clear()
 
 
 def require_auth(

--- a/projects/policyengine-api-simulation/src/modal/gateway/auth.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/auth.py
@@ -14,9 +14,14 @@ runtime container picks up the values injected via ``modal.Secret``:
 - ``GATEWAY_AUTH_AUDIENCE`` - Auth0 API identifier the gateway accepts
 
 For local development and unit tests the dependency can be bypassed by
-setting ``GATEWAY_AUTH_DISABLED=1``. Production deployments must leave this
-unset; the gateway returns ``503`` to callers if it is started without the
-issuer/audience configured.
+setting ``GATEWAY_AUTH_DISABLED=1``. This bypass is hard-gated by
+:func:`enforce_production_auth_guard`, which is called from the gateway
+ASGI factory at startup: it refuses to boot when ``MODAL_ENVIRONMENT`` is
+missing or looks like production, and otherwise requires an explicit
+``GATEWAY_AUTH_DISABLED_ACK=I_UNDERSTAND_THIS_IS_DEV`` acknowledgement so
+the bypass cannot be activated by a single stray env var. The gateway
+also returns ``503`` to callers if auth is enabled but the issuer/audience
+configuration is missing.
 """
 
 from __future__ import annotations
@@ -36,6 +41,16 @@ logger = logging.getLogger(__name__)
 GATEWAY_AUTH_ISSUER_ENV = "GATEWAY_AUTH_ISSUER"
 GATEWAY_AUTH_AUDIENCE_ENV = "GATEWAY_AUTH_AUDIENCE"
 GATEWAY_AUTH_DISABLED_ENV = "GATEWAY_AUTH_DISABLED"
+GATEWAY_AUTH_DISABLED_ACK_ENV = "GATEWAY_AUTH_DISABLED_ACK"
+GATEWAY_AUTH_DISABLED_ACK_VALUE = "I_UNDERSTAND_THIS_IS_DEV"
+
+# Modal injects ``MODAL_ENVIRONMENT`` into every container. Any of these
+# values are treated as production-equivalent: refuse to start the gateway
+# with auth disabled in them. If the env var is unset we also refuse,
+# because "unset" is the default state of a mis-deployed container and we
+# don't want the auth bypass to silently activate there.
+PRODUCTION_MODAL_ENVIRONMENTS = frozenset({"main", "prod", "production"})
+MODAL_ENVIRONMENT_ENV = "MODAL_ENVIRONMENT"
 
 
 _bearer_scheme = HTTPBearer(auto_error=False)
@@ -83,6 +98,75 @@ def _get_decoder() -> JWTDecoder:
 def reset_decoder_cache() -> None:
     """Clear the cached decoder. Intended for tests and process restarts."""
     _build_decoder.cache_clear()
+
+
+class AuthDisabledInProductionError(RuntimeError):
+    """Refuse to start when auth is disabled in a production-equivalent env."""
+
+
+class AuthDisabledWithoutAckError(RuntimeError):
+    """Refuse to start when auth is disabled without the explicit ACK."""
+
+
+def enforce_production_auth_guard() -> None:
+    """Validate at startup that the auth-disabled bypass is only used in dev.
+
+    Must be called from the ASGI app factory (``gateway.app.web_app``) before
+    serving any requests. The guard has three tiers so that accidental
+    production deploys cannot reach the "auth disabled" code path:
+
+    1. If ``GATEWAY_AUTH_DISABLED`` is not set, do nothing.
+    2. If set and ``MODAL_ENVIRONMENT`` is missing or looks like production
+       (``main``, ``prod``, ``production``), raise so the container crashes
+       at import time. ``modal serve`` / ``modal deploy`` surface the
+       traceback instead of silently serving an unprotected gateway.
+    3. Otherwise require an explicit acknowledgement env var
+       (``GATEWAY_AUTH_DISABLED_ACK=I_UNDERSTAND_THIS_IS_DEV``). This makes
+       the bypass impossible to set via one stray env var — an operator
+       must actively opt in.
+
+    Even when the guard passes, emit a ``CRITICAL`` log (and, if available,
+    a ``logfire.error``) so any audit of the service's logs surfaces the
+    bypass immediately.
+    """
+    if not _auth_disabled():
+        return
+
+    modal_env = os.environ.get(MODAL_ENVIRONMENT_ENV)
+    ack = os.environ.get(GATEWAY_AUTH_DISABLED_ACK_ENV, "")
+
+    if modal_env is None or modal_env.lower() in PRODUCTION_MODAL_ENVIRONMENTS:
+        raise AuthDisabledInProductionError(
+            f"Refusing to start gateway with {GATEWAY_AUTH_DISABLED_ENV}=1 "
+            f"when {MODAL_ENVIRONMENT_ENV}={modal_env!r}. "
+            "Disabling auth is only permitted in ephemeral dev environments."
+        )
+
+    if ack != GATEWAY_AUTH_DISABLED_ACK_VALUE:
+        raise AuthDisabledWithoutAckError(
+            f"Refusing to start gateway with {GATEWAY_AUTH_DISABLED_ENV}=1 "
+            f"unless {GATEWAY_AUTH_DISABLED_ACK_ENV}="
+            f"{GATEWAY_AUTH_DISABLED_ACK_VALUE} is also set."
+        )
+
+    banner = (
+        "\n"
+        "!! GATEWAY AUTH IS DISABLED !! "
+        f"MODAL_ENVIRONMENT={modal_env!r}. "
+        "This MUST NOT reach production. If you see this in prod logs, "
+        "roll back immediately."
+    )
+    logger.critical(banner)
+    try:
+        import logfire  # Local import: logfire is optional in tests.
+
+        logfire.error(
+            "gateway_auth_disabled_bypass_active",
+            modal_environment=modal_env,
+            ack_value_present=True,
+        )
+    except Exception:  # pragma: no cover - logfire optional / misconfigured
+        pass
 
 
 def require_auth(

--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -17,6 +17,7 @@ from src.modal.budget_window_state import (
     put_batch_job_state,
 )
 from src.modal.gateway.auth import require_auth
+from src.modal.gateway.errors import log_and_redact_exception
 from src.modal.gateway.models import (
     BudgetWindowBatchRequest,
     BudgetWindowBatchStatusResponse,
@@ -277,8 +278,13 @@ async def get_job_status(job_id: str):
         )
     except TimeoutError:
         return running_job_response(job_metadata)
-    except Exception as e:
-        return failed_job_response(error=str(e), job_metadata=job_metadata)
+    except Exception as exc:
+        redacted = log_and_redact_exception(
+            exc,
+            scope="simulation_job_status",
+            context={"job_id": job_id},
+        )
+        return failed_job_response(error=redacted, job_metadata=job_metadata)
 
 
 @router.get(
@@ -310,13 +316,18 @@ async def get_budget_window_job_status(batch_job_id: str):
         result = call.get(timeout=0)
     except TimeoutError:
         return batch_status_response(build_batch_status_response(seed_state))
-    except Exception as e:
+    except Exception as exc:
         # Persist the failure so subsequent polls don't resurrect the
         # "submitted" status from the seed store (#448). We deliberately
         # overwrite the main job store entry as well as the seed so either
         # lookup path observes the terminal failed state.
+        redacted = log_and_redact_exception(
+            exc,
+            scope="budget_window_parent_call",
+            context={"batch_job_id": batch_job_id},
+        )
         seed_state.status = "failed"
-        seed_state.error = str(e)
+        seed_state.error = redacted
         put_batch_job_state(seed_state)
         put_batch_job_seed(seed_state)
         return batch_status_response(build_batch_status_response(seed_state))

--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -6,7 +6,7 @@ import logging
 from typing import Optional
 
 import modal
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from src.modal.budget_window_state import (
     build_batch_status_response,
@@ -15,6 +15,7 @@ from src.modal.budget_window_state import (
     get_batch_job_state,
     put_batch_job_seed,
 )
+from src.modal.gateway.auth import require_auth
 from src.modal.gateway.models import (
     BudgetWindowBatchRequest,
     BudgetWindowBatchStatusResponse,
@@ -140,6 +141,7 @@ def get_app_name(country: str, version: Optional[str]) -> tuple[str, str]:
     "/simulate/economy/comparison",
     response_model=JobSubmitResponse,
     response_model_exclude_none=True,
+    dependencies=[Depends(require_auth)],
 )
 async def submit_simulation(request: SimulationRequest):
     """
@@ -196,6 +198,7 @@ async def submit_simulation(request: SimulationRequest):
     "/simulate/economy/budget-window",
     response_model=BudgetWindowBatchSubmitResponse,
     response_model_exclude_none=True,
+    dependencies=[Depends(require_auth)],
 )
 async def submit_budget_window_batch(request: BudgetWindowBatchRequest):
     """
@@ -247,6 +250,7 @@ async def submit_budget_window_batch(request: BudgetWindowBatchRequest):
     "/jobs/{job_id}",
     response_model=JobStatusResponse,
     response_model_exclude_none=True,
+    dependencies=[Depends(require_auth)],
 )
 async def get_job_status(job_id: str):
     """
@@ -280,6 +284,7 @@ async def get_job_status(job_id: str):
     "/budget-window-jobs/{batch_job_id}",
     response_model=BudgetWindowBatchStatusResponse,
     response_model_exclude_none=True,
+    dependencies=[Depends(require_auth)],
 )
 async def get_budget_window_job_status(batch_job_id: str):
     """

--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -14,6 +14,7 @@ from src.modal.budget_window_state import (
     get_batch_job_seed,
     get_batch_job_state,
     put_batch_job_seed,
+    put_batch_job_state,
 )
 from src.modal.gateway.auth import require_auth
 from src.modal.gateway.models import (
@@ -310,8 +311,14 @@ async def get_budget_window_job_status(batch_job_id: str):
     except TimeoutError:
         return batch_status_response(build_batch_status_response(seed_state))
     except Exception as e:
+        # Persist the failure so subsequent polls don't resurrect the
+        # "submitted" status from the seed store (#448). We deliberately
+        # overwrite the main job store entry as well as the seed so either
+        # lookup path observes the terminal failed state.
         seed_state.status = "failed"
         seed_state.error = str(e)
+        put_batch_job_state(seed_state)
+        put_batch_job_seed(seed_state)
         return batch_status_response(build_batch_status_response(seed_state))
 
     response = BudgetWindowBatchStatusResponse.model_validate(result)

--- a/projects/policyengine-api-simulation/src/modal/gateway/errors.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/errors.py
@@ -1,0 +1,101 @@
+"""Helpers for safe gateway error reporting.
+
+We intentionally do **not** leak ``str(exc)`` to API callers. Worker-side
+exceptions routinely embed container paths, HF URLs with pre-signed tokens,
+and internal parameter names that we do not want to surface to the public
+internet. Instead, we record the full exception server-side via
+:func:`logfire.exception` (or the configured structured logger) and return
+the caller a stable generic message plus a correlation id they can cite to
+support.
+
+Two helpers live here:
+
+- :func:`log_and_redact_exception` for request-handler code paths that want
+  to surface an HTTP error body.
+- :func:`make_correlation_id` for anywhere we need a free-standing id that
+  can be stitched back to a logged span.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    import logfire as _logfire  # type: ignore
+except Exception:  # pragma: no cover - logfire optional locally
+    _logfire = None
+
+
+def _logfire_is_configured() -> bool:
+    if _logfire is None:
+        return False
+    # logfire exposes a module-global "configured" flag only in newer
+    # versions; fall back to the private ``DEFAULT_LOGFIRE_INSTANCE``.
+    try:
+        instance = getattr(_logfire, "DEFAULT_LOGFIRE_INSTANCE", None)
+        if instance is None:
+            return False
+        return bool(getattr(instance.config, "send_to_logfire", False))
+    except Exception:
+        return False
+
+
+GENERIC_JOB_FAILURE_MESSAGE = "Simulation failed"
+
+
+def make_correlation_id() -> str:
+    return uuid.uuid4().hex
+
+
+def log_and_redact_exception(
+    exc: BaseException,
+    *,
+    scope: str,
+    context: dict[str, Any] | None = None,
+) -> str:
+    """Record ``exc`` with full context server-side and return a redacted
+    caller-safe message paired with a correlation id.
+
+    The public return string has the shape ``"Simulation failed
+    (correlation_id=<hex>)"`` so clients can paste it into support tickets
+    without needing to parse JSON. The same correlation id is attached to
+    the server-side log line so operators can jump between the two.
+    """
+
+    correlation_id = make_correlation_id()
+    payload = {
+        "correlation_id": correlation_id,
+        "scope": scope,
+    }
+    if context:
+        payload.update(context)
+
+    if _logfire_is_configured():
+        try:
+            _logfire.exception(  # type: ignore[union-attr]
+                "Gateway {scope} failed",
+                scope=scope,
+                correlation_id=correlation_id,
+                **(context or {}),
+            )
+        except Exception:  # pragma: no cover - defensive, never raise from logger
+            logger.exception(
+                "Gateway %s failed (correlation_id=%s)",
+                scope,
+                correlation_id,
+                extra=payload,
+            )
+    else:
+        logger.exception(
+            "Gateway %s failed (correlation_id=%s)",
+            scope,
+            correlation_id,
+            extra=payload,
+        )
+
+    return f"{GENERIC_JOB_FAILURE_MESSAGE} (correlation_id={correlation_id})"

--- a/projects/policyengine-api-simulation/src/modal/gateway/models.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/models.py
@@ -2,6 +2,7 @@
 Pydantic models for the Gateway API.
 """
 
+import json
 from typing import Any, ClassVar, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -9,33 +10,114 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from src.modal.telemetry import TelemetryEnvelope
 
 
+# Hard cap on request body size (bytes). SimulationOptions + telemetry + any
+# reform/baseline parameter tree should fit comfortably in ~256 KB. A hostile
+# client that tries to stream a multi-MB reform dict is rejected with 422
+# before Pydantic allocates proxy objects, which prevents memory-based DoS
+# against the gateway ASGI worker. If we discover a legitimate use case that
+# exceeds this we should add an explicit endpoint for bulk parameter upload
+# rather than relaxing the cap here.
+MAX_GATEWAY_REQUEST_BYTES = 262_144
+
+
+INTERNAL_PASSTHROUGH_FIELDS = frozenset({"_metadata"})
+
+
 def _move_internal_telemetry_alias(value):
     if not isinstance(value, dict):
         return value
-    if "telemetry" in value or "_telemetry" not in value:
-        return value
+    if "_telemetry" in value and "telemetry" not in value:
+        value = dict(value)
+        value["telemetry"] = value.pop("_telemetry")
+    return value
 
-    normalized = dict(value)
-    normalized["telemetry"] = normalized.pop("_telemetry")
-    return normalized
+
+def _strip_internal_passthrough_fields(value):
+    """Drop internal-only fields the gateway adds to payloads in flight.
+
+    When the parent batch entrypoint forwards a payload to the worker we
+    attach ``_metadata`` describing resolved routing. That enrichment is
+    consumed by :mod:`src.modal.budget_window_context`, not by the request
+    model itself. We strip it before strict validation so ``extra="forbid"``
+    keeps catching unknown fields from *callers* without breaking the
+    internal round-trip.
+    """
+
+    if not isinstance(value, dict):
+        return value
+    if not INTERNAL_PASSTHROUGH_FIELDS.intersection(value):
+        return value
+    return {
+        key: item
+        for key, item in value.items()
+        if key not in INTERNAL_PASSTHROUGH_FIELDS
+    }
+
+
+def _enforce_max_payload_size(value):
+    if not isinstance(value, dict):
+        return value
+    try:
+        encoded_length = len(json.dumps(value, default=str))
+    except TypeError:
+        # Non-JSON-serialisable values will fail later in Pydantic; size cap
+        # only guards against well-formed hostile payloads.
+        return value
+    if encoded_length > MAX_GATEWAY_REQUEST_BYTES:
+        raise ValueError(
+            f"Request body is too large ({encoded_length} bytes); the gateway "
+            f"accepts at most {MAX_GATEWAY_REQUEST_BYTES} bytes."
+        )
+    return value
 
 
 class GatewayRequestBase(BaseModel):
-    """Base request model that preserves internal telemetry aliasing."""
+    """Base request model with strict passthrough of documented fields only.
+
+    All fields that a caller may legitimately supply are declared explicitly:
+    fields consumed by the gateway router (``country``, ``version``,
+    ``telemetry``) plus every field the downstream ``SimulationOptions``
+    worker model accepts. Unknown fields are rejected (``extra="forbid"``)
+    so typos and adversarial payloads fail fast with a 422 instead of being
+    forwarded opaquely to the worker app.
+    """
 
     country: str
     version: Optional[str] = None
     telemetry: TelemetryEnvelope | None = None
 
+    # Fields forwarded to SimulationOptions on the worker side.
+    scope: Optional[str] = None
+    data: Optional[str] = None
+    time_period: Optional[str] = None
+    reform: Optional[dict[str, Any]] = None
+    baseline: Optional[dict[str, Any]] = None
+    region: Optional[str] = None
+    subsample: Optional[int] = None
+    title: Optional[str] = None
+    include_cliffs: Optional[bool] = None
+    model_version: Optional[str] = None
+    data_version: Optional[str] = None
+
     model_config = ConfigDict(
-        extra="allow",
+        extra="forbid",
         populate_by_name=True,
-    )  # Pass through all other fields
+    )
 
     @model_validator(mode="before")
     @classmethod
     def move_internal_telemetry_alias(cls, value):
         return _move_internal_telemetry_alias(value)
+
+    @model_validator(mode="before")
+    @classmethod
+    def strip_internal_passthrough_fields(cls, value):
+        return _strip_internal_passthrough_fields(value)
+
+    @model_validator(mode="before")
+    @classmethod
+    def enforce_max_payload_size(cls, value):
+        return _enforce_max_payload_size(value)
 
 
 class SimulationRequest(GatewayRequestBase):

--- a/projects/policyengine-api-simulation/src/modal/logging_redaction.py
+++ b/projects/policyengine-api-simulation/src/modal/logging_redaction.py
@@ -1,0 +1,43 @@
+"""Pure-Python payload redaction helpers for Logfire spans.
+
+We keep these in a separate module from :mod:`src.modal.app` so they can be
+unit-tested without instantiating the Modal app (which requires runtime
+Modal configuration that unit tests don't provide).
+"""
+
+from __future__ import annotations
+
+
+# Keys in request payloads that must never reach Logfire. ``data`` is a
+# signed GCS/HF URL (may contain embedded short-lived credentials), the
+# reform/baseline parameter trees are potentially large and reveal
+# proprietary policy design, and ``_telemetry`` / ``_metadata`` hold
+# internal routing/correlation fields we log separately via dedicated
+# structured attributes.
+SENSITIVE_PARAM_KEYS = ("data", "reform", "baseline", "_telemetry", "_metadata")
+
+
+def redact_params_for_logging(params) -> dict:
+    """Return a shallow copy of ``params`` safe to hand to Logfire.
+
+    We preserve routing-relevant fields (country, scope, version, time
+    period, etc.) so operators can still trace which simulation a span
+    corresponds to, but strip any field that may contain URLs with signed
+    credentials or arbitrarily large user-submitted parameter trees.
+    Non-dict inputs return an empty dict so callers can splat the result
+    into ``logfire.span(**...)`` without additional guards.
+    """
+
+    if not isinstance(params, dict):
+        return {}
+    redacted = {
+        key: value for key, value in params.items() if key not in SENSITIVE_PARAM_KEYS
+    }
+    # Surface only the correlation/run ids from telemetry, not the whole
+    # envelope.
+    telemetry = params.get("_telemetry")
+    if isinstance(telemetry, dict):
+        run_id = telemetry.get("run_id")
+        if run_id is not None:
+            redacted["run_id"] = run_id
+    return redacted

--- a/projects/policyengine-api-simulation/src/modal/simulation.py
+++ b/projects/policyengine-api-simulation/src/modal/simulation.py
@@ -5,10 +5,12 @@ This module has policyengine imports at module level so they are
 captured in Modal's image snapshot. No Modal dependencies here.
 """
 
+import contextlib
 import json
 import logging
 import os
 import tempfile
+from typing import Iterator
 
 # Module-level imports - these are SNAPSHOTTED at image build time
 from policyengine.simulation import Simulation, SimulationOptions
@@ -18,13 +20,37 @@ from src.modal.telemetry import split_internal_payload
 logger = logging.getLogger(__name__)
 
 
-def setup_gcp_credentials():
+def _normalize_credentials_blob(creds_json: str) -> str:
+    """Return the raw JSON blob, decoding the outer escape if present.
+
+    The upstream Modal secret sometimes stores the credentials payload
+    double-encoded (the entire JSON object is wrapped in quotes with
+    backslash-escaped interior quotes). Historically we always attempted
+    the unescape as a fallback which could accidentally parse an already
+    clean blob. Only unwrap when the payload looks wrapped."""
+
+    try:
+        json.loads(creds_json)
+    except json.JSONDecodeError:
+        looks_escaped = creds_json.lstrip().startswith('"') or '\\"' in creds_json
+        if looks_escaped:
+            return json.loads(f'"{creds_json}"')
+        raise
+    return creds_json
+
+
+@contextlib.contextmanager
+def setup_gcp_credentials() -> Iterator[None]:
     """
     Set up GCP credentials from environment variable.
 
     Modal secrets are injected as environment variables. The GCP library
-    expects GOOGLE_APPLICATION_CREDENTIALS to point to a file path.
-    If credentials JSON is provided, write it to a temp file.
+    expects GOOGLE_APPLICATION_CREDENTIALS to point to a file path. If
+    credentials JSON is provided, write it to a temp file that's deleted
+    on exit. This runs as a context manager to guarantee cleanup even if
+    the caller raises mid-simulation; the previous fire-and-forget
+    ``tempfile.mkstemp`` path leaked credential material on disk every
+    time a container served a request.
     """
     # Log available GCP-related env vars for debugging
     gcp_vars = {
@@ -37,6 +63,7 @@ def setup_gcp_credentials():
     # Check if credentials are already set as a file path
     if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
         logger.info("GOOGLE_APPLICATION_CREDENTIALS already set")
+        yield
         return
 
     # Check for credentials JSON in various env var names
@@ -47,22 +74,32 @@ def setup_gcp_credentials():
         or os.environ.get("SERVICE_ACCOUNT_JSON")
     )
 
-    if creds_json:
-        # Write credentials to a temp file
-        fd, path = tempfile.mkstemp(suffix=".json")
-        with os.fdopen(fd, "w") as f:
-            # Handle both raw JSON and escaped JSON strings
-            try:
-                json.loads(creds_json)  # Validate it's valid JSON
-                f.write(creds_json)
-            except json.JSONDecodeError:
-                # Try unescaping if it's a string-encoded JSON
-                f.write(json.loads(f'"{creds_json}"'))
-
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path
-        logger.info(f"GCP credentials written to {path}")
-    else:
+    if not creds_json:
         logger.warning("No GCP credentials found in environment variables")
+        yield
+        return
+
+    normalized = _normalize_credentials_blob(creds_json)
+
+    # ``NamedTemporaryFile(delete=True)`` removes the file when the context
+    # exits (either normally or via exception). We restore any prior value
+    # of ``GOOGLE_APPLICATION_CREDENTIALS`` so a retry in the same
+    # container doesn't silently pick up a path that no longer exists.
+    previous = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=True
+    ) as creds_file:
+        creds_file.write(normalized)
+        creds_file.flush()
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds_file.name
+        logger.info(f"GCP credentials written to {creds_file.name}")
+        try:
+            yield
+        finally:
+            if previous is None:
+                os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+            else:
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = previous
 
 
 def run_simulation_impl(params: dict) -> dict:
@@ -72,9 +109,13 @@ def run_simulation_impl(params: dict) -> dict:
     Pure implementation with no Modal dependencies.
     Accepts SimulationOptions as a dict and returns EconomyComparison as a dict.
     """
-    # Set up GCP credentials if needed
-    setup_gcp_credentials()
+    # Set up GCP credentials if needed. The credentials temp file is
+    # cleaned up on exit so we never leave signed JSON material on disk.
+    with setup_gcp_credentials():
+        return _run_simulation_impl_core(params)
 
+
+def _run_simulation_impl_core(params: dict) -> dict:
     simulation_params, telemetry, metadata = split_internal_payload(params)
 
     logger.info(

--- a/projects/policyengine-api-simulation/src/modal/utils/update_version_registry.py
+++ b/projects/policyengine-api-simulation/src/modal/utils/update_version_registry.py
@@ -20,6 +20,25 @@ Usage:
 
 import argparse
 import modal
+from packaging.version import InvalidVersion, Version
+
+
+def _is_newer_version(candidate: str, current: str | None) -> bool:
+    """Return True when ``candidate`` should replace ``current`` as 'latest'.
+
+    If the current pointer is missing we always advance. If either version
+    string is not PEP 440 parseable we fall back to a conservative rule:
+    advance only when the strings differ and the operator has explicitly
+    opted in via ``--force-latest``. That decision is made by the caller;
+    this helper answers the strict-greater-than question for valid versions.
+    """
+
+    if current is None:
+        return True
+    try:
+        return Version(candidate) > Version(current)
+    except InvalidVersion:
+        return False
 
 
 def update_version_dict(
@@ -27,15 +46,25 @@ def update_version_dict(
     environment: str,
     version: str,
     app_name: str,
+    *,
+    force_latest: bool = False,
 ) -> None:
     """
     Update a version dict entry, showing previous value if overwriting.
+
+    The mapping ``version_dict[version] -> app_name`` is always refreshed
+    so redeploying the same package version to a new app remains supported.
+    The ``latest`` pointer, however, is only advanced when ``version`` is a
+    strict semantic improvement over the current ``latest``. Pass
+    ``--force-latest`` to override (e.g. intentional downgrades or rollbacks).
 
     Args:
         dict_name: Name of the Modal Dict (e.g., "simulation-api-us-versions")
         environment: Modal environment (staging or main)
         version: Package version (e.g., "1.459.0")
         app_name: App name to map this version to
+        force_latest: When True, overwrite ``latest`` even if ``version`` is
+            older than the existing pointer.
     """
     version_dict = modal.Dict.from_name(
         dict_name,
@@ -56,13 +85,27 @@ def update_version_dict(
     # Update entry
     version_dict[version] = app_name
 
-    # Update latest pointer
+    # Update latest pointer only when the incoming version is newer or
+    # --force-latest was supplied.
     previous_latest = version_dict.get("latest")
-    version_dict["latest"] = version
-    if previous_latest != version:
-        print(f"  {dict_name}[latest]: {previous_latest} -> {version}")
+    should_advance = _is_newer_version(version, previous_latest) or force_latest
+
+    if should_advance:
+        version_dict["latest"] = version
+        if previous_latest != version:
+            forced = (
+                " [forced]"
+                if force_latest and not _is_newer_version(version, previous_latest)
+                else ""
+            )
+            print(f"  {dict_name}[latest]: {previous_latest} -> {version}{forced}")
+        else:
+            print(f"  {dict_name}[latest]: {version} (unchanged)")
     else:
-        print(f"  {dict_name}[latest]: {version} (unchanged)")
+        print(
+            f"  {dict_name}[latest]: {previous_latest} (kept; incoming "
+            f"{version} is not newer, pass --force-latest to override)"
+        )
 
 
 def main():
@@ -89,6 +132,14 @@ def main():
         required=True,
         help="Modal environment (staging or main)",
     )
+    parser.add_argument(
+        "--force-latest",
+        action="store_true",
+        help=(
+            "Overwrite 'latest' even when the supplied version is older than "
+            "the currently recorded latest (use for intentional rollbacks)."
+        ),
+    )
     args = parser.parse_args()
 
     print(f"Updating version registries in Modal environment: {args.environment}")
@@ -104,6 +155,7 @@ def main():
         args.environment,
         args.us_version,
         args.app_name,
+        force_latest=args.force_latest,
     )
     print()
 
@@ -114,6 +166,7 @@ def main():
         args.environment,
         args.uk_version,
         args.app_name,
+        force_latest=args.force_latest,
     )
     print()
 

--- a/projects/policyengine-api-simulation/tests/gateway/test_auth.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_auth.py
@@ -94,3 +94,100 @@ def test__given_health_endpoint__then_auth_not_required(monkeypatch):
     client = TestClient(create_gateway_app(authenticate=False))
     response = client.get("/health")
     assert response.status_code == 200
+
+
+def test__given_same_env__then_decoder_is_cached(monkeypatch):
+    """Calling ``_get_decoder`` repeatedly must return the same instance so
+    the wrapped ``PyJWKClient`` JWKS cache is reused across requests.
+    Rebuilding the decoder per request defeats the cache (#458 review)."""
+
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud-caching")
+
+    auth_module.reset_decoder_cache()
+    first = auth_module._get_decoder()
+    second = auth_module._get_decoder()
+
+    assert first is second
+
+
+def test__given_rotated_audience__then_cache_returns_new_decoder(monkeypatch):
+    """Cache is keyed on issuer+audience so rotating the audience yields a
+    fresh decoder without polluting the previous one."""
+
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+
+    auth_module.reset_decoder_cache()
+
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud-first")
+    first = auth_module._get_decoder()
+
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud-second")
+    second = auth_module._get_decoder()
+
+    assert first is not second
+    assert first.audience == "aud-first"
+    assert second.audience == "aud-second"
+
+
+def test__given_repeated_requests__then_decoder_not_reinstantiated(monkeypatch):
+    """Smoke test: hitting a gated endpoint many times must not rebuild the
+    decoder. We spy on ``JWTDecoder.__init__`` and assert it runs at most
+    once across many requests."""
+
+    from fixtures.gateway.shared import create_gateway_app
+    from policyengine_fastapi.auth import jwt_decoder as jwt_decoder_module
+
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud-repeat")
+
+    auth_module.reset_decoder_cache()
+
+    init_calls = {"count": 0}
+    original_init = jwt_decoder_module.JWTDecoder.__init__
+
+    def _counting_init(self, *args, **kwargs):
+        init_calls["count"] += 1
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(jwt_decoder_module.JWTDecoder, "__init__", _counting_init)
+
+    client = TestClient(create_gateway_app(authenticate=False))
+
+    for _ in range(5):
+        response = client.get("/jobs/some-id")
+        assert response.status_code == 403
+
+    assert init_calls["count"] == 1, (
+        f"Expected exactly one JWTDecoder instantiation across 5 requests, "
+        f"got {init_calls['count']}"
+    )
+
+
+def test__given_dependency_override__then_gated_endpoint_returns_200(
+    mock_modal, client: TestClient
+):
+    """Positive-path auth test: when ``app.dependency_overrides`` bypasses
+    ``require_auth`` (as real tests do), the gated endpoint returns 200 with
+    the expected payload. This guards the override path that other tests
+    rely on — if the override stops working, every gated-endpoint test would
+    start returning 403 instead of exercising real logic."""
+
+    mock_modal["dicts"]["simulation-api-us-versions"] = {
+        "latest": "1.500.0",
+        "1.500.0": "policyengine-simulation-us1-500-0-uk2-66-0",
+    }
+
+    response = client.post(
+        "/simulate/economy/comparison",
+        json={"country": "us", "scope": "macro", "reform": {}},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["job_id"] == "mock-job-id-123"
+    assert body["country"] == "us"
+    assert body["version"] == "1.500.0"

--- a/projects/policyengine-api-simulation/tests/gateway/test_auth.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_auth.py
@@ -191,3 +191,80 @@ def test__given_dependency_override__then_gated_endpoint_returns_200(
     assert body["job_id"] == "mock-job-id-123"
     assert body["country"] == "us"
     assert body["version"] == "1.500.0"
+
+
+class TestProductionAuthGuard:
+    """Tests for ``enforce_production_auth_guard`` — the startup-time check
+    that prevents ``GATEWAY_AUTH_DISABLED`` from slipping into production."""
+
+    def test__given_auth_enabled__then_guard_noops(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.delenv(auth_module.MODAL_ENVIRONMENT_ENV, raising=False)
+
+        # Must not raise even without any prod env configured.
+        auth_module.enforce_production_auth_guard()
+
+    def test__given_disabled_and_modal_env_missing__then_refuses(self, monkeypatch):
+        """Unset MODAL_ENVIRONMENT is treated as production: refuse."""
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.delenv(auth_module.MODAL_ENVIRONMENT_ENV, raising=False)
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_DISABLED_ACK_ENV,
+            auth_module.GATEWAY_AUTH_DISABLED_ACK_VALUE,
+        )
+
+        with pytest.raises(auth_module.AuthDisabledInProductionError):
+            auth_module.enforce_production_auth_guard()
+
+    @pytest.mark.parametrize("prod_env", ["main", "prod", "production", "PROD"])
+    def test__given_disabled_and_prod_modal_env__then_refuses(
+        self, monkeypatch, prod_env
+    ):
+        """Named production environments reject the bypass even with ACK."""
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.setenv(auth_module.MODAL_ENVIRONMENT_ENV, prod_env)
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_DISABLED_ACK_ENV,
+            auth_module.GATEWAY_AUTH_DISABLED_ACK_VALUE,
+        )
+
+        with pytest.raises(auth_module.AuthDisabledInProductionError):
+            auth_module.enforce_production_auth_guard()
+
+    def test__given_disabled_in_dev_without_ack__then_refuses(self, monkeypatch):
+        """A single env var (``GATEWAY_AUTH_DISABLED=1``) is not enough."""
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.setenv(auth_module.MODAL_ENVIRONMENT_ENV, "dev")
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ACK_ENV, raising=False)
+
+        with pytest.raises(auth_module.AuthDisabledWithoutAckError):
+            auth_module.enforce_production_auth_guard()
+
+    def test__given_disabled_in_dev_with_wrong_ack__then_refuses(self, monkeypatch):
+        """ACK must exactly match the magic string — truthy is not enough."""
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.setenv(auth_module.MODAL_ENVIRONMENT_ENV, "dev")
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ACK_ENV, "yes")
+
+        with pytest.raises(auth_module.AuthDisabledWithoutAckError):
+            auth_module.enforce_production_auth_guard()
+
+    def test__given_disabled_in_dev_with_correct_ack__then_allows_and_logs(
+        self, monkeypatch, caplog
+    ):
+        """The bypass is permitted but emits a CRITICAL log for audit."""
+        import logging
+
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.setenv(auth_module.MODAL_ENVIRONMENT_ENV, "dev")
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_DISABLED_ACK_ENV,
+            auth_module.GATEWAY_AUTH_DISABLED_ACK_VALUE,
+        )
+
+        with caplog.at_level(logging.CRITICAL, logger=auth_module.logger.name):
+            auth_module.enforce_production_auth_guard()
+
+        assert any(
+            "GATEWAY AUTH IS DISABLED" in record.message for record in caplog.records
+        ), f"Expected critical auth-disabled banner, got {caplog.records!r}"

--- a/projects/policyengine-api-simulation/tests/gateway/test_auth.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_auth.py
@@ -1,0 +1,96 @@
+"""Tests for gateway authentication middleware."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fixtures.gateway.shared import create_gateway_app
+from src.modal.gateway import auth as auth_module
+
+
+GATED_REQUESTS = [
+    (
+        "post",
+        "/simulate/economy/comparison",
+        {"country": "us", "scope": "macro", "reform": {}},
+    ),
+    (
+        "post",
+        "/simulate/economy/budget-window",
+        {
+            "country": "us",
+            "region": "us",
+            "scope": "macro",
+            "reform": {},
+            "start_year": "2026",
+            "window_size": 3,
+        },
+    ),
+    ("get", "/jobs/some-job-id", None),
+    ("get", "/budget-window-jobs/some-job-id", None),
+]
+
+
+@pytest.fixture
+def unauthenticated_client(monkeypatch) -> TestClient:
+    """A client where the real auth dependency is active but no token is
+    attached. The underlying JWTDecoder is stubbed to preserve the 403
+    contract without making a live JWKS fetch."""
+
+    class FailingDecoder:
+        def __call__(self, token):
+            from fastapi import HTTPException, status
+
+            if token is None:
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+    monkeypatch.setattr(auth_module, "_get_decoder", lambda: FailingDecoder())
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+
+    return TestClient(create_gateway_app(authenticate=False))
+
+
+@pytest.mark.parametrize("method,path,body", GATED_REQUESTS)
+def test__given_no_bearer_token__then_gated_endpoint_returns_403(
+    unauthenticated_client, method, path, body
+):
+    """Missing bearer tokens should be rejected on all private endpoints."""
+
+    if method == "post":
+        response = unauthenticated_client.post(path, json=body)
+    else:
+        response = unauthenticated_client.get(path)
+
+    assert response.status_code == 403
+
+
+def test__given_auth_disabled_env__then_dependency_returns_none(monkeypatch):
+    monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+    assert auth_module.require_auth(token=None) is None
+
+
+def test__given_auth_misconfigured__then_dependency_raises_503(monkeypatch):
+    from fastapi import HTTPException
+
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, raising=False)
+    monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth_module.require_auth(token=None)
+
+    assert exc_info.value.status_code == 503
+
+
+def test__given_health_endpoint__then_auth_not_required(monkeypatch):
+    """Health/ping/versions endpoints remain public by design."""
+
+    from fixtures.gateway.shared import create_gateway_app
+
+    client = TestClient(create_gateway_app(authenticate=False))
+    response = client.get("/health")
+    assert response.status_code == 200

--- a/projects/policyengine-api-simulation/tests/gateway/test_budget_window_state.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_budget_window_state.py
@@ -28,7 +28,7 @@ def test_create_initial_batch_state_builds_queued_years_and_run_id():
         start_year="2026",
         window_size=3,
         max_parallel=2,
-        dataset="enhanced_cps_2024",
+        data="enhanced_cps_2024",
         scope="macro",
         reform={},
         _telemetry={
@@ -52,7 +52,7 @@ def test_create_initial_batch_state_builds_queued_years_and_run_id():
     assert state.target == "general"
     assert state.years == ["2026", "2027", "2028"]
     assert state.queued_years == ["2026", "2027", "2028"]
-    assert state.request_payload["dataset"] == "enhanced_cps_2024"
+    assert state.request_payload["data"] == "enhanced_cps_2024"
     assert state.request_payload["scope"] == "macro"
     assert state.request_payload["reform"] == {}
     assert state.run_id == "batch-run-123"

--- a/projects/policyengine-api-simulation/tests/gateway/test_budget_window_state.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_budget_window_state.py
@@ -201,6 +201,72 @@ def test_state_transition_helpers_track_failed_child():
     assert state.child_jobs["2027"].status == "failed"
 
 
+def test_mark_child_completed_handles_missing_child_jobs_entry(caplog):
+    """Regression test for #454: ``mark_child_completed`` crashed with a
+    ``KeyError`` when transitions were invoked without a preceding
+    ``mark_child_started`` call. The guard should synthesise a sentinel and
+    log a warning instead of aborting the batch."""
+    request = BudgetWindowBatchRequest(
+        country="us",
+        region="us",
+        start_year="2026",
+        window_size=1,
+    )
+    state = create_initial_batch_state(
+        batch_job_id="fc-parent-123",
+        request=request,
+        resolved_version="1.500.0",
+        resolved_app_name="policyengine-simulation-us1-500-0-uk2-66-0",
+        bundle=PolicyEngineBundle(model_version="1.500.0"),
+    )
+    # Simulate the crash-recovery path where the running/completed lists
+    # were restored but child_jobs wasn't fully repopulated.
+    state.running_years = ["2026"]
+
+    with caplog.at_level("WARNING", logger="src.modal.budget_window_state"):
+        mark_child_completed(
+            state,
+            year="2026",
+            annual_impact=BudgetWindowAnnualImpact(
+                year="2026",
+                taxRevenueImpact=1,
+                federalTaxRevenueImpact=1,
+                stateTaxRevenueImpact=0,
+                benefitSpendingImpact=1,
+                budgetaryImpact=2,
+            ),
+        )
+
+    assert state.child_jobs["2026"].status == "complete"
+    assert state.child_jobs["2026"].job_id == "unknown"
+    assert state.completed_years == ["2026"]
+    assert any("no prior child_jobs entry" in r.message for r in caplog.records)
+
+
+def test_mark_child_failed_handles_missing_child_jobs_entry(caplog):
+    request = BudgetWindowBatchRequest(
+        country="us",
+        region="us",
+        start_year="2026",
+        window_size=1,
+    )
+    state = create_initial_batch_state(
+        batch_job_id="fc-parent-123",
+        request=request,
+        resolved_version="1.500.0",
+        resolved_app_name="policyengine-simulation-us1-500-0-uk2-66-0",
+        bundle=PolicyEngineBundle(model_version="1.500.0"),
+    )
+    state.running_years = ["2026"]
+
+    with caplog.at_level("WARNING", logger="src.modal.budget_window_state"):
+        mark_child_failed(state, year="2026", error="boom")
+
+    assert state.child_jobs["2026"].status == "failed"
+    assert state.child_jobs["2026"].error == "boom"
+    assert any("no prior child_jobs entry" in r.message for r in caplog.records)
+
+
 def test_mark_batch_failed_cancels_any_remaining_running_children():
     request = BudgetWindowBatchRequest(
         country="us",

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -678,3 +678,46 @@ class TestBudgetWindowBatchEndpoints:
 
         assert response.status_code == 422
         assert response.json()["detail"][0]["loc"] == ["body", "max_parallel"]
+
+    def test__given_parent_call_raises__then_failure_persists_across_polls(
+        self, mock_modal, client: TestClient
+    ):
+        """Regression test for #448: when the parent Modal FunctionCall raises
+        on .get() the first poll flipped seed state to failed in-memory only.
+        Subsequent polls re-read the unmodified seed and flipped back to
+        "submitted". Verify the mutation is persisted so the terminal state
+        survives a second poll."""
+
+        mock_modal["dicts"]["simulation-api-us-versions"] = {
+            "latest": "1.500.0",
+            "1.500.0": "policyengine-simulation-us1-500-0-uk2-66-0",
+        }
+
+        submit_response = client.post(
+            "/simulate/economy/budget-window",
+            json={
+                "country": "us",
+                "region": "us",
+                "scope": "macro",
+                "reform": {},
+                "start_year": "2026",
+                "window_size": 2,
+                "max_parallel": 2,
+            },
+        )
+        batch_id = submit_response.json()["batch_job_id"]
+
+        # Arm the mocked call so .get(timeout=0) raises a non-timeout error.
+        call = mock_modal["func"].last_call
+        call.error = RuntimeError("worker crashed")
+        call.running = False
+
+        first_poll = client.get(f"/budget-window-jobs/{batch_id}")
+        assert first_poll.status_code == 500
+        assert first_poll.json()["status"] == "failed"
+        assert first_poll.json()["error"] == "worker crashed"
+
+        second_poll = client.get(f"/budget-window-jobs/{batch_id}")
+        assert second_poll.status_code == 500, second_poll.json()
+        assert second_poll.json()["status"] == "failed"
+        assert second_poll.json()["error"] == "worker crashed"

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -714,10 +714,16 @@ class TestBudgetWindowBatchEndpoints:
 
         first_poll = client.get(f"/budget-window-jobs/{batch_id}")
         assert first_poll.status_code == 500
-        assert first_poll.json()["status"] == "failed"
-        assert first_poll.json()["error"] == "worker crashed"
+        first_body = first_poll.json()
+        assert first_body["status"] == "failed"
+        # Error is redacted (#453); the correlation id is in the string so
+        # operators can jump from the user's report to the server-side log.
+        assert first_body["error"].startswith("Simulation failed")
+        assert "correlation_id=" in first_body["error"]
+        assert "worker crashed" not in first_body["error"]
 
         second_poll = client.get(f"/budget-window-jobs/{batch_id}")
         assert second_poll.status_code == 500, second_poll.json()
-        assert second_poll.json()["status"] == "failed"
-        assert second_poll.json()["error"] == "worker crashed"
+        second_body = second_poll.json()
+        assert second_body["status"] == "failed"
+        assert second_body["error"].startswith("Simulation failed")

--- a/projects/policyengine-api-simulation/tests/gateway/test_errors.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_errors.py
@@ -1,0 +1,56 @@
+"""Tests for gateway error-redaction helpers."""
+
+from __future__ import annotations
+
+import re
+
+from src.modal.gateway import errors as errors_module
+
+
+CORRELATION_RE = re.compile(r"correlation_id=([0-9a-f]{32})")
+
+
+def test_log_and_redact_exception_emits_correlation_id(monkeypatch):
+    class _FakeLogfire:
+        def __init__(self):
+            self.calls = []
+
+        def exception(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+
+    fake = _FakeLogfire()
+    monkeypatch.setattr(errors_module, "_logfire", fake)
+    monkeypatch.setattr(errors_module, "_logfire_is_configured", lambda: True)
+
+    exc = RuntimeError(
+        "Signed GCS URL https://storage.googleapis.com/foo?token=SECRET "
+        "failed to resolve"
+    )
+    message = errors_module.log_and_redact_exception(
+        exc, scope="test_scope", context={"job_id": "abc"}
+    )
+
+    match = CORRELATION_RE.search(message)
+    assert match is not None, message
+
+    assert "SECRET" not in message
+    assert "token=" not in message
+    assert message.startswith("Simulation failed")
+
+    assert len(fake.calls) == 1
+    # Correlation id must appear in the server-side structured log.
+    _, kwargs = fake.calls[0]
+    assert kwargs["correlation_id"] == match.group(1)
+    assert kwargs["scope"] == "test_scope"
+    assert kwargs["job_id"] == "abc"
+
+
+def test_log_and_redact_exception_falls_back_to_stdlib_logger(monkeypatch, caplog):
+    monkeypatch.setattr(errors_module, "_logfire", None)
+    exc = ValueError("secret-parameter-name")
+    with caplog.at_level("ERROR", logger="src.modal.gateway.errors"):
+        message = errors_module.log_and_redact_exception(exc, scope="fallback")
+
+    assert "secret-parameter-name" not in message
+    assert message.startswith("Simulation failed")
+    assert any("fallback" in record.message for record in caplog.records)

--- a/projects/policyengine-api-simulation/tests/gateway/test_models.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_models.py
@@ -198,6 +198,60 @@ class TestSimulationRequest:
         with pytest.raises(ValidationError, match="too large"):
             SimulationRequest(country="us", reform=giant_reform)
 
+    def test_simulation_request_accepts_payload_just_below_256kb(self):
+        """256 KB boundary (#450): a payload just below the cap must be
+        accepted. We build a reform dict whose JSON encoding is ~256_100
+        bytes before adding the ``country`` key, then prune until just under
+        the 262_144 byte limit."""
+        import json
+
+        from src.modal.gateway.models import MAX_GATEWAY_REQUEST_BYTES
+
+        # Each entry in this shape encodes to roughly 40 bytes of JSON. We
+        # build a generous reform then trim the last few entries until the
+        # total is safely under the cap.
+        reform = {f"mock.parameter[{i}]": {"2024-01-01": i} for i in range(6_000)}
+        payload = {"country": "us", "reform": reform}
+
+        while len(json.dumps(payload, default=str)) > MAX_GATEWAY_REQUEST_BYTES - 200:
+            reform.popitem()
+
+        encoded_size = len(json.dumps(payload, default=str))
+        assert encoded_size < MAX_GATEWAY_REQUEST_BYTES, (
+            f"Test setup produced {encoded_size} bytes, "
+            f"expected < {MAX_GATEWAY_REQUEST_BYTES}"
+        )
+
+        # Must not raise — this is the just-under-cap happy path.
+        request = SimulationRequest(**payload)
+        assert request.country == "us"
+        assert len(request.reform) == len(reform)
+
+    def test_simulation_request_rejects_payload_just_above_256kb(self):
+        """The cap is strict: a payload that crosses 262_144 bytes by even a
+        few bytes should be rejected with a ``too large`` ValidationError."""
+        import json
+
+        from src.modal.gateway.models import MAX_GATEWAY_REQUEST_BYTES
+
+        # Generate enough entries to definitely exceed the cap, then trim to
+        # just a few bytes above it.
+        reform = {f"mock.parameter[{i}]": {"2024-01-01": i} for i in range(12_000)}
+        payload = {"country": "us", "reform": reform}
+
+        # Trim down to just above the cap (within 200 bytes).
+        while len(json.dumps(payload, default=str)) > MAX_GATEWAY_REQUEST_BYTES + 200:
+            reform.popitem()
+
+        encoded_size = len(json.dumps(payload, default=str))
+        assert encoded_size > MAX_GATEWAY_REQUEST_BYTES, (
+            f"Test setup produced {encoded_size} bytes, "
+            f"expected > {MAX_GATEWAY_REQUEST_BYTES}"
+        )
+
+        with pytest.raises(ValidationError, match="too large"):
+            SimulationRequest(**payload)
+
     def test_simulation_request_accepts_typed_telemetry_envelope(self):
         """
         Given a telemetry envelope

--- a/projects/policyengine-api-simulation/tests/gateway/test_models.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_models.py
@@ -156,17 +156,19 @@ class TestSimulationRequest:
         assert request.country == "uk"
         assert request.version == "1.0.0"
 
-    def test_simulation_request_allows_extra_fields(self):
+    def test_simulation_request_accepts_documented_simulation_fields(self):
         """
-        Given extra fields (reform, region, etc.)
+        Given the documented simulation fields (reform, region, data, ...)
         When creating a SimulationRequest
-        Then the model accepts the extra fields.
+        Then the model accepts and preserves them.
         """
         # Given
         data = {
             "country": "us",
             "region": "enhanced_us",
             "reform": {"some.parameter": {"2024-01-01": True}},
+            "data": "enhanced_cps_2024",
+            "scope": "macro",
         }
 
         # When
@@ -174,10 +176,27 @@ class TestSimulationRequest:
 
         # Then
         assert request.country == "us"
-        # Extra fields should be accessible via model_dump
-        dumped = request.model_dump()
+        dumped = request.model_dump(exclude_none=True)
         assert dumped["region"] == "enhanced_us"
         assert dumped["reform"] == {"some.parameter": {"2024-01-01": True}}
+        assert dumped["data"] == "enhanced_cps_2024"
+        assert dumped["scope"] == "macro"
+
+    def test_simulation_request_rejects_unknown_fields(self):
+        """Unknown fields should fail fast with ``extra="forbid"``."""
+        with pytest.raises(ValidationError):
+            SimulationRequest(country="us", dataset="enhanced_cps_2024")
+        with pytest.raises(ValidationError):
+            SimulationRequest(country="us", mystery_flag=True)
+
+    def test_simulation_request_rejects_oversized_payload(self):
+        """Payloads that exceed the gateway max should 422 before Pydantic
+        allocates proxy objects for the nested reform dict."""
+        giant_reform = {
+            f"mock.parameter[{i}]": {"2024-01-01": i} for i in range(10_000)
+        }
+        with pytest.raises(ValidationError, match="too large"):
+            SimulationRequest(country="us", reform=giant_reform)
 
     def test_simulation_request_accepts_typed_telemetry_envelope(self):
         """

--- a/projects/policyengine-api-simulation/tests/integration/test_budget_window_ephemeral_modal.py
+++ b/projects/policyengine-api-simulation/tests/integration/test_budget_window_ephemeral_modal.py
@@ -1,0 +1,48 @@
+"""Real-Modal integration smoke test for the budget-window batch path.
+
+This test is intentionally skipped by default. It is meant to be run
+against an ephemeral Modal environment (``modal environment create``) that
+has the gateway and a versioned worker app deployed; it exercises the
+full spawn + poll loop against the real control plane.
+
+Run explicitly with::
+
+    pytest tests/integration -m integration
+
+The test body is a skeleton; a follow-up change will wire up the actual
+ephemeral deployment fixtures once the orchestration scripts land.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def modal_integration_environment():
+    """Guard the integration test behind an explicit env opt-in."""
+    if not os.environ.get("POLICYENGINE_MODAL_INTEGRATION_BASE_URL"):
+        pytest.skip(
+            "Set POLICYENGINE_MODAL_INTEGRATION_BASE_URL to enable the "
+            "Modal integration smoke test."
+        )
+    return os.environ["POLICYENGINE_MODAL_INTEGRATION_BASE_URL"]
+
+
+def test_budget_window_submission_reaches_complete(
+    modal_integration_environment: str,
+):
+    """Placeholder for the real integration run.
+
+    The real implementation will submit a 2-year US batch to the ephemeral
+    gateway URL, poll until ``status=="complete"``, and assert the
+    returned annual impacts match a golden fixture. For now the test is
+    intentionally empty so the integration bucket exists as a real
+    directory with a valid Python test module.
+    """
+
+    assert modal_integration_environment.startswith("http")

--- a/projects/policyengine-api-simulation/tests/test_app_redaction.py
+++ b/projects/policyengine-api-simulation/tests/test_app_redaction.py
@@ -1,0 +1,47 @@
+"""Tests for the Logfire payload redaction helper."""
+
+from __future__ import annotations
+
+from src.modal.logging_redaction import redact_params_for_logging
+
+
+def test_redact_params_strips_signed_urls_and_reform_bodies():
+    """Signed URLs and the reform parameter tree must not reach Logfire."""
+    params = {
+        "country": "us",
+        "scope": "macro",
+        "data": "https://storage.googleapis.com/bucket/key?token=SECRET&expiry=123",
+        "reform": {"gov.irs.income.bracket[2].rate": {"2024-01-01": 0.45}},
+        "baseline": {"gov.irs.income.bracket[2].rate": {"2023-01-01": 0.43}},
+        "_telemetry": {"run_id": "run-123", "process_id": "p-1"},
+        "_metadata": {"resolved_app_name": "policyengine-simulation-us1-500"},
+    }
+
+    redacted = redact_params_for_logging(params)
+
+    # Routing context is preserved.
+    assert redacted["country"] == "us"
+    assert redacted["scope"] == "macro"
+    # Correlation id is preserved, but the rest of the telemetry envelope
+    # is not.
+    assert redacted["run_id"] == "run-123"
+    assert "_telemetry" not in redacted
+    assert "_metadata" not in redacted
+
+    # Sensitive fields are stripped entirely.
+    assert "data" not in redacted
+    assert "reform" not in redacted
+    assert "baseline" not in redacted
+
+    # The signed URL value is not present anywhere in the redacted dict.
+    assert all("SECRET" not in str(value) for value in redacted.values())
+
+
+def test_redact_params_tolerates_non_dict_input():
+    assert redact_params_for_logging(None) == {}
+    assert redact_params_for_logging("string-payload") == {}
+
+
+def test_redact_params_handles_missing_telemetry():
+    params = {"country": "uk", "scope": "macro"}
+    assert redact_params_for_logging(params) == params

--- a/projects/policyengine-api-simulation/tests/test_budget_window_batch.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_batch.py
@@ -288,6 +288,65 @@ def test_run_budget_window_batch_impl_marks_failure(mock_batch_modal):
     assert state.child_jobs["2027"].status == "cancelled"
 
 
+def test_scheduler_sleep_exponentially_backs_off_then_resets_on_progress(
+    monkeypatch, mock_batch_modal
+):
+    """When every poll sees nothing resolve the runner should sleep with
+    increasing intervals, capped at the configured max. Any progress in a
+    subsequent poll should reset the cadence to the initial interval.
+    """
+
+    request, payload = _build_parent_payload(window_size=1)
+    _seed_parent_batch(request, mock_batch_modal["parent_call_id"])
+
+    tracker = SpawnTracker()
+    run_simulation = MockRunSimulationFunction(
+        tracker=tracker,
+        results_by_year={
+            "2026": [
+                TimeoutError(),
+                TimeoutError(),
+                TimeoutError(),
+                TimeoutError(),
+                {
+                    "budget": {
+                        "tax_revenue_impact": 10,
+                        "state_tax_revenue_impact": 3,
+                        "benefit_spending_impact": 5,
+                        "budgetary_impact": 15,
+                    }
+                },
+            ],
+        },
+        call_registry=mock_batch_modal["call_registry"],
+    )
+    mock_batch_modal["functions"][
+        ("policyengine-simulation-us1-500-0-uk2-66-0", "run_simulation")
+    ] = run_simulation
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(scheduler_module.time, "sleep", sleeps.append)
+
+    runner = scheduler_module.BudgetWindowBatchRunner(
+        context=scheduler_module.BudgetWindowBatchContext(
+            batch_job_id=mock_batch_modal["parent_call_id"],
+            request=request,
+            resolved_version="1.500.0",
+            resolved_app_name="policyengine-simulation-us1-500-0-uk2-66-0",
+            bundle=PolicyEngineBundle(model_version="1.500.0"),
+            raw_params=payload,
+        ),
+        poll_interval_seconds=0.5,
+        poll_interval_max_seconds=4.0,
+        poll_interval_backoff_factor=2.0,
+    )
+
+    runner.run()
+
+    # We expect 4 sleeps from the 4 TimeoutError probes: 0.5, 1.0, 2.0, 4.0.
+    assert sleeps == [0.5, 1.0, 2.0, 4.0]
+
+
 def test_run_budget_window_batch_impl_fails_on_malformed_child_result(
     mock_batch_modal,
 ):

--- a/projects/policyengine-api-simulation/tests/test_budget_window_batch.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_batch.py
@@ -277,13 +277,16 @@ def test_run_budget_window_batch_impl_marks_failure(mock_batch_modal):
 
     assert result["status"] == "failed"
     assert result["failed_years"] == ["2026"]
-    assert result["error"] == "child failed"
+    # Error body is redacted (#453); message must not leak the raw exception.
+    assert result["error"].startswith("Simulation failed")
+    assert "correlation_id=" in result["error"]
+    assert "child failed" not in result["error"]
     assert result["running_years"] == []
     assert result["child_jobs"]["2027"]["status"] == "cancelled"
-    assert result["child_jobs"]["2027"]["error"] == "child failed"
+    assert result["child_jobs"]["2027"]["error"].startswith("Simulation failed")
     assert state is not None
     assert state.status == "failed"
-    assert state.error == "child failed"
+    assert state.error.startswith("Simulation failed")
     assert state.running_years == []
     assert state.child_jobs["2027"].status == "cancelled"
 
@@ -378,10 +381,11 @@ def test_run_budget_window_batch_impl_fails_on_malformed_child_result(
 
     assert result["status"] == "failed"
     assert result["failed_years"] == ["2026"]
-    assert (
-        result["error"]
-        == "Malformed budget-window child result: missing numeric budget.tax_revenue_impact"
-    )
+    # The raw "Malformed ..." message is logged server-side but only a
+    # redacted correlated message reaches the caller (#453).
+    assert result["error"].startswith("Simulation failed")
+    assert "correlation_id=" in result["error"]
+    assert "Malformed" not in result["error"]
     assert state is not None
     assert state.status == "failed"
     assert state.child_jobs["2026"].status == "failed"

--- a/projects/policyengine-api-simulation/tests/test_budget_window_results.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_results.py
@@ -33,6 +33,35 @@ def test_extract_annual_impact_matches_v1_shape():
     )
 
 
+def test_extract_annual_impact_defaults_state_tax_for_uk_child_result():
+    """UK worker results omit ``state_tax_revenue_impact`` because the UK
+    microsimulation has no devolved fiscal layer. The aggregator should
+    accept these results and treat the state component as zero instead of
+    failing with "missing numeric budget.state_tax_revenue_impact"."""
+
+    annual = extract_annual_impact(
+        simulation_year="2026",
+        child_result={
+            "budget": {
+                # UK payload shape: tax_revenue_impact is the full HMRC total,
+                # state_tax_revenue_impact is absent.
+                "tax_revenue_impact": 250,
+                "benefit_spending_impact": 40,
+                "budgetary_impact": 210,
+            }
+        },
+    )
+
+    assert annual == BudgetWindowAnnualImpact(
+        year="2026",
+        taxRevenueImpact=250,
+        federalTaxRevenueImpact=250,
+        stateTaxRevenueImpact=0,
+        benefitSpendingImpact=40,
+        budgetaryImpact=210,
+    )
+
+
 def test_extract_annual_impact_rejects_malformed_child_result():
     with pytest.raises(
         ValueError,

--- a/projects/policyengine-api-simulation/tests/test_budget_window_results.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_results.py
@@ -50,6 +50,46 @@ def test_extract_annual_impact_rejects_malformed_child_result():
         )
 
 
+def test_sum_annual_impacts_avoids_binary_float_drift():
+    """0.1 + 0.2 + 0.3 = 0.6 exactly when accumulated in Decimal.
+
+    With float addition this sequence drifts by ~5e-17 which is enough to
+    break bit-exact deduplication on the client side. Accumulating in
+    :class:`decimal.Decimal` collapses the drift before the float downcast.
+    """
+    from src.modal.budget_window_results import sum_annual_impacts
+
+    totals = sum_annual_impacts(
+        [
+            BudgetWindowAnnualImpact(
+                year="2026",
+                taxRevenueImpact=0.1,
+                federalTaxRevenueImpact=0,
+                stateTaxRevenueImpact=0,
+                benefitSpendingImpact=0,
+                budgetaryImpact=0,
+            ),
+            BudgetWindowAnnualImpact(
+                year="2027",
+                taxRevenueImpact=0.2,
+                federalTaxRevenueImpact=0,
+                stateTaxRevenueImpact=0,
+                benefitSpendingImpact=0,
+                budgetaryImpact=0,
+            ),
+            BudgetWindowAnnualImpact(
+                year="2028",
+                taxRevenueImpact=0.3,
+                federalTaxRevenueImpact=0,
+                stateTaxRevenueImpact=0,
+                benefitSpendingImpact=0,
+                budgetaryImpact=0,
+            ),
+        ]
+    )
+    assert totals.taxRevenueImpact == 0.6
+
+
 def test_build_budget_window_result_sums_totals():
     annual_impacts = [
         BudgetWindowAnnualImpact(

--- a/projects/policyengine-api-simulation/tests/test_budget_window_scheduler.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_scheduler.py
@@ -1,4 +1,11 @@
-"""Semi-integration coverage for budget-window gateway and worker seams."""
+"""Unit coverage for the budget-window scheduler wiring.
+
+Despite the previous filename (``test_budget_window_semi_integration.py``),
+nothing in this file talks to a real Modal control plane: we monkey-patch
+the ``modal`` module with in-memory fakes and run the scheduler against
+those fakes. Renamed to reflect the actual scope (#457). Real Modal
+integration tests live under ``tests/integration/`` and are skipped by
+default."""
 
 from __future__ import annotations
 

--- a/projects/policyengine-api-simulation/tests/test_gcp_credentials.py
+++ b/projects/policyengine-api-simulation/tests/test_gcp_credentials.py
@@ -1,0 +1,77 @@
+"""Tests for GCP credentials setup in ``src.modal.simulation``."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from src.modal.simulation import (
+    _normalize_credentials_blob,
+    setup_gcp_credentials,
+)
+
+
+def test_setup_gcp_credentials_deletes_temp_file_on_exit(monkeypatch):
+    creds = json.dumps({"type": "service_account", "project_id": "p"})
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", creds)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    with setup_gcp_credentials():
+        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        assert path is not None
+        assert os.path.exists(path)
+        with open(path) as file:
+            assert json.loads(file.read())["project_id"] == "p"
+
+    # Temp file must be gone after the context exits, and the env var
+    # must be cleared so a retry doesn't chase a missing path.
+    assert not os.path.exists(path)
+    assert os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") is None
+
+
+def test_setup_gcp_credentials_cleans_up_on_exception(monkeypatch):
+    creds = json.dumps({"type": "service_account", "project_id": "q"})
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", creds)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    captured_path: list[str] = []
+    with pytest.raises(RuntimeError):
+        with setup_gcp_credentials():
+            captured_path.append(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
+            raise RuntimeError("boom")
+
+    assert captured_path
+    assert not os.path.exists(captured_path[0])
+
+
+def test_setup_gcp_credentials_preserves_existing_env(monkeypatch, tmp_path):
+    existing = tmp_path / "existing.json"
+    existing.write_text("{}")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(existing))
+
+    with setup_gcp_credentials():
+        assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(existing)
+
+    # Pre-existing var should not be disturbed.
+    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(existing)
+
+
+def test_normalize_credentials_blob_accepts_plain_json():
+    payload = '{"a": 1}'
+    assert _normalize_credentials_blob(payload) == payload
+
+
+def test_normalize_credentials_blob_unwraps_double_escaped():
+    inner = '{"a": 1}'
+    wrapped = '"' + inner.replace('"', '\\"') + '"'
+    # ``_normalize_credentials_blob`` expects the outer quotes to be absent
+    # from the raw env var value; they're added by ``json.loads`` in tests.
+    result = _normalize_credentials_blob(wrapped[1:-1])
+    assert result == inner
+
+
+def test_normalize_credentials_blob_reraises_on_unparseable():
+    with pytest.raises(json.JSONDecodeError):
+        _normalize_credentials_blob("not even close to json")

--- a/projects/policyengine-api-simulation/tests/test_update_version_registry.py
+++ b/projects/policyengine-api-simulation/tests/test_update_version_registry.py
@@ -1,0 +1,136 @@
+"""Tests for the Modal version-registry updater."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modal.utils import update_version_registry as registry
+
+
+class FakeDict:
+    def __init__(self, initial: dict | None = None):
+        self._data = dict(initial or {})
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def snapshot(self) -> dict:
+        return dict(self._data)
+
+
+@pytest.fixture
+def patched_modal(monkeypatch):
+    stores: dict[str, FakeDict] = {}
+
+    class _Dict:
+        @staticmethod
+        def from_name(name: str, environment_name: str, create_if_missing: bool):
+            key = f"{environment_name}/{name}"
+            if key not in stores:
+                stores[key] = FakeDict()
+            return stores[key]
+
+    class _Modal:
+        Dict = _Dict
+
+    monkeypatch.setattr(registry, "modal", _Modal)
+    return stores
+
+
+def test__is_newer_version__advances_on_higher_minor():
+    assert registry._is_newer_version("1.501.0", "1.500.0") is True
+
+
+def test__is_newer_version__does_not_advance_on_lower_minor():
+    assert registry._is_newer_version("1.499.0", "1.500.0") is False
+
+
+def test__is_newer_version__advances_when_current_missing():
+    assert registry._is_newer_version("1.500.0", None) is True
+
+
+def test__is_newer_version__does_not_advance_on_equal():
+    assert registry._is_newer_version("1.500.0", "1.500.0") is False
+
+
+def test_update_version_dict__keeps_latest_when_incoming_older(patched_modal):
+    stores = patched_modal
+    stores["main/simulation-api-us-versions"] = FakeDict(
+        {
+            "latest": "1.500.0",
+            "1.500.0": "policyengine-simulation-us1-500-0-uk2-66-0",
+        }
+    )
+
+    registry.update_version_dict(
+        "simulation-api-us-versions",
+        "main",
+        "1.400.0",
+        "policyengine-simulation-us1-400-0-uk2-66-0",
+    )
+
+    snapshot = stores["main/simulation-api-us-versions"].snapshot()
+    assert snapshot["latest"] == "1.500.0"
+    assert snapshot["1.400.0"] == "policyengine-simulation-us1-400-0-uk2-66-0"
+
+
+def test_update_version_dict__advances_latest_when_incoming_newer(patched_modal):
+    stores = patched_modal
+    stores["main/simulation-api-us-versions"] = FakeDict(
+        {
+            "latest": "1.500.0",
+            "1.500.0": "policyengine-simulation-us1-500-0-uk2-66-0",
+        }
+    )
+
+    registry.update_version_dict(
+        "simulation-api-us-versions",
+        "main",
+        "1.601.2",
+        "policyengine-simulation-us1-601-2-uk2-70-0",
+    )
+
+    snapshot = stores["main/simulation-api-us-versions"].snapshot()
+    assert snapshot["latest"] == "1.601.2"
+
+
+def test_update_version_dict__force_latest_allows_downgrade(patched_modal):
+    stores = patched_modal
+    stores["main/simulation-api-us-versions"] = FakeDict(
+        {
+            "latest": "1.500.0",
+            "1.500.0": "policyengine-simulation-us1-500-0-uk2-66-0",
+        }
+    )
+
+    registry.update_version_dict(
+        "simulation-api-us-versions",
+        "main",
+        "1.400.0",
+        "policyengine-simulation-us1-400-0-uk2-66-0",
+        force_latest=True,
+    )
+
+    snapshot = stores["main/simulation-api-us-versions"].snapshot()
+    assert snapshot["latest"] == "1.400.0"
+
+
+def test_update_version_dict__new_registry_sets_latest_even_without_force(
+    patched_modal,
+):
+    registry.update_version_dict(
+        "simulation-api-uk-versions",
+        "staging",
+        "2.66.0",
+        "policyengine-simulation-us1-500-0-uk2-66-0",
+    )
+
+    snapshot = patched_modal["staging/simulation-api-uk-versions"].snapshot()
+    assert snapshot["latest"] == "2.66.0"
+    assert snapshot["2.66.0"] == "policyengine-simulation-us1-500-0-uk2-66-0"


### PR DESCRIPTION
## Summary

Batch fix for 12 audit findings in `projects/policyengine-api-simulation/`. Each commit maps to exactly one GitHub issue and contains the fix plus its test coverage. Covers authentication, correctness, error redaction, request validation, observability hygiene, and a test-layout cleanup.

Test suite: **154 passed, 1 deselected** (the new integration skeleton opts out by default via the new `integration` marker).

## Per-issue summary

### Gate gateway write and job-status endpoints behind auth — Fixes #446
- New `src/modal/gateway/auth.py` exposes a `require_auth` FastAPI dependency wrapping the shared `JWTDecoder`.
- Configured via `GATEWAY_AUTH_ISSUER` / `GATEWAY_AUTH_AUDIENCE`; `GATEWAY_AUTH_DISABLED=1` bypasses for local/tests.
- `POST /simulate/economy/comparison`, `POST /simulate/economy/budget-window`, `GET /jobs/{id}`, `GET /budget-window-jobs/{id}` now require a bearer JWT. `/health`, `/ping`, `/versions`, `/versions/{country}` remain public (routing/health only).
- Missing-token paths return 403; misconfiguration returns 503 so operators see failures instead of a silent bypass.
- New `tests/gateway/test_auth.py` asserts 403 on every gated endpoint without a token; existing tests use `app.dependency_overrides` to skip the dependency.
- Gateway image now pip-installs `pyjwt` + `cryptography` and copies the `policyengine_fastapi` source so `JWTDecoder` is available in the ASGI container.

### Guard version registry latest pointer against downgrade — Fixes #447
- `update_version_dict` compares the incoming package version to the current `latest` via `packaging.version.Version`.
- Added `--force-latest` CLI flag for intentional rollbacks.
- New `tests/test_update_version_registry.py` covers advance/no-advance/force-override/new-registry flows.

### Persist budget-window failure state across polls — Fixes #448
- `GET /budget-window-jobs/{id}` now calls `put_batch_job_state` + `put_batch_job_seed` after mutating the seed to `failed`, so the second poll doesn't flip back to `submitted`.
- New endpoint test arms the mocked Modal `FunctionCall` to raise and asserts both polls observe `failed`.

### Back off scheduler poll interval exponentially — Fixes #449
- Introduced `POLL_INTERVAL_INITIAL_SECONDS=0.5`, `POLL_INTERVAL_MAX_SECONDS=30.0`, `POLL_INTERVAL_BACKOFF_FACTOR=2.0`.
- `BudgetWindowBatchRunner.run` doubles its sleep when no child resolves and resets on progress.
- Commit message explains the tradeoff vs. blocking `FunctionCall.get(timeout=...)` — staying on polling keeps the cancel-on-failure path simple.
- New test verifies the observed sleeps are `[0.5, 1.0, 2.0, 4.0]` on four consecutive timeouts.

### Forbid unknown gateway request fields and cap payload size — Fixes #450
- `GatewayRequestBase` switches to `extra="forbid"` and declares every documented SimulationOptions pass-through (`scope`, `data`, `time_period`, `reform`, `baseline`, `region`, `subsample`, `title`, `include_cliffs`, `model_version`, `data_version`).
- Internal enrichment fields (`_metadata`, `_telemetry`, `version`) are stripped/aliased before strict validation so gateway → worker round-trips keep working.
- Added `MAX_GATEWAY_REQUEST_BYTES=262144` enforced via a `before` validator; oversized payloads raise 422 before Pydantic allocates per-field proxies.
- Updated `tests/gateway/test_models.py` to assert unknown-field rejection, size-cap rejection, and documented-field acceptance.

### Accumulate budget-window totals in Decimal — Fixes #451
- `sum_annual_impacts` accumulates in `Decimal`, converts to `float` only at the `BudgetWindowTotals` boundary.
- JSON schema is unchanged (clients still receive numeric fields).
- New test asserts `0.1 + 0.2 + 0.3 == 0.6` exactly, regression-guarding against binary-float drift.

### Make state_tax_revenue_impact optional for UK results — Fixes #452
- `state_tax_revenue_impact` moved from `REQUIRED_BUDGET_KEYS` to `OPTIONAL_BUDGET_KEYS`, defaulting to 0.0 when absent.
- New test `test_extract_annual_impact_defaults_state_tax_for_uk_child_result` exercises the UK-shape child payload.

### Redact exception details from gateway error responses — Fixes #453
- New `src/modal/gateway/errors.py::log_and_redact_exception`:
  - Logs the full exception via `logfire.exception(...)` (falls back to stdlib logger when Logfire isn't configured).
  - Returns a caller-safe `"Simulation failed (correlation_id=<hex>)"` string.
- `get_job_status`, `get_budget_window_job_status`, and the scheduler's child-failure paths route errors through the redactor.
- New `tests/gateway/test_errors.py` asserts correlation id propagation and that signed-URL / raw-exception content never leaks through.

### Guard budget-window child state transitions from missing entries — Fixes #454
- New `_existing_child_or_sentinel` helper synthesises a `BatchChildJobStatus` when `state.child_jobs[year]` is missing, logs a WARNING, and continues.
- Applied in both `mark_child_completed` and `mark_child_failed`.
- Two new regression tests in `tests/gateway/test_budget_window_state.py`.

### Redact Logfire span payloads for simulation functions — Fixes #455
- New `src/modal/logging_redaction.py::redact_params_for_logging` strips `data`, `reform`, `baseline`, `_telemetry`, `_metadata`; surfaces only `run_id` from telemetry.
- `run_simulation` and `run_budget_window_batch` no longer pass full `params` or `output_result` to spans; they splat the redacted dict and do not set `output_result` at all.
- New `tests/test_app_redaction.py` covers signed-URL stripping, non-dict inputs, and pass-through of safe fields.

### Clean up GCP credential temp file after use — Fixes #456
- `setup_gcp_credentials` is now a `@contextlib.contextmanager` that writes credentials to a `NamedTemporaryFile(delete=True)` and clears `GOOGLE_APPLICATION_CREDENTIALS` on exit (restoring any prior value).
- `_normalize_credentials_blob` only unwraps the double-escape path when the input actually looks wrapped.
- New `tests/test_gcp_credentials.py` verifies cleanup on normal exit, exception exit, pre-existing env preservation, and both unescape paths.

### Rename scheduler test and scaffold real-Modal integration bucket — Fixes #457
- Renamed `tests/test_budget_window_semi_integration.py` → `tests/test_budget_window_scheduler.py` with an updated docstring explaining the actual scope (unit-level fake-Modal).
- New `tests/integration/` bucket with a skeleton `@pytest.mark.integration` smoke test that skips unless `POLICYENGINE_MODAL_INTEGRATION_BASE_URL` is set.
- `pyproject.toml` registers the marker and defaults to `-m 'not integration'` so the main test run stays hermetic.

## Test plan

- [x] `uv run pytest tests/` inside `projects/policyengine-api-simulation/` — 154 passed, 1 deselected
- [x] `uv run ruff format .` clean
- [x] `uv run ruff check src/modal tests fixtures` passes
- [ ] CI green on GitHub
- [ ] `gh pr view --json mergeable` reports `MERGEABLE`
