### PR TITLE
Prepare simulation gateway auth enforcement

### DIFF
--- a/.github/scripts/modal-run-integ-tests.sh
+++ b/.github/scripts/modal-run-integ-tests.sh
@@ -9,10 +9,104 @@ ENVIRONMENT="${1:?Environment required (beta or prod)}"
 BASE_URL="${2:?Base URL required}"
 US_VERSION="${3:-}"
 
+truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+GATEWAY_AUTH_VARS=(
+  GATEWAY_AUTH_ISSUER
+  GATEWAY_AUTH_AUDIENCE
+  GATEWAY_AUTH_CLIENT_ID
+  GATEWAY_AUTH_CLIENT_SECRET
+)
+present=()
+missing=()
+for var in "${GATEWAY_AUTH_VARS[@]}"; do
+  if [ -n "${!var:-}" ]; then
+    present+=("$var")
+  else
+    missing+=("$var")
+  fi
+done
+
+if [ ${#present[@]} -gt 0 ] && [ ${#missing[@]} -gt 0 ]; then
+  echo "Gateway auth integration-test config is partial." >&2
+  echo "  Present: ${present[*]-}" >&2
+  echo "  Missing: ${missing[*]-}" >&2
+  exit 1
+fi
+
+SHOULD_MINT_TOKEN=0
+if truthy "${GATEWAY_AUTH_REQUIRED:-}"; then
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "GATEWAY_AUTH_REQUIRED is enabled but integration-test auth secrets are missing." >&2
+    echo "  Missing: ${missing[*]-}" >&2
+    exit 1
+  fi
+  SHOULD_MINT_TOKEN=1
+elif [ ${#present[@]} -eq ${#GATEWAY_AUTH_VARS[@]} ]; then
+  SHOULD_MINT_TOKEN=1
+fi
+
+ACCESS_TOKEN=""
+if [ "$SHOULD_MINT_TOKEN" -eq 1 ]; then
+  ISSUER="${GATEWAY_AUTH_ISSUER%/}"
+  TOKEN_URL="$ISSUER/oauth/token"
+
+  # Build the token-request JSON with Python so that any ", \, or newline in
+  # the client secret is encoded correctly (Auth0-generated secrets are random
+  # strings that routinely contain characters that break a shell heredoc).
+  TOKEN_REQUEST_JSON=$(
+    CLIENT_ID="$GATEWAY_AUTH_CLIENT_ID" \
+    CLIENT_SECRET="$GATEWAY_AUTH_CLIENT_SECRET" \
+    AUDIENCE="$GATEWAY_AUTH_AUDIENCE" \
+    python3 -c '
+import json, os
+print(json.dumps({
+    "client_id": os.environ["CLIENT_ID"],
+    "client_secret": os.environ["CLIENT_SECRET"],
+    "audience": os.environ["AUDIENCE"],
+    "grant_type": "client_credentials",
+}))
+'
+  )
+
+  echo "Requesting client_credentials access token from $TOKEN_URL"
+  TOKEN_RESPONSE=$(
+    curl --fail-with-body --silent --show-error \
+      --request POST "$TOKEN_URL" \
+      --header "content-type: application/json" \
+      --data-binary "$TOKEN_REQUEST_JSON"
+  )
+
+  ACCESS_TOKEN=$(
+    printf '%s' "$TOKEN_RESPONSE" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+token = data.get("access_token")
+if not token:
+    sys.exit(f"Auth0 response missing access_token: {data}")
+print(token)
+'
+  )
+  if [ -z "$ACCESS_TOKEN" ]; then
+    echo "Failed to extract access_token from Auth0 response" >&2
+    exit 1
+  fi
+fi
+
 cd projects/policyengine-apis-integ
 uv sync --extra test
 
 export simulation_integ_test_base_url="$BASE_URL"
+export simulation_integ_test_gateway_auth_required="${GATEWAY_AUTH_REQUIRED:-}"
+
+if [ -n "$ACCESS_TOKEN" ]; then
+  export simulation_integ_test_access_token="$ACCESS_TOKEN"
+fi
 
 if [ -n "$US_VERSION" ]; then
   export simulation_integ_test_us_model_version="$US_VERSION"

--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -8,7 +8,44 @@ set -euo pipefail
 MODAL_ENV="${1:?Modal environment required}"
 GH_ENV="${2:?GitHub environment required}"
 
+truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 echo "Syncing secrets to Modal environment: $MODAL_ENV"
+
+GATEWAY_AUTH_VARS=(
+  GATEWAY_AUTH_ISSUER
+  GATEWAY_AUTH_AUDIENCE
+  GATEWAY_AUTH_CLIENT_ID
+  GATEWAY_AUTH_CLIENT_SECRET
+)
+present=()
+missing=()
+for var in "${GATEWAY_AUTH_VARS[@]}"; do
+  if [ -n "${!var:-}" ]; then
+    present+=("$var")
+  else
+    missing+=("$var")
+  fi
+done
+
+if [ ${#present[@]} -gt 0 ] && [ ${#missing[@]} -gt 0 ]; then
+  echo "Gateway auth config is partial." >&2
+  echo "  Present: ${present[*]-}" >&2
+  echo "  Missing: ${missing[*]-}" >&2
+  echo "Refusing to sync a broken auth secret state." >&2
+  exit 1
+fi
+
+if truthy "${GATEWAY_AUTH_REQUIRED:-}" && [ ${#missing[@]} -gt 0 ]; then
+  echo "GATEWAY_AUTH_REQUIRED is enabled but gateway auth secrets are missing." >&2
+  echo "  Missing: ${missing[*]-}" >&2
+  exit 1
+fi
 
 # Sync Logfire secret
 uv run modal secret create policyengine-logfire \
@@ -25,13 +62,22 @@ if [ -n "${GCP_CREDENTIALS_JSON:-}" ]; then
     --force || true
 fi
 
-# Sync gateway auth config. Empty values preserve the existing public-gateway
-# behavior unless GATEWAY_AUTH_REQUIRED is explicitly set.
+# Sync gateway auth config. The gateway runtime only needs issuer/audience and
+# the explicit requirement flag; client credentials stay on the GitHub side and
+# are only used to mint integration-test tokens.
+NORMALIZED_ISSUER="${GATEWAY_AUTH_ISSUER:-}"
+if [ -n "$NORMALIZED_ISSUER" ]; then
+  case "$NORMALIZED_ISSUER" in
+    */) ;;
+    *) NORMALIZED_ISSUER="$NORMALIZED_ISSUER/" ;;
+  esac
+fi
+
 uv run modal secret create policyengine-gateway-auth \
-  "GATEWAY_AUTH_ISSUER=${GATEWAY_AUTH_ISSUER:-}" \
+  "GATEWAY_AUTH_ISSUER=$NORMALIZED_ISSUER" \
   "GATEWAY_AUTH_AUDIENCE=${GATEWAY_AUTH_AUDIENCE:-}" \
   "GATEWAY_AUTH_REQUIRED=${GATEWAY_AUTH_REQUIRED:-}" \
   --env="$MODAL_ENV" \
-  --force || true
+  --force
 
 echo "Modal secrets synced"

--- a/.github/workflows/modal-deploy.reusable.yml
+++ b/.github/workflows/modal-deploy.reusable.yml
@@ -57,6 +57,8 @@ jobs:
         GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
         GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
         GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
+        GATEWAY_AUTH_CLIENT_ID: ${{ secrets.GATEWAY_AUTH_CLIENT_ID }}
+        GATEWAY_AUTH_CLIENT_SECRET: ${{ secrets.GATEWAY_AUTH_CLIENT_SECRET }}
         GATEWAY_AUTH_REQUIRED: ${{ vars.GATEWAY_AUTH_REQUIRED }}
       run: ../../.github/scripts/modal-sync-secrets.sh "${{ inputs.modal_environment }}" "${{ inputs.environment }}"
 
@@ -105,4 +107,10 @@ jobs:
       run: ./scripts/generate-clients.sh
 
     - name: Run simulation integration tests
+      env:
+        GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
+        GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
+        GATEWAY_AUTH_CLIENT_ID: ${{ secrets.GATEWAY_AUTH_CLIENT_ID }}
+        GATEWAY_AUTH_CLIENT_SECRET: ${{ secrets.GATEWAY_AUTH_CLIENT_SECRET }}
+        GATEWAY_AUTH_REQUIRED: ${{ vars.GATEWAY_AUTH_REQUIRED }}
       run: .github/scripts/modal-run-integ-tests.sh "${{ inputs.environment }}" "${{ needs.deploy.outputs.simulation_api_url }}" "${{ needs.deploy.outputs.us_version }}"

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -45,7 +45,10 @@ def web_app():
     """
     from fastapi import FastAPI
 
-    from src.modal.gateway.auth import enforce_production_auth_guard
+    from src.modal.gateway.auth import (
+        enforce_auth_configured_guard,
+        enforce_production_auth_guard,
+    )
     from src.modal.gateway.endpoints import router
 
     # Startup guard: crash the container if GATEWAY_AUTH_DISABLED is set in
@@ -54,6 +57,7 @@ def web_app():
     # accidentally shipping to prod if a dev deploy grabs the wrong secret
     # bundle. See gateway.auth.enforce_production_auth_guard for the rules.
     enforce_production_auth_guard()
+    enforce_auth_configured_guard()
 
     api = FastAPI(
         title="PolicyEngine Simulation Gateway",

--- a/projects/policyengine-api-simulation/src/modal/gateway/auth.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/auth.py
@@ -103,6 +103,8 @@ def _get_decoder() -> JWTDecoder:
             f"{GATEWAY_AUTH_ISSUER_ENV} and {GATEWAY_AUTH_AUDIENCE_ENV} or "
             f"{GATEWAY_AUTH_DISABLED_ENV}=1 for local/test use."
         )
+    if not issuer.endswith("/"):
+        issuer = issuer + "/"
     return _build_decoder(issuer, audience)
 
 
@@ -117,6 +119,10 @@ class AuthDisabledInProductionError(RuntimeError):
 
 class AuthDisabledWithoutAckError(RuntimeError):
     """Refuse to start when auth is disabled without the explicit ACK."""
+
+
+class AuthMisconfiguredError(RuntimeError):
+    """Refuse to start when required auth config is absent or partial."""
 
 
 def enforce_production_auth_guard() -> None:
@@ -178,6 +184,38 @@ def enforce_production_auth_guard() -> None:
         )
     except Exception:  # pragma: no cover - logfire optional / misconfigured
         pass
+
+
+def enforce_auth_configured_guard() -> None:
+    """Crash startup when gateway auth would serve broken gated endpoints.
+
+    Rules:
+    - auth disabled: allow startup; the separate production guard handles safety.
+    - partial issuer/audience config: always refuse startup because every gated
+      endpoint would return 503 in that state.
+    - auth required and both values missing: refuse startup.
+    - auth optional and both values missing: allow startup (public gateway mode).
+    """
+    if _auth_disabled():
+        return
+
+    issuer = os.environ.get(GATEWAY_AUTH_ISSUER_ENV)
+    audience = os.environ.get(GATEWAY_AUTH_AUDIENCE_ENV)
+
+    if bool(issuer) != bool(audience):
+        raise AuthMisconfiguredError(
+            "Gateway auth is partially configured: set both "
+            f"{GATEWAY_AUTH_ISSUER_ENV} and {GATEWAY_AUTH_AUDIENCE_ENV}, "
+            "or clear both."
+        )
+
+    if _auth_required() and (not issuer or not audience):
+        raise AuthMisconfiguredError(
+            "Gateway auth is required but "
+            f"{GATEWAY_AUTH_ISSUER_ENV}/{GATEWAY_AUTH_AUDIENCE_ENV} are not set "
+            "in the container environment. Verify the "
+            "'policyengine-gateway-auth' Modal secret is synced correctly."
+        )
 
 
 def require_auth(

--- a/projects/policyengine-api-simulation/tests/gateway/test_auth.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_auth.py
@@ -309,3 +309,98 @@ class TestProductionAuthGuard:
         assert any(
             "GATEWAY AUTH IS DISABLED" in record.message for record in caplog.records
         ), f"Expected critical auth-disabled banner, got {caplog.records!r}"
+
+
+class TestAuthConfiguredGuard:
+    """Startup guard for required-or-partial auth misconfiguration."""
+
+    def test__given_auth_disabled__then_guard_noops(self, monkeypatch):
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, "1")
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+        auth_module.enforce_auth_configured_guard()
+
+    def test__given_auth_optional_and_unset__then_guard_noops(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_REQUIRED_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+        auth_module.enforce_auth_configured_guard()
+
+    def test__given_partial_auth_config__then_guard_raises(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_REQUIRED_ENV, raising=False)
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+        with pytest.raises(auth_module.AuthMisconfiguredError):
+            auth_module.enforce_auth_configured_guard()
+
+    def test__given_required_and_missing__then_guard_raises(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_REQUIRED_ENV, "1")
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, raising=False)
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, raising=False)
+
+        with pytest.raises(auth_module.AuthMisconfiguredError):
+            auth_module.enforce_auth_configured_guard()
+
+    def test__given_required_and_configured__then_guard_noops(self, monkeypatch):
+        monkeypatch.delenv(auth_module.GATEWAY_AUTH_DISABLED_ENV, raising=False)
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_REQUIRED_ENV, "1")
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+
+        auth_module.enforce_auth_configured_guard()
+
+
+class TestIssuerNormalization:
+    """Issuer should be normalized to the trailing-slash Auth0 form."""
+
+    def test__given_issuer_without_slash__then_decoder_receives_normalized_value(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example")
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+        auth_module.reset_decoder_cache()
+
+        captured = {}
+
+        def fake_builder(issuer, audience):
+            captured["issuer"] = issuer
+            captured["audience"] = audience
+            return object()
+
+        monkeypatch.setattr(auth_module, "_build_decoder", fake_builder)
+
+        auth_module._get_decoder()
+
+        assert captured == {
+            "issuer": "https://issuer.example/",
+            "audience": "aud",
+        }
+
+    def test__given_issuer_with_slash__then_decoder_receives_unchanged_value(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_ISSUER_ENV, "https://issuer.example/")
+        monkeypatch.setenv(auth_module.GATEWAY_AUTH_AUDIENCE_ENV, "aud")
+        auth_module.reset_decoder_cache()
+
+        captured = {}
+
+        def fake_builder(issuer, audience):
+            captured["issuer"] = issuer
+            captured["audience"] = audience
+            return object()
+
+        monkeypatch.setattr(auth_module, "_build_decoder", fake_builder)
+
+        auth_module._get_decoder()
+
+        assert captured == {
+            "issuer": "https://issuer.example/",
+            "audience": "aud",
+        }

--- a/projects/policyengine-api-simulation/tests/test_modal_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_scripts.py
@@ -206,6 +206,87 @@ class TestModalSyncSecrets:
         )
         assert result.returncode != 0, "Should fail without GH environment"
 
+    def test_fails_when_gateway_auth_config_is_partial(self):
+        """Should fail before touching Modal when auth config is partial."""
+        env = os.environ.copy()
+        env["GATEWAY_AUTH_ISSUER"] = "https://tenant.auth0.com"
+        env.pop("GATEWAY_AUTH_AUDIENCE", None)
+        env.pop("GATEWAY_AUTH_CLIENT_ID", None)
+        env.pop("GATEWAY_AUTH_CLIENT_SECRET", None)
+
+        result = subprocess.run(
+            ["bash", str(self.script), "staging", "beta"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        assert "Gateway auth config is partial." in result.stderr
+
+    def test_fails_when_auth_required_but_gateway_auth_vars_missing(self):
+        """Required auth must refuse deploy when the GitHub secrets are absent."""
+        env = os.environ.copy()
+        env["GATEWAY_AUTH_REQUIRED"] = "1"
+        for key in (
+            "GATEWAY_AUTH_ISSUER",
+            "GATEWAY_AUTH_AUDIENCE",
+            "GATEWAY_AUTH_CLIENT_ID",
+            "GATEWAY_AUTH_CLIENT_SECRET",
+        ):
+            env.pop(key, None)
+
+        result = subprocess.run(
+            ["bash", str(self.script), "staging", "beta"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        assert "GATEWAY_AUTH_REQUIRED is enabled" in result.stderr
+
+    def test_creates_gateway_secret_with_normalized_issuer(self, tmp_path):
+        """Should sync only runtime gateway values and normalize issuer."""
+        uv_calls_log = tmp_path / "uv_calls.log"
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_uv = fake_bin / "uv"
+        fake_uv.write_text('#!/bin/bash\nprintf "%s\\n" "$*" >> "$UV_CALLS_LOG"\n')
+        fake_uv.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{fake_bin}:{env['PATH']}",
+                "UV_CALLS_LOG": str(uv_calls_log),
+                "GATEWAY_AUTH_ISSUER": "https://tenant.auth0.com",
+                "GATEWAY_AUTH_AUDIENCE": "https://simulation-api-beta.policyengine.org",
+                "GATEWAY_AUTH_CLIENT_ID": "client-id",
+                "GATEWAY_AUTH_CLIENT_SECRET": "client-secret",
+                "GATEWAY_AUTH_REQUIRED": "1",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(self.script), "staging", "beta"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0, result.stderr
+        calls = uv_calls_log.read_text()
+        assert "run modal secret create policyengine-gateway-auth" in calls
+        assert "GATEWAY_AUTH_ISSUER=https://tenant.auth0.com/" in calls
+        assert (
+            "GATEWAY_AUTH_AUDIENCE=https://simulation-api-beta.policyengine.org"
+            in calls
+        )
+        assert "GATEWAY_AUTH_REQUIRED=1" in calls
+        assert "GATEWAY_AUTH_CLIENT_ID" not in calls
+        assert "GATEWAY_AUTH_CLIENT_SECRET" not in calls
+
 
 class TestModalDeployApp:
     """Tests for modal-deploy-app.sh"""
@@ -317,6 +398,46 @@ class TestModalRunIntegTests:
             text=True,
         )
         assert result.returncode != 0, "Should fail without base URL"
+
+    def test_fails_when_gateway_auth_config_is_partial(self):
+        """Should fail before running tests if token-mint config is partial."""
+        env = os.environ.copy()
+        env["GATEWAY_AUTH_ISSUER"] = "https://tenant.auth0.com/"
+        env.pop("GATEWAY_AUTH_AUDIENCE", None)
+        env.pop("GATEWAY_AUTH_CLIENT_ID", None)
+        env.pop("GATEWAY_AUTH_CLIENT_SECRET", None)
+
+        result = subprocess.run(
+            ["bash", str(self.script), "beta", "https://example.com"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        assert "Gateway auth integration-test config is partial." in result.stderr
+
+    def test_fails_when_auth_required_but_gateway_auth_vars_missing(self):
+        """Required auth must not run tests unauthenticated."""
+        env = os.environ.copy()
+        env["GATEWAY_AUTH_REQUIRED"] = "1"
+        for key in (
+            "GATEWAY_AUTH_ISSUER",
+            "GATEWAY_AUTH_AUDIENCE",
+            "GATEWAY_AUTH_CLIENT_ID",
+            "GATEWAY_AUTH_CLIENT_SECRET",
+        ):
+            env.pop(key, None)
+
+        result = subprocess.run(
+            ["bash", str(self.script), "beta", "https://example.com"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        assert "GATEWAY_AUTH_REQUIRED is enabled" in result.stderr
 
 
 class TestAllScriptsHaveShebang:

--- a/projects/policyengine-apis-integ/tests/simulation/conftest.py
+++ b/projects/policyengine-apis-integ/tests/simulation/conftest.py
@@ -8,6 +8,7 @@ from policyengine_api_simulation_client import AuthenticatedClient, Client
 class Settings(BaseSettings):
     base_url: str = "http://localhost:8082"
     access_token: str | None = None
+    gateway_auth_required: bool = False
     timeout_in_millis: int = 600_000  # 10 minutes for full simulations
     poll_interval_seconds: float = 5.0
     us_model_version: str = "1.562.3"

--- a/projects/policyengine-apis-integ/tests/simulation/test_auth_smoke.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_auth_smoke.py
@@ -1,0 +1,55 @@
+"""End-to-end auth smoke tests for the simulation gateway."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from .conftest import settings
+
+
+pytestmark = pytest.mark.skipif(
+    not settings.gateway_auth_required,
+    reason="Gateway auth is not required for this deployment; skipping auth smoke.",
+)
+
+
+def _base() -> str:
+    return settings.base_url.rstrip("/")
+
+
+def test_gated_endpoint_rejects_missing_token() -> None:
+    """Unauthenticated access to a gated endpoint must be rejected."""
+    response = httpx.get(
+        f"{_base()}/jobs/auth-smoke-probe-no-token",
+        timeout=30.0,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected /jobs to reject an unauthenticated request with 401/403, "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+
+
+def test_gated_endpoint_accepts_valid_token() -> None:
+    """A valid token must advance past auth and reach the job lookup."""
+    assert settings.access_token, (
+        "simulation_integ_test_access_token must be set when gateway auth "
+        "is required"
+    )
+
+    response = httpx.get(
+        f"{_base()}/jobs/auth-smoke-probe-does-not-exist",
+        headers={"Authorization": f"Bearer {settings.access_token}"},
+        timeout=30.0,
+    )
+
+    auth_failures = {401, 403, 503}
+    assert response.status_code not in auth_failures, (
+        f"Gated endpoint rejected a valid token with {response.status_code}: "
+        f"{response.text[:200]}"
+    )
+    assert response.status_code == 404, (
+        f"Expected 404 for an unknown job id after auth, got "
+        f"{response.status_code}: {response.text[:200]}"
+    )


### PR DESCRIPTION
Fixes #470

## Summary

Prepare `policyengine-api-v2` to safely enable simulation gateway auth enforcement.

Current `main` already contains the gateway-side auth dependency and the explicit `GATEWAY_AUTH_REQUIRED` flag, but it was still missing the CI/test/deploy plumbing needed to actually flip that flag on without breaking deploys.

## Changes

- Mint an Auth0 `client_credentials` token in integration CI and export it as `simulation_integ_test_access_token`
- Plumb `GATEWAY_AUTH_CLIENT_ID` and `GATEWAY_AUTH_CLIENT_SECRET` through the reusable deploy workflow where needed
- Tighten Modal secret sync so partial auth config fails fast and client credentials stay out of the gateway runtime secret
- Normalize issuer trailing slash before writing the runtime gateway secret
- Add a startup guard that crashes the gateway only when auth is required but misconfigured, while preserving the current optional/public mode otherwise
- Add integration auth smoke coverage for gated endpoints

## Rollout

1. Set `GATEWAY_AUTH_REQUIRED=1` in the `beta` environment and verify deploy + integration + auth smoke are green.
2. Set `GATEWAY_AUTH_REQUIRED=1` in `prod` after beta is green.

## Validation

- bash syntax checks for the updated deploy/test scripts
- YAML parse of the reusable deploy workflow
- targeted Ruff checks on touched Python files
- gateway/unit script pytest suite passes
- auth smoke test file collects and skips cleanly while auth is not yet required