### PR TITLE
Raise budget-window batch max_parallel to 20

### DIFF
--- a/projects/policyengine-api-simulation/src/modal/gateway/models.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/models.py
@@ -162,7 +162,7 @@ class BudgetWindowBatchRequest(GatewayRequestBase):
 
     MAX_YEARS: ClassVar[int] = 75
     MAX_END_YEAR: ClassVar[int] = 2099
-    MAX_PARALLEL: ClassVar[int] = 3
+    MAX_PARALLEL: ClassVar[int] = 20
 
     region: str
     start_year: str

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -672,7 +672,7 @@ class TestBudgetWindowBatchEndpoints:
                 "reform": {},
                 "start_year": "2026",
                 "window_size": 3,
-                "max_parallel": 4,
+                "max_parallel": 21,
             },
         )
 

--- a/projects/policyengine-api-simulation/tests/gateway/test_models.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_models.py
@@ -459,7 +459,7 @@ class TestBudgetWindowBatchRequest:
                 region="us",
                 start_year="2026",
                 window_size=3,
-                max_parallel=4,
+                max_parallel=21,
             )
 
     def test_budget_window_batch_request_accepts_extra_simulation_fields(self):


### PR DESCRIPTION
Fixes #459

## Summary
- raise the budget-window batch request cap from 3 to 20
- keep the change isolated to the contract and validation tests
- leave polling/scheduler behavior unchanged in this PR

## Testing
- uv run ruff format projects/policyengine-api-simulation/src/modal/gateway/models.py projects/policyengine-api-simulation/tests/gateway/test_models.py projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
- uv run ruff check projects/policyengine-api-simulation/src/modal/gateway/models.py projects/policyengine-api-simulation/tests/gateway/test_models.py projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
- uv run --project projects/policyengine-api-simulation --extra test pytest projects/policyengine-api-simulation/tests/gateway/test_models.py projects/policyengine-api-simulation/tests/gateway/test_endpoints.py