### PR TITLE
Align simulation UK runtime with PolicyEngine 4.4.3

### DIFF
--- a/projects/policyengine-api-simulation/pyproject.toml
+++ b/projects/policyengine-api-simulation/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "policyengine-fastapi",
     "policyengine==4.4.3",
     "policyengine-core>=3.26.1",
-    "policyengine-uk==2.88.14",
+    "policyengine-uk==2.88.0",
     "policyengine-us==1.690.7",
     "tables>=3.10.2",
     "modal>=0.73.0",

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -15,7 +15,7 @@ from src.modal.logging_redaction import redact_params_for_logging
 
 # Get versions from environment or use defaults
 US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.690.7")
-UK_VERSION = os.environ.get("POLICYENGINE_UK_VERSION", "2.88.14")
+UK_VERSION = os.environ.get("POLICYENGINE_UK_VERSION", "2.88.0")
 
 
 def get_app_name(us_version: str, uk_version: str) -> str:

--- a/projects/policyengine-api-simulation/uv.lock
+++ b/projects/policyengine-api-simulation/uv.lock
@@ -1734,7 +1734,7 @@ requires-dist = [
     { name = "policyengine", specifier = "==4.4.3" },
     { name = "policyengine-core", specifier = ">=3.26.1" },
     { name = "policyengine-fastapi", editable = "../../libs/policyengine-fastapi" },
-    { name = "policyengine-uk", specifier = "==2.88.14" },
+    { name = "policyengine-uk", specifier = "==2.88.0" },
     { name = "policyengine-us", specifier = "==1.690.7" },
     { name = "pydantic-settings", specifier = ">=2.7.1,<3.0.0" },
     { name = "pyright", marker = "extra == 'build'", specifier = ">=1.1.401" },
@@ -1747,7 +1747,7 @@ provides-extras = ["test", "build"]
 
 [[package]]
 name = "policyengine-uk"
-version = "2.88.14"
+version = "2.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -1755,9 +1755,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tables" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/2b/ab82aa30c5d27176fd9d449ff5ed9708d0080b00912f7dc2efa0af0fd87e/policyengine_uk-2.88.14.tar.gz", hash = "sha256:21a4387ae52dcb5430b6d790edcc321816ed47147a3a0e21ffd482a36834d352", size = 1185947, upload-time = "2026-05-09T04:19:25.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/cf/749dea25c17210b5dc40098363e0b6a60b7fc5feb69ff77c74b88deb5cde/policyengine_uk-2.88.0.tar.gz", hash = "sha256:d157c7336b7aa3a321f317af1a4f111d7b857451ff43f4998abdc5a8c893e989", size = 1166666, upload-time = "2026-04-17T19:22:55.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/fc/276fb639a46bda35523329d8968bcc4089fde9e97fab82722c0ec853c6cc/policyengine_uk-2.88.14-py3-none-any.whl", hash = "sha256:ed10005ba7d0c973c0966ebbf7672853fb3caaa0456b8bf485fb13f8c323d975", size = 1913671, upload-time = "2026-05-09T04:19:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/23/7e/8a2a42eac1da63730a865964aa17e7fd4420ce4db4c80001c1b5ca6011e8/policyengine_uk-2.88.0-py3-none-any.whl", hash = "sha256:46a3ba443b43ec810c5efaccd4645edb63c8dc90ef5acf9b0cdf5ace86b9334d", size = 1867764, upload-time = "2026-04-17T19:22:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- keep the simulation API on policyengine-us 1.690.7
- revert the simulation worker UK package pin/default to policyengine-uk 2.88.0, matching policyengine.py 4.4.3
- update the simulation API lockfile

## Context
The PolicyEngine 4.4.3 simulation API deploy passed the US beta smoke tests, but the beta UK simulation failed under policyengine-uk 2.88.14. policyengine.py 4.4.3 still declares policyengine-uk 2.88.0, so this aligns the Modal worker with that bundle instead of deploying a known UK failure.

## Verification
- env -u UV_FROZEN uv lock
- env -u UV_FROZEN uv run pytest -q tests/test_modal_scripts.py tests/test_policyengine_dependency_source.py