### PR TITLE
Wire gateway-auth secret and M2M token into integ tests

### DIFF
--- a/.github/scripts/modal-run-integ-tests.sh
+++ b/.github/scripts/modal-run-integ-tests.sh
@@ -23,22 +23,43 @@ US_VERSION="${3:-}"
 ISSUER="${GATEWAY_AUTH_ISSUER%/}"
 TOKEN_URL="$ISSUER/oauth/token"
 
-echo "Requesting client_credentials access token from $TOKEN_URL"
-TOKEN_RESPONSE=$(
-  curl --fail --silent --show-error \
-    --request POST "$TOKEN_URL" \
-    --header "content-type: application/json" \
-    --data @- <<JSON
-{
-  "client_id": "$GATEWAY_AUTH_CLIENT_ID",
-  "client_secret": "$GATEWAY_AUTH_CLIENT_SECRET",
-  "audience": "$GATEWAY_AUTH_AUDIENCE",
-  "grant_type": "client_credentials"
-}
-JSON
+# Build the token-request JSON with Python so that any ", \, or newline in
+# the client secret is encoded correctly (Auth0-generated secrets are
+# random strings that routinely contain characters that break a shell
+# heredoc).
+TOKEN_REQUEST_JSON=$(
+  CLIENT_ID="$GATEWAY_AUTH_CLIENT_ID" \
+  CLIENT_SECRET="$GATEWAY_AUTH_CLIENT_SECRET" \
+  AUDIENCE="$GATEWAY_AUTH_AUDIENCE" \
+  python3 -c '
+import json, os
+print(json.dumps({
+    "client_id": os.environ["CLIENT_ID"],
+    "client_secret": os.environ["CLIENT_SECRET"],
+    "audience": os.environ["AUDIENCE"],
+    "grant_type": "client_credentials",
+}))
+'
 )
 
-ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])')
+echo "Requesting client_credentials access token from $TOKEN_URL"
+TOKEN_RESPONSE=$(
+  curl --fail-with-body --silent --show-error \
+    --request POST "$TOKEN_URL" \
+    --header "content-type: application/json" \
+    --data-binary "$TOKEN_REQUEST_JSON"
+)
+
+ACCESS_TOKEN=$(
+  printf '%s' "$TOKEN_RESPONSE" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+token = data.get("access_token")
+if not token:
+    sys.exit(f"Auth0 response missing access_token: {data}")
+print(token)
+'
+)
 if [ -z "$ACCESS_TOKEN" ]; then
   echo "Failed to extract access_token from Auth0 response" >&2
   exit 1

--- a/.github/scripts/modal-run-integ-tests.sh
+++ b/.github/scripts/modal-run-integ-tests.sh
@@ -2,6 +2,12 @@
 # Run simulation integration tests
 # Usage: ./modal-run-integ-tests.sh <environment> <base-url> [us-version]
 # Environment: beta runs all tests, prod excludes beta_only tests
+#
+# Required env vars (set in the calling workflow from org-wide GH secrets):
+#   GATEWAY_AUTH_ISSUER, GATEWAY_AUTH_AUDIENCE,
+#   GATEWAY_AUTH_CLIENT_ID, GATEWAY_AUTH_CLIENT_SECRET
+# Used to fetch an Auth0 client_credentials token that the pytest client
+# sends as Authorization: Bearer on every call to the gated gateway.
 
 set -euo pipefail
 
@@ -9,10 +15,40 @@ ENVIRONMENT="${1:?Environment required (beta or prod)}"
 BASE_URL="${2:?Base URL required}"
 US_VERSION="${3:-}"
 
+: "${GATEWAY_AUTH_ISSUER:?GATEWAY_AUTH_ISSUER is required to mint an integ-test token}"
+: "${GATEWAY_AUTH_AUDIENCE:?GATEWAY_AUTH_AUDIENCE is required to mint an integ-test token}"
+: "${GATEWAY_AUTH_CLIENT_ID:?GATEWAY_AUTH_CLIENT_ID is required to mint an integ-test token}"
+: "${GATEWAY_AUTH_CLIENT_SECRET:?GATEWAY_AUTH_CLIENT_SECRET is required to mint an integ-test token}"
+
+ISSUER="${GATEWAY_AUTH_ISSUER%/}"
+TOKEN_URL="$ISSUER/oauth/token"
+
+echo "Requesting client_credentials access token from $TOKEN_URL"
+TOKEN_RESPONSE=$(
+  curl --fail --silent --show-error \
+    --request POST "$TOKEN_URL" \
+    --header "content-type: application/json" \
+    --data @- <<JSON
+{
+  "client_id": "$GATEWAY_AUTH_CLIENT_ID",
+  "client_secret": "$GATEWAY_AUTH_CLIENT_SECRET",
+  "audience": "$GATEWAY_AUTH_AUDIENCE",
+  "grant_type": "client_credentials"
+}
+JSON
+)
+
+ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])')
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo "Failed to extract access_token from Auth0 response" >&2
+  exit 1
+fi
+
 cd projects/policyengine-apis-integ
 uv sync --extra test
 
 export simulation_integ_test_base_url="$BASE_URL"
+export simulation_integ_test_access_token="$ACCESS_TOKEN"
 
 if [ -n "$US_VERSION" ]; then
   export simulation_integ_test_us_model_version="$US_VERSION"

--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -28,17 +28,52 @@ fi
 # Sync gateway auth secret. The gateway container consumes issuer+audience to
 # validate bearer tokens; client_id/secret are stored alongside so rotating the
 # Auth0 M2M app updates every consumer from one place.
-if [ -n "${GATEWAY_AUTH_ISSUER:-}" ] \
-  && [ -n "${GATEWAY_AUTH_AUDIENCE:-}" ] \
-  && [ -n "${GATEWAY_AUTH_CLIENT_ID:-}" ] \
-  && [ -n "${GATEWAY_AUTH_CLIENT_SECRET:-}" ]; then
+#
+# Fail loud if some but not all of the four GH secrets are present — a
+# partial config would silently leave the Modal secret stale or missing,
+# which surfaces as 503s from /require_auth on every gated request.
+GATEWAY_AUTH_VARS=(
+  GATEWAY_AUTH_ISSUER
+  GATEWAY_AUTH_AUDIENCE
+  GATEWAY_AUTH_CLIENT_ID
+  GATEWAY_AUTH_CLIENT_SECRET
+)
+present=()
+missing=()
+for var in "${GATEWAY_AUTH_VARS[@]}"; do
+  if [ -n "${!var:-}" ]; then
+    present+=("$var")
+  else
+    missing+=("$var")
+  fi
+done
+
+if [ ${#present[@]} -gt 0 ] && [ ${#missing[@]} -gt 0 ]; then
+  echo "Partial GATEWAY_AUTH_* GitHub secrets detected." >&2
+  echo "  Present: ${present[*]}" >&2
+  echo "  Missing: ${missing[*]}" >&2
+  echo "Refusing to write a partial gateway-auth Modal secret." >&2
+  exit 1
+fi
+
+if [ ${#present[@]} -eq ${#GATEWAY_AUTH_VARS[@]} ]; then
+  # Auth0 issuer strings are expected to end with "/" to match the `iss`
+  # claim and JWKS-url construction on the verifier side. Normalize here
+  # so an operator who stored the GH secret without the trailing slash
+  # doesn't silently break JWT validation on every gated call.
+  NORMALIZED_ISSUER="$GATEWAY_AUTH_ISSUER"
+  case "$NORMALIZED_ISSUER" in
+    */) ;;
+    *) NORMALIZED_ISSUER="$NORMALIZED_ISSUER/" ;;
+  esac
+
   uv run modal secret create gateway-auth \
-    "GATEWAY_AUTH_ISSUER=$GATEWAY_AUTH_ISSUER" \
+    "GATEWAY_AUTH_ISSUER=$NORMALIZED_ISSUER" \
     "GATEWAY_AUTH_AUDIENCE=$GATEWAY_AUTH_AUDIENCE" \
     "GATEWAY_AUTH_CLIENT_ID=$GATEWAY_AUTH_CLIENT_ID" \
     "GATEWAY_AUTH_CLIENT_SECRET=$GATEWAY_AUTH_CLIENT_SECRET" \
     --env="$MODAL_ENV" \
-    --force || true
+    --force
 fi
 
 echo "Modal secrets synced"

--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -25,4 +25,20 @@ if [ -n "${GCP_CREDENTIALS_JSON:-}" ]; then
     --force || true
 fi
 
+# Sync gateway auth secret. The gateway container consumes issuer+audience to
+# validate bearer tokens; client_id/secret are stored alongside so rotating the
+# Auth0 M2M app updates every consumer from one place.
+if [ -n "${GATEWAY_AUTH_ISSUER:-}" ] \
+  && [ -n "${GATEWAY_AUTH_AUDIENCE:-}" ] \
+  && [ -n "${GATEWAY_AUTH_CLIENT_ID:-}" ] \
+  && [ -n "${GATEWAY_AUTH_CLIENT_SECRET:-}" ]; then
+  uv run modal secret create gateway-auth \
+    "GATEWAY_AUTH_ISSUER=$GATEWAY_AUTH_ISSUER" \
+    "GATEWAY_AUTH_AUDIENCE=$GATEWAY_AUTH_AUDIENCE" \
+    "GATEWAY_AUTH_CLIENT_ID=$GATEWAY_AUTH_CLIENT_ID" \
+    "GATEWAY_AUTH_CLIENT_SECRET=$GATEWAY_AUTH_CLIENT_SECRET" \
+    --env="$MODAL_ENV" \
+    --force || true
+fi
+
 echo "Modal secrets synced"

--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -10,28 +10,10 @@ GH_ENV="${2:?GitHub environment required}"
 
 echo "Syncing secrets to Modal environment: $MODAL_ENV"
 
-# Sync Logfire secret
-uv run modal secret create policyengine-logfire \
-  "LOGFIRE_TOKEN=${LOGFIRE_TOKEN:-}" \
-  "LOGFIRE_ENVIRONMENT=$GH_ENV" \
-  --env="$MODAL_ENV" \
-  --force || true
-
-# Sync GCP credentials if provided
-if [ -n "${GCP_CREDENTIALS_JSON:-}" ]; then
-  uv run modal secret create gcp-credentials \
-    "GOOGLE_APPLICATION_CREDENTIALS_JSON=$GCP_CREDENTIALS_JSON" \
-    --env="$MODAL_ENV" \
-    --force || true
-fi
-
-# Sync gateway auth secret. The gateway container consumes issuer+audience to
-# validate bearer tokens; client_id/secret are stored alongside so rotating the
-# Auth0 M2M app updates every consumer from one place.
-#
-# Fail loud if some but not all of the four GH secrets are present — a
-# partial config would silently leave the Modal secret stale or missing,
-# which surfaces as 503s from /require_auth on every gated request.
+# Validate gateway auth config before touching any Modal secret state. We need
+# all four values in CI because the deploy job syncs the gateway runtime config
+# from GitHub and the integration job mints an Auth0 M2M token from the same
+# GitHub secret set.
 GATEWAY_AUTH_VARS=(
   GATEWAY_AUTH_ISSUER
   GATEWAY_AUTH_AUDIENCE
@@ -48,32 +30,47 @@ for var in "${GATEWAY_AUTH_VARS[@]}"; do
   fi
 done
 
-if [ ${#present[@]} -gt 0 ] && [ ${#missing[@]} -gt 0 ]; then
-  echo "Partial GATEWAY_AUTH_* GitHub secrets detected." >&2
-  echo "  Present: ${present[*]}" >&2
-  echo "  Missing: ${missing[*]}" >&2
-  echo "Refusing to write a partial gateway-auth Modal secret." >&2
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "Missing required GATEWAY_AUTH_* GitHub secrets." >&2
+  echo "  Present: ${present[*]-}" >&2
+  echo "  Missing: ${missing[*]-}" >&2
+  echo "Refusing to deploy because auth config would drift from GitHub state." >&2
   exit 1
 fi
 
-if [ ${#present[@]} -eq ${#GATEWAY_AUTH_VARS[@]} ]; then
-  # Auth0 issuer strings are expected to end with "/" to match the `iss`
-  # claim and JWKS-url construction on the verifier side. Normalize here
-  # so an operator who stored the GH secret without the trailing slash
-  # doesn't silently break JWT validation on every gated call.
-  NORMALIZED_ISSUER="$GATEWAY_AUTH_ISSUER"
-  case "$NORMALIZED_ISSUER" in
-    */) ;;
-    *) NORMALIZED_ISSUER="$NORMALIZED_ISSUER/" ;;
-  esac
+# Sync Logfire secret
+uv run modal secret create policyengine-logfire \
+  "LOGFIRE_TOKEN=${LOGFIRE_TOKEN:-}" \
+  "LOGFIRE_ENVIRONMENT=$GH_ENV" \
+  --env="$MODAL_ENV" \
+  --force || true
 
-  uv run modal secret create gateway-auth \
-    "GATEWAY_AUTH_ISSUER=$NORMALIZED_ISSUER" \
-    "GATEWAY_AUTH_AUDIENCE=$GATEWAY_AUTH_AUDIENCE" \
-    "GATEWAY_AUTH_CLIENT_ID=$GATEWAY_AUTH_CLIENT_ID" \
-    "GATEWAY_AUTH_CLIENT_SECRET=$GATEWAY_AUTH_CLIENT_SECRET" \
+# Sync GCP credentials if provided
+if [ -n "${GCP_CREDENTIALS_JSON:-}" ]; then
+  uv run modal secret create gcp-credentials \
+    "GOOGLE_APPLICATION_CREDENTIALS_JSON=$GCP_CREDENTIALS_JSON" \
     --env="$MODAL_ENV" \
-    --force
+    --force || true
 fi
+
+# Sync gateway auth secret. The gateway runtime only needs issuer+audience to
+# validate tokens; CI callers keep the M2M client credentials on the GitHub
+# side and mint tokens there.
+#
+# Auth0 issuer strings are expected to end with "/" to match the `iss`
+# claim and JWKS-url construction on the verifier side. Normalize here
+# so an operator who stored the GH secret without the trailing slash
+# doesn't silently break JWT validation on every gated call.
+NORMALIZED_ISSUER="$GATEWAY_AUTH_ISSUER"
+case "$NORMALIZED_ISSUER" in
+  */) ;;
+  *) NORMALIZED_ISSUER="$NORMALIZED_ISSUER/" ;;
+esac
+
+uv run modal secret create gateway-auth \
+  "GATEWAY_AUTH_ISSUER=$NORMALIZED_ISSUER" \
+  "GATEWAY_AUTH_AUDIENCE=$GATEWAY_AUTH_AUDIENCE" \
+  --env="$MODAL_ENV" \
+  --force
 
 echo "Modal secrets synced"

--- a/.github/workflows/modal-deploy.reusable.yml
+++ b/.github/workflows/modal-deploy.reusable.yml
@@ -55,6 +55,10 @@ jobs:
         MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
         GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
+        GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
+        GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
+        GATEWAY_AUTH_CLIENT_ID: ${{ secrets.GATEWAY_AUTH_CLIENT_ID }}
+        GATEWAY_AUTH_CLIENT_SECRET: ${{ secrets.GATEWAY_AUTH_CLIENT_SECRET }}
       run: ../../.github/scripts/modal-sync-secrets.sh "${{ inputs.modal_environment }}" "${{ inputs.environment }}"
 
     - name: Deploy simulation API to Modal
@@ -102,4 +106,9 @@ jobs:
       run: ./scripts/generate-clients.sh
 
     - name: Run simulation integration tests
+      env:
+        GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
+        GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
+        GATEWAY_AUTH_CLIENT_ID: ${{ secrets.GATEWAY_AUTH_CLIENT_ID }}
+        GATEWAY_AUTH_CLIENT_SECRET: ${{ secrets.GATEWAY_AUTH_CLIENT_SECRET }}
       run: .github/scripts/modal-run-integ-tests.sh "${{ inputs.environment }}" "${{ needs.deploy.outputs.simulation_api_url }}" "${{ needs.deploy.outputs.us_version }}"

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -13,10 +13,8 @@ import modal
 # Stable app name - this should rarely change
 app = modal.App("policyengine-simulation-gateway")
 
-# Injects GATEWAY_AUTH_ISSUER, GATEWAY_AUTH_AUDIENCE, GATEWAY_AUTH_CLIENT_ID,
-# and GATEWAY_AUTH_CLIENT_SECRET. Only the issuer and audience are consumed
-# by this container (see gateway.auth); the client id/secret are kept in the
-# same secret so a single rotation updates every consumer at once.
+# Injects only the gateway validation config the public-facing container
+# actually needs.
 gateway_auth_secret = modal.Secret.from_name("gateway-auth")
 
 # Lightweight image for gateway - no heavy dependencies

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -50,15 +50,21 @@ def web_app():
     """
     from fastapi import FastAPI
 
-    from src.modal.gateway.auth import enforce_production_auth_guard
+    from src.modal.gateway.auth import (
+        enforce_auth_configured_guard,
+        enforce_production_auth_guard,
+    )
     from src.modal.gateway.endpoints import router
 
-    # Startup guard: crash the container if GATEWAY_AUTH_DISABLED is set in
-    # a production-equivalent Modal environment, or set without the
-    # explicit acknowledgement env var. This prevents the bypass from
-    # accidentally shipping to prod if a dev deploy grabs the wrong secret
-    # bundle. See gateway.auth.enforce_production_auth_guard for the rules.
+    # Startup guards:
+    # 1. Crash if GATEWAY_AUTH_DISABLED is set in a production-equivalent
+    #    Modal env, or set without the explicit acknowledgement — prevents
+    #    the bypass from accidentally shipping to prod.
+    # 2. Crash if auth is enabled but issuer/audience aren't configured —
+    #    prevents a silently broken gateway that returns 503 on every
+    #    gated request.
     enforce_production_auth_guard()
+    enforce_auth_configured_guard()
 
     api = FastAPI(
         title="PolicyEngine Simulation Gateway",

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -13,6 +13,12 @@ import modal
 # Stable app name - this should rarely change
 app = modal.App("policyengine-simulation-gateway")
 
+# Injects GATEWAY_AUTH_ISSUER, GATEWAY_AUTH_AUDIENCE, GATEWAY_AUTH_CLIENT_ID,
+# and GATEWAY_AUTH_CLIENT_SECRET. Only the issuer and audience are consumed
+# by this container (see gateway.auth); the client id/secret are kept in the
+# same secret so a single rotation updates every consumer at once.
+gateway_auth_secret = modal.Secret.from_name("gateway-auth")
+
 # Lightweight image for gateway - no heavy dependencies
 gateway_image = (
     modal.Image.debian_slim(python_version="3.13")
@@ -30,7 +36,7 @@ gateway_image = (
 )
 
 
-@app.function(image=gateway_image)
+@app.function(image=gateway_image, secrets=[gateway_auth_secret])
 @modal.asgi_app()
 def web_app():
     """

--- a/projects/policyengine-api-simulation/src/modal/gateway/auth.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/auth.py
@@ -92,6 +92,13 @@ def _get_decoder() -> JWTDecoder:
             f"{GATEWAY_AUTH_ISSUER_ENV} and {GATEWAY_AUTH_AUDIENCE_ENV} or "
             f"{GATEWAY_AUTH_DISABLED_ENV}=1 for local/test use."
         )
+    # The verifier expects issuer to end with "/" so that Auth0's `iss`
+    # claim matches and the JWKS URL is constructed correctly. Operators
+    # storing the secret without the trailing slash would otherwise see
+    # every gated request fail with an opaque JWKS-fetch or iss-mismatch
+    # error.
+    if not issuer.endswith("/"):
+        issuer = issuer + "/"
     return _build_decoder(issuer, audience)
 
 
@@ -167,6 +174,34 @@ def enforce_production_auth_guard() -> None:
         )
     except Exception:  # pragma: no cover - logfire optional / misconfigured
         pass
+
+
+class AuthMisconfiguredError(RuntimeError):
+    """Refuse to start when the issuer/audience env vars are missing in prod."""
+
+
+def enforce_auth_configured_guard() -> None:
+    """Crash the ASGI factory if auth is enabled but misconfigured.
+
+    Without this, a missing ``GATEWAY_AUTH_ISSUER`` / ``GATEWAY_AUTH_AUDIENCE``
+    (e.g. the ``gateway-auth`` Modal secret failed to attach, or a GH secret
+    is misspelled) surfaces only as 503s at request time from
+    :func:`require_auth`. Fail fast at container boot so Modal's deploy
+    reports the misconfiguration instead of a silently broken gateway.
+    """
+    if _auth_disabled():
+        return
+
+    issuer = os.environ.get(GATEWAY_AUTH_ISSUER_ENV)
+    audience = os.environ.get(GATEWAY_AUTH_AUDIENCE_ENV)
+    if not issuer or not audience:
+        raise AuthMisconfiguredError(
+            "Gateway auth is enabled but "
+            f"{GATEWAY_AUTH_ISSUER_ENV}/{GATEWAY_AUTH_AUDIENCE_ENV} are not set "
+            "in the container environment. Verify the 'gateway-auth' Modal "
+            "secret is attached and synced from the GATEWAY_AUTH_* GitHub "
+            "Actions secrets."
+        )
 
 
 def require_auth(

--- a/projects/policyengine-api-simulation/tests/gateway/test_auth.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_auth.py
@@ -268,3 +268,92 @@ class TestProductionAuthGuard:
         assert any(
             "GATEWAY AUTH IS DISABLED" in record.message for record in caplog.records
         ), f"Expected critical auth-disabled banner, got {caplog.records!r}"
+
+
+class TestAuthConfiguredGuard:
+    """``enforce_auth_configured_guard`` crashes the ASGI factory at boot
+    when auth is enabled but issuer/audience env vars are missing."""
+
+    def test__given_auth_disabled__then_guard_noops(self, monkeypatch):
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+        auth_module.enforce_auth_configured_guard()
+
+    def test__given_issuer_missing__then_raises(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, raising=False)
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+
+        with pytest.raises(auth_module.AuthMisconfiguredError):
+            auth_module.enforce_auth_configured_guard()
+
+    def test__given_audience_missing__then_raises(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://tenant.auth0.com/"
+        )
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+        with pytest.raises(auth_module.AuthMisconfiguredError):
+            auth_module.enforce_auth_configured_guard()
+
+    def test__given_both_set__then_noops(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://tenant.auth0.com/"
+        )
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+
+        auth_module.enforce_auth_configured_guard()
+
+
+class TestIssuerNormalization:
+    """``_get_decoder`` appends a trailing "/" to issuer values that lack
+    one, so Auth0's ``iss`` claim and JWKS URL construction line up."""
+
+    def test__given_issuer_without_trailing_slash__then_decoder_receives_slash(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://tenant.auth0.com"
+        )
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+        auth_module.reset_decoder_cache()
+
+        captured = {}
+
+        def fake_builder(issuer, audience):
+            captured["issuer"] = issuer
+            captured["audience"] = audience
+            return object()
+
+        monkeypatch.setattr(auth_module, "_build_decoder", fake_builder)
+
+        auth_module._get_decoder()
+
+        assert captured["issuer"] == "https://tenant.auth0.com/"
+        assert captured["audience"] == "aud"
+
+    def test__given_issuer_with_trailing_slash__then_decoder_receives_unchanged(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(
+            auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://tenant.auth0.com/"
+        )
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+        auth_module.reset_decoder_cache()
+
+        captured = {}
+
+        def fake_builder(issuer, audience):
+            captured["issuer"] = issuer
+            captured["audience"] = audience
+            return object()
+
+        monkeypatch.setattr(auth_module, "_build_decoder", fake_builder)
+
+        auth_module._get_decoder()
+
+        assert captured["issuer"] == "https://tenant.auth0.com/"

--- a/projects/policyengine-api-simulation/tests/test_modal_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_scripts.py
@@ -206,6 +206,72 @@ class TestModalSyncSecrets:
         )
         assert result.returncode != 0, "Should fail without GH environment"
 
+    def test_fails_when_gateway_auth_vars_missing(self):
+        """Should fail before touching Modal when auth config is absent."""
+        env = os.environ.copy()
+        for key in (
+            "GATEWAY_AUTH_ISSUER",
+            "GATEWAY_AUTH_AUDIENCE",
+            "GATEWAY_AUTH_CLIENT_ID",
+            "GATEWAY_AUTH_CLIENT_SECRET",
+        ):
+            env.pop(key, None)
+
+        result = subprocess.run(
+            ["bash", str(self.script), "staging", "beta"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        assert "Missing required GATEWAY_AUTH_* GitHub secrets." in result.stderr
+        assert "Refusing to deploy because auth config would drift" in result.stderr
+
+    def test_creates_gateway_secret_without_client_credentials(self, tmp_path):
+        """Should only sync issuer/audience into the gateway Modal secret."""
+        uv_calls_log = tmp_path / "uv_calls.log"
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_uv = fake_bin / "uv"
+        fake_uv.write_text(
+            "#!/bin/bash\n"
+            'printf "%s\\n" "$*" >> "$UV_CALLS_LOG"\n'
+        )
+        fake_uv.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{fake_bin}:{env['PATH']}",
+                "UV_CALLS_LOG": str(uv_calls_log),
+                "GATEWAY_AUTH_ISSUER": "https://tenant.auth0.com",
+                "GATEWAY_AUTH_AUDIENCE": "https://simulation-api-beta.policyengine.org",
+                "GATEWAY_AUTH_CLIENT_ID": "client-id",
+                "GATEWAY_AUTH_CLIENT_SECRET": "client-secret",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(self.script), "staging", "beta"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0, result.stderr
+        calls = uv_calls_log.read_text()
+        assert "run modal secret create gateway-auth" in calls
+        assert (
+            "GATEWAY_AUTH_ISSUER=https://tenant.auth0.com/" in calls
+        ), calls
+        assert (
+            "GATEWAY_AUTH_AUDIENCE=https://simulation-api-beta.policyengine.org"
+            in calls
+        ), calls
+        assert "GATEWAY_AUTH_CLIENT_ID" not in calls
+        assert "GATEWAY_AUTH_CLIENT_SECRET" not in calls
+
 
 class TestModalDeployApp:
     """Tests for modal-deploy-app.sh"""

--- a/projects/policyengine-apis-integ/tests/simulation/test_auth_smoke.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_auth_smoke.py
@@ -1,0 +1,74 @@
+"""Authenticated smoke tests that must pass in both beta and prod.
+
+These tests assert the end-to-end auth wiring is functional: the gateway
+has the ``gateway-auth`` Modal secret attached, the JWKS-fetch and token
+verification work against the configured Auth0 tenant, and the test
+harness can mint a bearer token that the gateway accepts.
+
+They intentionally do NOT use ``@pytest.mark.beta_only`` so they run in the
+prod deployment job too. Without an auth test in the prod integ suite, a
+misconfigured ``gateway-auth`` secret in the ``main`` Modal environment
+would pass CI while serving 503s to every real client.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from .conftest import settings
+
+
+pytestmark = pytest.mark.skipif(
+    not settings.access_token,
+    reason="Auth token not configured; skipping auth smoke tests (dev only).",
+)
+
+
+def _base() -> str:
+    return settings.base_url.rstrip("/")
+
+
+def test_gated_endpoint_rejects_missing_token() -> None:
+    """No ``Authorization`` header on a gated endpoint must be rejected.
+
+    Without a token the gateway's ``Depends(require_auth)`` surfaces a 403
+    (HTTPBearer auto_error=False + JWTDecoder rejects). A 2xx here means
+    the auth dependency is not actually wired and the gateway is open.
+    """
+    response = httpx.get(
+        f"{_base()}/jobs/auth-smoke-probe-no-token",
+        timeout=30.0,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected the gated /jobs endpoint to reject an unauthenticated "
+        f"request with 401/403, got {response.status_code}: {response.text[:200]}"
+    )
+
+
+def test_gated_endpoint_accepts_valid_token() -> None:
+    """With a valid bearer token the endpoint must advance past auth.
+
+    The probe job id will not resolve, so the expected body is a 404.
+    Any auth-layer status (401, 403, 503) means the container's
+    ``gateway-auth`` secret is misattached or ``GATEWAY_AUTH_ISSUER`` /
+    ``GATEWAY_AUTH_AUDIENCE`` do not match the tenant that minted the
+    token — which is exactly the silent-failure mode this test guards.
+    """
+    response = httpx.get(
+        f"{_base()}/jobs/auth-smoke-probe-does-not-exist",
+        headers={"Authorization": f"Bearer {settings.access_token}"},
+        timeout=30.0,
+    )
+
+    auth_failures = {401, 403, 503}
+    assert response.status_code not in auth_failures, (
+        f"Gated endpoint rejected a valid token with {response.status_code}: "
+        f"{response.text[:200]}. Check that the gateway-auth Modal secret "
+        f"in the deploy environment matches the Auth0 tenant minting the token."
+    )
+    assert response.status_code == 404, (
+        f"Expected 404 for an unknown job id after auth, got "
+        f"{response.status_code}: {response.text[:200]}"
+    )

--- a/projects/policyengine-apis-integ/tests/simulation/test_auth_smoke.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_auth_smoke.py
@@ -1,9 +1,10 @@
 """Authenticated smoke tests that must pass in both beta and prod.
 
 These tests assert the end-to-end auth wiring is functional: the gateway
-has the ``gateway-auth`` Modal secret attached, the JWKS-fetch and token
-verification work against the configured Auth0 tenant, and the test
-harness can mint a bearer token that the gateway accepts.
+has the ``gateway-auth`` Modal secret attached with issuer/audience
+configuration, the JWKS-fetch and token verification work against the
+configured Auth0 tenant, and the test harness can mint a bearer token
+that the gateway accepts.
 
 They intentionally do NOT use ``@pytest.mark.beta_only`` so they run in the
 prod deployment job too. Without an auth test in the prod integ suite, a


### PR DESCRIPTION
## Summary

Unsticks the Modal deploy pipeline that has been frozen since #458 merged: the `require_auth` dependency was landed without attaching a Modal secret to the gateway function or teaching the beta integ tests to mint a bearer token. Every push to `main` since then has failed beta integ tests and skipped the prod deploy (#460 is also stuck behind this).

Auth0 tenant + M2M client + `gateway-auth` Modal secret were set up by Anthony tonight; this PR is the code side.

## Changes

**Gateway container** — `projects/policyengine-api-simulation/src/modal/gateway/app.py`
- Attach `modal.Secret.from_name("gateway-auth")` to the `web_app` function so `GATEWAY_AUTH_ISSUER` / `GATEWAY_AUTH_AUDIENCE` are present at request time for `_get_decoder()`. `CLIENT_ID` / `CLIENT_SECRET` ride along in the same secret so rotating the Auth0 M2M app updates every consumer from one place.

**Deploy sync** — `.github/scripts/modal-sync-secrets.sh`, `.github/workflows/modal-deploy.reusable.yml`
- `modal-sync-secrets.sh` now upserts the `gateway-auth` secret from the four `GATEWAY_AUTH_*` org-wide GH Actions secrets on every deploy, so beta (staging) and prod (main) Modal environments stay in sync and future rotations only need a GH secret update.

**Integ tests** — `.github/scripts/modal-run-integ-tests.sh`, `.github/workflows/modal-deploy.reusable.yml`
- Before pytest, fetch an Auth0 `client_credentials` access token and export it as `simulation_integ_test_access_token`. The existing conftest fixture already swaps to `AuthenticatedClient` when that env var is set, so the test client sends `Authorization: Bearer` on every gateway call.

## Test plan

- [ ] Beta deploy step succeeds (`Sync Modal secrets from GitHub` includes `gateway-auth`)
- [ ] Beta integ tests pass: token mint succeeds, `test_calculate_*` and `test_ping` all green
- [ ] Prod deploy step proceeds (no longer skipped)
- [ ] Prod integ tests pass (subset excluding `beta_only`)
- [ ] `#460` deploy can now ride the pipeline too

## Notes

The `policyengine-api` (v1) side — fetching a token and attaching `Authorization: Bearer` on every outbound sim-gateway call — is tracked separately; that PR will be opened after this one lands so the prod gateway actually has auth available before v1 starts sending tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)