### PR TITLE
Ignore empty gateway auth required setting

### DIFF
--- a/.github/scripts/modal-run-integ-tests.sh
+++ b/.github/scripts/modal-run-integ-tests.sh
@@ -102,7 +102,10 @@ cd projects/policyengine-apis-integ
 uv sync --extra test
 
 export simulation_integ_test_base_url="$BASE_URL"
-export simulation_integ_test_gateway_auth_required="${GATEWAY_AUTH_REQUIRED:-}"
+
+if [ -n "${GATEWAY_AUTH_REQUIRED:-}" ]; then
+  export simulation_integ_test_gateway_auth_required="$GATEWAY_AUTH_REQUIRED"
+fi
 
 if [ -n "$ACCESS_TOKEN" ]; then
   export simulation_integ_test_access_token="$ACCESS_TOKEN"

--- a/projects/policyengine-apis-integ/tests/simulation/conftest.py
+++ b/projects/policyengine-apis-integ/tests/simulation/conftest.py
@@ -13,7 +13,10 @@ class Settings(BaseSettings):
     poll_interval_seconds: float = 5.0
     us_model_version: str = "1.562.3"
 
-    model_config = SettingsConfigDict(env_prefix="simulation_integ_test_")
+    model_config = SettingsConfigDict(
+        env_prefix="simulation_integ_test_",
+        env_ignore_empty=True,
+    )
 
 
 settings = Settings()


### PR DESCRIPTION
Fixes #472

## Summary

Fix the deploy integration-test collection failure when `GATEWAY_AUTH_REQUIRED` is not configured yet.

GitHub Actions can pass an unset variable through as an empty string. After #471, that empty string reached `simulation_integ_test_gateway_auth_required`, and Pydantic attempted to parse `""` as a boolean instead of using the field default.

## Changes

- Set `env_ignore_empty=True` for the simulation integration settings so empty env values fall back to defaults.
- Only export `simulation_integ_test_gateway_auth_required` from `modal-run-integ-tests.sh` when `GATEWAY_AUTH_REQUIRED` is non-empty.

## Validation

- `bash -n .github/scripts/modal-run-integ-tests.sh`
- `uv run ruff check projects/policyengine-apis-integ/tests/simulation/conftest.py`
- Generated the simulation client with `./scripts/generate-clients.sh`
- Verified `simulation_integ_test_gateway_auth_required=""` loads as `False`
- Verified `simulation_integ_test_gateway_auth_required=1` loads as `True`
- `uv run pytest tests/simulation/test_auth_smoke.py -q` skips cleanly while auth is not required