### PR TITLE
Omit null optional fields from Modal worker payloads

### DIFF
--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -100,6 +100,7 @@ def _build_budget_window_parent_payload(
     payload = request.model_dump(
         exclude={"telemetry"},
         mode="json",
+        exclude_none=True,
     )
     payload["version"] = resolved_version
     if request.telemetry is not None:
@@ -162,6 +163,7 @@ async def submit_simulation(request: SimulationRequest):
     payload = request.model_dump(
         exclude={"version", "telemetry"},
         mode="json",
+        exclude_none=True,
     )
     run_id = request.telemetry.run_id if request.telemetry else None
     if request.telemetry is not None:

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -167,6 +167,8 @@ class TestSubmitSimulationEndpoint:
             "policyengine-simulation-us1-500-0-uk2-66-0",
             "run_simulation",
         )
+        assert "time_period" not in mock_modal["func"].last_payload
+        assert "data_version" not in mock_modal["func"].last_payload
 
     def test__given_submission__then_returns_job_id_and_poll_url(
         self, mock_modal, client: TestClient


### PR DESCRIPTION
## Summary
- Use `exclude_none=True` when the gateway forwards simulation and budget-window payloads to Modal worker functions.
- Add a regression assertion that omitted optional fields like `time_period` and `data_version` are not forwarded as explicit `null` values.

## Why
The main deploy after #468 reached the worker but beta integration still failed because the gateway sent `time_period: null`. The current worker `SimulationOptions` rejects `None` for `time_period`; omitting absent optional values preserves the worker default behavior.

## Testing
- `env -u UV_FROZEN uv run pytest tests/gateway/test_endpoints.py -q`
- `env -u UV_FROZEN uv run pytest -q`
- `env -u UV_FROZEN uv run --with ruff ruff format --check src`
