### PR TITLE
Restore full macro simulation outputs

### DIFF
--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -31,6 +31,7 @@ from src.modal.gateway.models import (
 )
 from src.modal.gateway.responses import (
     batch_status_response,
+    complete_job_response,
     failed_job_response,
     running_job_response,
 )
@@ -298,9 +299,7 @@ async def get_job_status(job_id: str):
 
     try:
         result = call.get(timeout=0)
-        return JobStatusResponse(
-            status="complete", result=result, **(job_metadata or {})
-        )
+        return complete_job_response(result=result, job_metadata=job_metadata)
     except TimeoutError:
         return running_job_response(job_metadata)
     except Exception as exc:

--- a/projects/policyengine-api-simulation/src/modal/gateway/responses.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/responses.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi.responses import JSONResponse
 
-from src.modal.gateway.models import BudgetWindowBatchStatusResponse
+from src.modal.gateway.models import (
+    BudgetWindowBatchStatusResponse,
+    JobStatusResponse,
+)
 
 
 class AcceptedResponse(JSONResponse):
@@ -37,7 +42,25 @@ def batch_status_response(response: BudgetWindowBatchStatusResponse):
         return AcceptedResponse(payload)
     if response.status == "failed":
         return ServerErrorResponse(payload)
-    return response
+    # Preserve null-valued annual sections inside outputsByYear. Returning the
+    # model directly would let FastAPI's route-level exclude_none prune them.
+    return JSONResponse(payload)
+
+
+def complete_job_response(*, result: Any, job_metadata: dict | None = None):
+    response = JobStatusResponse(
+        status="complete",
+        result=result,
+        **(job_metadata or {}),
+    )
+    payload = response.model_dump(mode="json")
+    if response.policyengine_bundle is not None:
+        payload["policyengine_bundle"] = response.policyengine_bundle.model_dump(
+            mode="json",
+            exclude_none=True,
+        )
+    # Preserve null-valued legacy sections inside pass-through result payloads.
+    return JSONResponse(payload)
 
 
 def running_job_response(job_metadata: dict | None = None) -> AcceptedResponse:

--- a/projects/policyengine-api-simulation/src/modal/gateway/responses.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/responses.py
@@ -26,6 +26,10 @@ class ServerErrorResponse(JSONResponse):
         super().__init__(status_code=500, content=content)
 
 
+def _omit_top_level_none(payload: dict) -> dict:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
 def batch_status_payload(response: BudgetWindowBatchStatusResponse) -> dict:
     payload = response.model_dump(mode="json")
     if response.policyengine_bundle is not None:
@@ -44,7 +48,7 @@ def batch_status_response(response: BudgetWindowBatchStatusResponse):
         return ServerErrorResponse(payload)
     # Preserve null-valued annual sections inside outputsByYear. Returning the
     # model directly would let FastAPI's route-level exclude_none prune them.
-    return JSONResponse(payload)
+    return JSONResponse(_omit_top_level_none(payload))
 
 
 def complete_job_response(*, result: Any, job_metadata: dict | None = None):
@@ -60,7 +64,7 @@ def complete_job_response(*, result: Any, job_metadata: dict | None = None):
             exclude_none=True,
         )
     # Preserve null-valued legacy sections inside pass-through result payloads.
-    return JSONResponse(payload)
+    return JSONResponse(_omit_top_level_none(payload))
 
 
 def running_job_response(job_metadata: dict | None = None) -> AcceptedResponse:

--- a/projects/policyengine-api-simulation/src/modal/simulation.py
+++ b/projects/policyengine-api-simulation/src/modal/simulation.py
@@ -403,9 +403,19 @@ def _budget_result(country: str, baseline, reform) -> dict[str, float]:
         baseline, reform, "household_benefits", entity="household"
     )
     budgetary_impact = tax_revenue_impact - benefit_spending_impact
+    if country == "us":
+        state_tax_revenue_impact = _try_change_sum(
+            baseline,
+            reform,
+            "household_state_income_tax",
+            entity="tax_unit",
+        )
+    else:
+        state_tax_revenue_impact = 0.0
+
     result = {
         "tax_revenue_impact": tax_revenue_impact,
-        "state_tax_revenue_impact": 0.0,
+        "state_tax_revenue_impact": state_tax_revenue_impact,
         "benefit_spending_impact": benefit_spending_impact,
         "budgetary_impact": budgetary_impact,
         "baseline_net_income": _try_aggregate_sum(
@@ -419,13 +429,6 @@ def _budget_result(country: str, baseline, reform) -> dict[str, float]:
             entity="household",
         ),
     }
-    if country == "us":
-        result["state_tax_revenue_impact"] = _try_change_sum(
-            baseline,
-            reform,
-            "household_state_income_tax",
-            entity="tax_unit",
-        )
     return result
 
 

--- a/projects/policyengine-api-simulation/src/modal/simulation.py
+++ b/projects/policyengine-api-simulation/src/modal/simulation.py
@@ -6,11 +6,12 @@ captured in Modal's image snapshot. No Modal dependencies here.
 """
 
 import contextlib
+import importlib
 import json
 import logging
 import os
 import tempfile
-import importlib
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Iterator
 
 # policyengine.core is imported for every simulation. Without this guard,
@@ -27,6 +28,44 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_YEAR = 2026
+POVERTY_TYPES = ("poverty", "deep_poverty")
+AGE_GROUPS = {
+    "all": {},
+    "child": {"filter_variable": "age", "filter_variable_leq": 17},
+    "adult": {
+        "filter_variable": "age",
+        "filter_variable_geq": 18,
+        "filter_variable_leq": 64,
+    },
+    "senior": {"filter_variable": "age", "filter_variable_geq": 65},
+}
+GENDER_GROUPS = {
+    "male": {"filter_variable": "is_male", "filter_variable_eq": True},
+    "female": {"filter_variable": "is_male", "filter_variable_eq": False},
+}
+RACE_GROUPS = {
+    "white": {"filter_variable": "race", "filter_variable_eq": "WHITE"},
+    "black": {"filter_variable": "race", "filter_variable_eq": "BLACK"},
+    "hispanic": {"filter_variable": "race", "filter_variable_eq": "HISPANIC"},
+    "other": {"filter_variable": "race", "filter_variable_eq": "OTHER"},
+}
+POVERTY_VARIABLES = {
+    "us": {
+        "poverty": "spm_unit_is_in_spm_poverty",
+        "deep_poverty": "spm_unit_is_in_deep_spm_poverty",
+    },
+    "uk": {
+        "poverty": "in_poverty_bhc",
+        "deep_poverty": None,
+    },
+}
+INTRA_DECILE_FIELDS = {
+    "Gain less than 5%": "gain_less_than_5pct",
+    "Gain more than 5%": "gain_more_than_5pct",
+    "Lose less than 5%": "lose_less_than_5pct",
+    "Lose more than 5%": "lose_more_than_5pct",
+    "No change": "no_change",
+}
 DATASET_ALIASES = {
     "us": {
         "enhanced_cps": "enhanced_cps_2024",
@@ -250,6 +289,13 @@ def _country_module(country: str):
     raise ValueError(f"Unsupported country: {country}")
 
 
+def _package_version(package_name: str) -> str | None:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None
+
+
 def _load_dataset(params: dict[str, Any]):
     country = params.get("country", "us").lower()
     year = _parse_year(params)
@@ -297,6 +343,32 @@ def _change_sum(baseline, reform, variable: str, entity: str | None = None) -> f
     return float(output.result)
 
 
+def _aggregate_sum(simulation, variable: str, entity: str | None = None) -> float:
+    from policyengine.outputs import Aggregate, AggregateType
+
+    output = Aggregate(
+        simulation=simulation,
+        variable=variable,
+        entity=entity,
+        aggregate_type=AggregateType.SUM,
+    )
+    output.run()
+    return float(output.result)
+
+
+def _aggregate_count(simulation, variable: str, entity: str | None = None) -> float:
+    from policyengine.outputs import Aggregate, AggregateType
+
+    output = Aggregate(
+        simulation=simulation,
+        variable=variable,
+        entity=entity,
+        aggregate_type=AggregateType.COUNT,
+    )
+    output.run()
+    return float(output.result)
+
+
 def _try_change_sum(
     baseline, reform, variable: str, entity: str | None = None
 ) -> float:
@@ -304,6 +376,22 @@ def _try_change_sum(
         return _change_sum(baseline, reform, variable, entity)
     except Exception:
         logger.warning("Unable to calculate change for %s", variable, exc_info=True)
+        return 0.0
+
+
+def _try_aggregate_sum(simulation, variable: str, entity: str | None = None) -> float:
+    try:
+        return _aggregate_sum(simulation, variable, entity)
+    except Exception:
+        logger.warning("Unable to calculate sum for %s", variable, exc_info=True)
+        return 0.0
+
+
+def _try_aggregate_count(simulation, variable: str, entity: str | None = None) -> float:
+    try:
+        return _aggregate_count(simulation, variable, entity)
+    except Exception:
+        logger.warning("Unable to calculate count for %s", variable, exc_info=True)
         return 0.0
 
 
@@ -317,8 +405,19 @@ def _budget_result(country: str, baseline, reform) -> dict[str, float]:
     budgetary_impact = tax_revenue_impact - benefit_spending_impact
     result = {
         "tax_revenue_impact": tax_revenue_impact,
+        "state_tax_revenue_impact": 0.0,
         "benefit_spending_impact": benefit_spending_impact,
         "budgetary_impact": budgetary_impact,
+        "baseline_net_income": _try_aggregate_sum(
+            baseline,
+            "household_net_income",
+            entity="household",
+        ),
+        "households": _try_aggregate_count(
+            baseline,
+            "household_net_income",
+            entity="household",
+        ),
     }
     if country == "us":
         result["state_tax_revenue_impact"] = _try_change_sum(
@@ -330,44 +429,291 @@ def _budget_result(country: str, baseline, reform) -> dict[str, float]:
     return result
 
 
-def _poverty_result(country: str, baseline, reform) -> dict[str, list[dict[str, Any]]]:
-    country_module = _country_module(country)
-    impact = country_module.economic_impact_analysis(baseline, reform)
-    baseline_poverty = impact.baseline_poverty
-    reform_poverty = impact.reform_poverty
+def _rows(collection) -> list[dict[str, Any]]:
+    return collection.dataframe.to_dict("records")
 
+
+def _number_or_zero(value: Any) -> float:
+    return float(value) if isinstance(value, int | float) else 0.0
+
+
+def _empty_metric_pair() -> dict[str, float]:
+    return {"baseline": 0.0, "reform": 0.0}
+
+
+def _empty_labor_supply_response() -> dict[str, Any]:
     return {
-        "baseline": baseline_poverty.dataframe.to_dict("records"),
-        "reform": reform_poverty.dataframe.to_dict("records"),
+        "decile": {
+            "average": {"income": {}, "substitution": {}},
+            "relative": {"income": {}, "substitution": {}},
+        },
+        "hours": {
+            "baseline": 0.0,
+            "reform": 0.0,
+            "change": 0.0,
+            "income_effect": 0.0,
+            "substitution_effect": 0.0,
+        },
+        "income_lsr": 0.0,
+        "substitution_lsr": 0.0,
+        "relative_lsr": {"income": 0.0, "substitution": 0.0},
+        "total_change": 0.0,
+        "revenue_change": 0.0,
     }
 
 
-def _analysis_result(country: str, baseline, reform) -> dict[str, Any]:
-    country_module = _country_module(country)
-    analysis = country_module.economic_impact_analysis(baseline, reform)
+def _decile_result(decile_rows: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    average: dict[str, float] = {}
+    relative: dict[str, float] = {}
+    for row in sorted(decile_rows, key=lambda item: item["decile"]):
+        decile = str(row["decile"])
+        average[decile] = _number_or_zero(row.get("absolute_change"))
+        relative[decile] = _number_or_zero(row.get("relative_change"))
+    return {"average": average, "relative": relative}
 
+
+def _detailed_budget_result(
+    program_rows: list[dict[str, Any]],
+) -> dict[str, dict[str, float]]:
     return {
-        "decile_impacts": analysis.decile_impacts.dataframe.to_dict("records"),
-        "program_statistics": analysis.program_statistics.dataframe.to_dict("records"),
+        row["program_name"]: {
+            "baseline": _number_or_zero(row.get("baseline_total")),
+            "reform": _number_or_zero(row.get("reform_total")),
+            "difference": _number_or_zero(row.get("change")),
+        }
+        for row in program_rows
+    }
+
+
+def _inequality_result(analysis) -> dict[str, dict[str, float]]:
+    return {
+        "gini": {
+            "baseline": _number_or_zero(analysis.baseline_inequality.gini),
+            "reform": _number_or_zero(analysis.reform_inequality.gini),
+        },
+        "top_10_pct_share": {
+            "baseline": _number_or_zero(analysis.baseline_inequality.top_10_share),
+            "reform": _number_or_zero(analysis.reform_inequality.top_10_share),
+        },
+        "top_1_pct_share": {
+            "baseline": _number_or_zero(analysis.baseline_inequality.top_1_share),
+            "reform": _number_or_zero(analysis.reform_inequality.top_1_share),
+        },
+    }
+
+
+def _poverty_rate(
+    country: str,
+    simulation,
+    poverty_type: str,
+    filters: dict[str, Any],
+) -> float:
+    from policyengine.outputs.poverty import Poverty
+
+    variable = POVERTY_VARIABLES[country][poverty_type]
+    if variable is None:
+        return 0.0
+
+    poverty = Poverty(
+        simulation=simulation,
+        poverty_variable=variable,
+        poverty_type=poverty_type,
+        entity="person",
+        **filters,
+    )
+    poverty.run()
+    return _number_or_zero(poverty.rate)
+
+
+def _try_poverty_pair(
+    country: str,
+    baseline,
+    reform,
+    poverty_type: str,
+    filters: dict[str, Any],
+) -> dict[str, float]:
+    try:
+        return {
+            "baseline": _poverty_rate(country, baseline, poverty_type, filters),
+            "reform": _poverty_rate(country, reform, poverty_type, filters),
+        }
+    except Exception:
+        logger.warning(
+            "Unable to calculate %s poverty for filters %s",
+            poverty_type,
+            filters,
+            exc_info=True,
+        )
+        return _empty_metric_pair()
+
+
+def _poverty_result(country: str, baseline, reform) -> dict[str, Any]:
+    return {
+        poverty_type: {
+            group: _try_poverty_pair(country, baseline, reform, poverty_type, filters)
+            for group, filters in AGE_GROUPS.items()
+        }
+        for poverty_type in POVERTY_TYPES
+    }
+
+
+def _poverty_by_gender_result(country: str, baseline, reform) -> dict[str, Any]:
+    return {
+        poverty_type: {
+            group: _try_poverty_pair(country, baseline, reform, poverty_type, filters)
+            for group, filters in GENDER_GROUPS.items()
+        }
+        for poverty_type in POVERTY_TYPES
+    }
+
+
+def _poverty_by_race_result(country: str, baseline, reform) -> dict[str, Any] | None:
+    if country != "us":
+        return None
+    return {
         "poverty": {
-            "baseline": analysis.baseline_poverty.dataframe.to_dict("records"),
-            "reform": analysis.reform_poverty.dataframe.to_dict("records"),
-        },
-        "inequality": {
-            "baseline": _inequality_summary(analysis.baseline_inequality),
-            "reform": _inequality_summary(analysis.reform_inequality),
-        },
+            group: _try_poverty_pair(country, baseline, reform, "poverty", filters)
+            for group, filters in RACE_GROUPS.items()
+        }
     }
 
 
-def _inequality_summary(inequality) -> dict[str, Any]:
+def _intra_decile_rows(country: str, baseline, reform) -> list[dict[str, Any]]:
+    from policyengine.outputs import compute_intra_decile_impacts
+
+    income_variable = (
+        "household_net_income"
+        if country == "us"
+        else "equiv_hbai_household_net_income"
+    )
+    return _rows(
+        compute_intra_decile_impacts(
+            baseline_simulation=baseline,
+            reform_simulation=reform,
+            income_variable=income_variable,
+        )
+    )
+
+
+def _try_intra_decile_rows(country: str, baseline, reform) -> list[dict[str, Any]]:
+    try:
+        return _intra_decile_rows(country, baseline, reform)
+    except Exception:
+        logger.warning("Unable to calculate intra-decile impact", exc_info=True)
+        return []
+
+
+def _intra_decile_result(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    output = {
+        "all": {label: 0.0 for label in INTRA_DECILE_FIELDS},
+        "deciles": {label: [] for label in INTRA_DECILE_FIELDS},
+    }
+    sorted_rows = sorted(rows, key=lambda row: row["decile"])
+
+    for label, field in INTRA_DECILE_FIELDS.items():
+        decile_values = [
+            _number_or_zero(row.get(field))
+            for row in sorted_rows
+            if row.get("decile") != 0
+        ]
+        output["deciles"][label] = decile_values
+
+        overall = next((row for row in sorted_rows if row.get("decile") == 0), None)
+        if overall is not None:
+            output["all"][label] = _number_or_zero(overall.get(field))
+        elif decile_values:
+            output["all"][label] = sum(decile_values) / len(decile_values)
+
+    return output
+
+
+def _congressional_district_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        state_fips = int(_number_or_zero(row.get("state_fips")))
+        district_number = int(_number_or_zero(row.get("district_number")))
+        output.append(
+            {
+                "district": f"{state_fips:02d}-{district_number:02d}",
+                "average_household_income_change": _number_or_zero(
+                    row.get("average_household_income_change")
+                ),
+                "relative_household_income_change": _number_or_zero(
+                    row.get("relative_household_income_change")
+                ),
+                "winner_percentage": _number_or_zero(row.get("winner_percentage")),
+                "loser_percentage": _number_or_zero(row.get("loser_percentage")),
+                "no_change_percentage": _number_or_zero(
+                    row.get("no_change_percentage")
+                ),
+            }
+        )
+    return output
+
+
+def _congressional_district_impact(
+    country: str, baseline, reform
+) -> dict[str, Any] | None:
+    if country != "us":
+        return None
+    try:
+        from policyengine.outputs import compute_us_congressional_district_impacts
+
+        impact = compute_us_congressional_district_impacts(
+            baseline_simulation=baseline,
+            reform_simulation=reform,
+        )
+    except Exception:
+        logger.warning("Unable to calculate congressional district impact", exc_info=True)
+        return None
+
+    return {"districts": _congressional_district_rows(impact.district_results or [])}
+
+
+def _legacy_macro_result(
+    *,
+    country: str,
+    params: dict[str, Any],
+    baseline,
+    reform,
+    analysis,
+    budget: dict[str, float],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    decile_rows = _rows(analysis.decile_impacts)
+    program_rows = _rows(analysis.program_statistics)
+    intra_decile_rows = _try_intra_decile_rows(country, baseline, reform)
+    country_package = f"policyengine-{country}"
+
     return {
-        "income_variable": inequality.income_variable,
-        "entity": inequality.entity,
-        "gini": inequality.gini,
-        "top_10_share": inequality.top_10_share,
-        "top_1_share": inequality.top_1_share,
-        "bottom_50_share": inequality.bottom_50_share,
+        "budget": budget,
+        "detailed_budget": _detailed_budget_result(program_rows),
+        "decile": _decile_result(decile_rows),
+        "inequality": _inequality_result(analysis),
+        "poverty": _poverty_result(country, baseline, reform),
+        "poverty_by_gender": _poverty_by_gender_result(country, baseline, reform),
+        "poverty_by_race": _poverty_by_race_result(country, baseline, reform),
+        "intra_decile": _intra_decile_result(intra_decile_rows),
+        "wealth_decile": None,
+        "intra_wealth_decile": None,
+        "labor_supply_response": _empty_labor_supply_response(),
+        "constituency_impact": None,
+        "local_authority_impact": None,
+        "congressional_district_impact": _congressional_district_impact(
+            country,
+            baseline,
+            reform,
+        ),
+        "cliff_impact": None,
+        "model_version": _package_version(country_package),
+        "policyengine_version": _package_version("policyengine"),
+        "data_version": params.get("data_version"),
+        "dataset": metadata.get("dataset"),
+        "metadata": metadata,
+        # Preserve the row-oriented PolicyEngine 4.4.x outputs as extra fields.
+        "decile_impacts": decile_rows,
+        "program_statistics": program_rows,
+        "intra_decile_rows": intra_decile_rows,
     }
 
 
@@ -392,12 +738,21 @@ def _run_simulation_impl_core(params: dict) -> dict:
     reform = _build_simulation(simulation_params, reform_policy)
 
     logger.info("Calculating economic impact")
-    analysis = _analysis_result(country, baseline, reform)
-    analysis["budget"] = _budget_result(country, baseline, reform)
-    analysis["metadata"] = {
+    country_module = _country_module(country)
+    analysis = country_module.economic_impact_analysis(baseline, reform)
+    metadata = {
         "country": country,
         "year": _parse_year(simulation_params),
         "dataset": getattr(baseline.dataset, "filepath", None),
     }
+    result = _legacy_macro_result(
+        country=country,
+        params=simulation_params,
+        baseline=baseline,
+        reform=reform,
+        analysis=analysis,
+        budget=_budget_result(country, baseline, reform),
+        metadata=metadata,
+    )
     logger.info("Comparison complete")
-    return analysis
+    return result

--- a/projects/policyengine-api-simulation/tests/fixtures/budget_window_outputs.py
+++ b/projects/policyengine-api-simulation/tests/fixtures/budget_window_outputs.py
@@ -5,6 +5,25 @@ from __future__ import annotations
 from copy import deepcopy
 
 
+FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS = {
+    "budget",
+    "detailed_budget",
+    "decile",
+    "inequality",
+    "poverty",
+    "poverty_by_gender",
+    "poverty_by_race",
+    "intra_decile",
+    "wealth_decile",
+    "intra_wealth_decile",
+    "labor_supply_response",
+    "constituency_impact",
+    "local_authority_impact",
+    "congressional_district_impact",
+    "cliff_impact",
+}
+
+
 def _baseline_reform_values() -> dict[str, float]:
     return {"baseline": 0.0, "reform": 0.0}
 
@@ -48,8 +67,10 @@ def make_single_year_macro_output(
 
     return {
         "budget": budget,
-        "detailed_budget": None,
-        "decile": {"relative": {}, "average": {}},
+        "detailed_budget": {
+            "income_tax": {"baseline": 100.0, "reform": 110.0, "difference": 10.0}
+        },
+        "decile": {"relative": {"1": 0.01}, "average": {"1": 100.0}},
         "inequality": {
             "gini": _baseline_reform_values(),
             "top_10_pct_share": _baseline_reform_values(),
@@ -86,4 +107,21 @@ def make_single_year_macro_output(
         "local_authority_impact": None,
         "congressional_district_impact": None,
         "cliff_impact": None,
+        "model_version": "1.500.0",
+        "policyengine_version": "4.4.3",
+        "data_version": None,
+        "dataset": "fixture-dataset.h5",
+        "metadata": {"country": "us", "year": 2026, "dataset": "fixture-dataset.h5"},
+        "decile_impacts": [
+            {"decile": 1, "absolute_change": 100.0, "relative_change": 0.01}
+        ],
+        "program_statistics": [
+            {
+                "program_name": "income_tax",
+                "baseline_total": 100.0,
+                "reform_total": 110.0,
+                "change": 10.0,
+            }
+        ],
+        "intra_decile_rows": [],
     }

--- a/projects/policyengine-api-simulation/tests/gateway/test_models.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_models.py
@@ -20,7 +20,10 @@ from src.modal.gateway.models import (
     _move_internal_telemetry_alias,
     _strip_internal_passthrough_fields,
 )
-from tests.fixtures.budget_window_outputs import make_single_year_macro_output
+from tests.fixtures.budget_window_outputs import (
+    FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS,
+    make_single_year_macro_output,
+)
 
 
 class TestPingRequest:
@@ -671,7 +674,9 @@ class TestBudgetWindowBatchStatusResponse:
         assert dumped["result"]["kind"] == "budgetWindow"
         assert dumped["result"]["years"] == ["2026", "2027"]
         assert "annualImpacts" not in dumped["result"]
+        first_year_output = dumped["result"]["outputsByYear"]["2026"]
+        assert FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS <= first_year_output.keys()
         assert (
-            dumped["result"]["outputsByYear"]["2026"]["budget"]["tax_revenue_impact"]
-            == 10
+            first_year_output["budget"]["tax_revenue_impact"] == 10
         )
+        assert first_year_output["detailed_budget"]["income_tax"]["difference"] == 10

--- a/projects/policyengine-api-simulation/tests/gateway/test_responses.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_responses.py
@@ -1,0 +1,72 @@
+"""Tests for gateway response serialization helpers."""
+
+import json
+
+from src.modal.gateway.models import (
+    BatchChildJobStatus,
+    BudgetWindowBatchStatusResponse,
+    BudgetWindowResult,
+    BudgetWindowTotals,
+)
+from src.modal.gateway.responses import batch_status_response, complete_job_response
+from tests.fixtures.budget_window_outputs import make_single_year_macro_output
+
+
+def test_complete_budget_window_response_preserves_null_annual_sections():
+    response = BudgetWindowBatchStatusResponse(
+        status="complete",
+        progress=100,
+        completed_years=["2026"],
+        running_years=[],
+        queued_years=[],
+        failed_years=[],
+        child_jobs={"2026": BatchChildJobStatus(job_id="fc-2026", status="complete")},
+        result=BudgetWindowResult(
+            startYear="2026",
+            endYear="2026",
+            windowSize=1,
+            years=["2026"],
+            outputsByYear={
+                "2026": make_single_year_macro_output(
+                    tax_revenue_impact=10,
+                    state_tax_revenue_impact=0,
+                    benefit_spending_impact=5,
+                    budgetary_impact=5,
+                )
+            },
+            totals=BudgetWindowTotals(
+                taxRevenueImpact=10,
+                federalTaxRevenueImpact=10,
+                stateTaxRevenueImpact=0,
+                benefitSpendingImpact=5,
+                budgetaryImpact=5,
+            ),
+        ),
+    )
+
+    serialized = batch_status_response(response)
+    body = json.loads(serialized.body)
+    output = body["result"]["outputsByYear"]["2026"]
+
+    assert "wealth_decile" in output
+    assert output["wealth_decile"] is None
+    assert "congressional_district_impact" in output
+    assert output["congressional_district_impact"] is None
+
+
+def test_complete_job_response_preserves_null_result_sections():
+    result = make_single_year_macro_output(
+        tax_revenue_impact=10,
+        state_tax_revenue_impact=0,
+        benefit_spending_impact=5,
+        budgetary_impact=5,
+    )
+
+    serialized = complete_job_response(result=result)
+    body = json.loads(serialized.body)
+    output = body["result"]
+
+    assert "wealth_decile" in output
+    assert output["wealth_decile"] is None
+    assert "congressional_district_impact" in output
+    assert output["congressional_district_impact"] is None

--- a/projects/policyengine-api-simulation/tests/gateway/test_responses.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_responses.py
@@ -48,6 +48,8 @@ def test_complete_budget_window_response_preserves_null_annual_sections():
     body = json.loads(serialized.body)
     output = body["result"]["outputsByYear"]["2026"]
 
+    assert "run_id" not in body
+    assert "error" not in body
     assert "wealth_decile" in output
     assert output["wealth_decile"] is None
     assert "congressional_district_impact" in output
@@ -66,6 +68,8 @@ def test_complete_job_response_preserves_null_result_sections():
     body = json.loads(serialized.body)
     output = body["result"]
 
+    assert "run_id" not in body
+    assert "error" not in body
     assert "wealth_decile" in output
     assert output["wealth_decile"] is None
     assert "congressional_district_impact" in output

--- a/projects/policyengine-api-simulation/tests/test_budget_window_batch.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_batch.py
@@ -14,7 +14,10 @@ from src.modal.gateway.models import (
     BudgetWindowBatchRequest,
     PolicyEngineBundle,
 )
-from tests.fixtures.budget_window_outputs import make_single_year_macro_output
+from tests.fixtures.budget_window_outputs import (
+    FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS,
+    make_single_year_macro_output,
+)
 
 
 class SequencedCall:
@@ -236,10 +239,13 @@ def test_run_budget_window_batch_impl_completes_and_respects_max_parallel(
     assert result["result"]["years"] == ["2026", "2027", "2028"]
     assert list(result["result"]["outputsByYear"]) == ["2026", "2027", "2028"]
     assert "annualImpacts" not in result["result"]
+    first_year_output = result["result"]["outputsByYear"]["2026"]
+    assert FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS <= first_year_output.keys()
     assert (
-        result["result"]["outputsByYear"]["2026"]["budget"]["tax_revenue_impact"]
-        == 10
+        first_year_output["budget"]["tax_revenue_impact"] == 10
     )
+    assert first_year_output["detailed_budget"]["income_tax"]["difference"] == 10.0
+    assert first_year_output["program_statistics"][0]["program_name"] == "income_tax"
     assert result["result"]["totals"]["budgetaryImpact"] == 51
     assert state is not None
     assert state.status == "complete"

--- a/projects/policyengine-api-simulation/tests/test_budget_window_results.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_results.py
@@ -7,7 +7,10 @@ from src.modal.budget_window_results import (
     sum_single_year_outputs,
     validate_single_year_output,
 )
-from tests.fixtures.budget_window_outputs import make_single_year_macro_output
+from tests.fixtures.budget_window_outputs import (
+    FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS,
+    make_single_year_macro_output,
+)
 
 
 def test_validate_single_year_output_preserves_full_macro_output():
@@ -24,10 +27,15 @@ def test_validate_single_year_output_preserves_full_macro_output():
     )
 
     dumped = output.model_dump(mode="json")
+    assert FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS <= dumped.keys()
     assert dumped["budget"]["tax_revenue_impact"] == 100
     assert dumped["budget"]["state_tax_revenue_impact"] == 40
-    assert "poverty" in dumped
-    assert "decile" in dumped
+    assert dumped["detailed_budget"]["income_tax"]["difference"] == 10
+    assert dumped["decile"]["average"]["1"] == 100
+    assert dumped["decile_impacts"] == [
+        {"decile": 1, "absolute_change": 100.0, "relative_change": 0.01}
+    ]
+    assert dumped["program_statistics"][0]["program_name"] == "income_tax"
     assert "annualImpacts" not in dumped
 
 

--- a/projects/policyengine-api-simulation/tests/test_budget_window_scheduler.py
+++ b/projects/policyengine-api-simulation/tests/test_budget_window_scheduler.py
@@ -25,7 +25,10 @@ from src.modal.gateway.models import (
     BudgetWindowBatchRequest,
     PolicyEngineBundle,
 )
-from tests.fixtures.budget_window_outputs import make_single_year_macro_output
+from tests.fixtures.budget_window_outputs import (
+    FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS,
+    make_single_year_macro_output,
+)
 
 
 @dataclass
@@ -228,9 +231,13 @@ def test_budget_window_submit_and_poll_exercise_gateway_worker_seams(
     assert body["result"]["years"] == ["2026", "2027", "2028"]
     assert list(body["result"]["outputsByYear"]) == ["2026", "2027", "2028"]
     assert "annualImpacts" not in body["result"]
+    first_year_output = body["result"]["outputsByYear"]["2026"]
+    assert FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS <= first_year_output.keys()
     assert (
-        body["result"]["outputsByYear"]["2026"]["budget"]["tax_revenue_impact"] == 100.0
+        first_year_output["budget"]["tax_revenue_impact"] == 100.0
     )
+    assert first_year_output["detailed_budget"]["income_tax"]["difference"] == 10.0
+    assert first_year_output["decile_impacts"][0]["absolute_change"] == 100.0
     assert body["result"]["totals"] == {
         "taxRevenueImpact": 600.0,
         "federalTaxRevenueImpact": 540.0,

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_shape.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_shape.py
@@ -1,0 +1,219 @@
+"""Regression coverage for worker macro output shaping."""
+
+from types import SimpleNamespace
+
+import src.modal.simulation as simulation_module
+from tests.fixtures.budget_window_outputs import FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS
+
+
+class FakeDataFrame:
+    def __init__(self, rows: list[dict]):
+        self.rows = rows
+
+    def to_dict(self, orient: str):
+        assert orient == "records"
+        return self.rows
+
+
+def _collection(rows: list[dict]):
+    return SimpleNamespace(dataframe=FakeDataFrame(rows))
+
+
+def _metric_pair(baseline: float = 0.0, reform: float = 0.0) -> dict[str, float]:
+    return {"baseline": baseline, "reform": reform}
+
+
+def test_legacy_macro_result_restores_full_single_year_shape(monkeypatch):
+    decile_rows = [
+        {"decile": 2, "absolute_change": 200.0, "relative_change": 0.02},
+        {"decile": 1, "absolute_change": 100.0, "relative_change": 0.01},
+    ]
+    program_rows = [
+        {
+            "program_name": "income_tax",
+            "baseline_total": 1000.0,
+            "reform_total": 1100.0,
+            "change": 100.0,
+        }
+    ]
+    intra_decile_rows = [
+        {
+            "decile": 0,
+            "gain_less_than_5pct": 0.1,
+            "gain_more_than_5pct": 0.2,
+            "lose_less_than_5pct": 0.3,
+            "lose_more_than_5pct": 0.4,
+            "no_change": 0.0,
+        },
+        {
+            "decile": 1,
+            "gain_less_than_5pct": 0.5,
+            "gain_more_than_5pct": 0.6,
+            "lose_less_than_5pct": 0.7,
+            "lose_more_than_5pct": 0.8,
+            "no_change": 0.9,
+        },
+    ]
+    poverty = {
+        "poverty": {"all": _metric_pair(0.1, 0.2)},
+        "deep_poverty": {"all": _metric_pair(0.03, 0.04)},
+    }
+    poverty_by_gender = {
+        "poverty": {"male": _metric_pair(0.1, 0.2)},
+        "deep_poverty": {"male": _metric_pair(0.03, 0.04)},
+    }
+    poverty_by_race = {"poverty": {"white": _metric_pair(0.1, 0.2)}}
+
+    analysis = SimpleNamespace(
+        decile_impacts=_collection(decile_rows),
+        program_statistics=_collection(program_rows),
+        baseline_inequality=SimpleNamespace(
+            gini=0.31,
+            top_10_share=0.42,
+            top_1_share=0.12,
+        ),
+        reform_inequality=SimpleNamespace(
+            gini=0.32,
+            top_10_share=0.43,
+            top_1_share=0.13,
+        ),
+    )
+
+    monkeypatch.setattr(
+        simulation_module,
+        "_try_intra_decile_rows",
+        lambda country, baseline, reform: intra_decile_rows,
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "_poverty_result",
+        lambda country, baseline, reform: poverty,
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "_poverty_by_gender_result",
+        lambda country, baseline, reform: poverty_by_gender,
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "_poverty_by_race_result",
+        lambda country, baseline, reform: poverty_by_race,
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "_congressional_district_impact",
+        lambda country, baseline, reform: {"districts": []},
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "_package_version",
+        lambda package: {"policyengine-us": "1.500.0", "policyengine": "4.4.3"}.get(
+            package
+        ),
+    )
+
+    result = simulation_module._legacy_macro_result(
+        country="us",
+        params={"data_version": "data-v1"},
+        baseline=object(),
+        reform=object(),
+        analysis=analysis,
+        budget={
+            "tax_revenue_impact": 100.0,
+            "state_tax_revenue_impact": 20.0,
+            "benefit_spending_impact": 30.0,
+            "budgetary_impact": 70.0,
+            "baseline_net_income": 1000.0,
+            "households": 10.0,
+        },
+        metadata={"country": "us", "year": 2026, "dataset": "dataset.h5"},
+    )
+
+    assert FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS <= result.keys()
+    assert result["budget"]["baseline_net_income"] == 1000.0
+    assert result["budget"]["households"] == 10.0
+    assert result["detailed_budget"]["income_tax"] == {
+        "baseline": 1000.0,
+        "reform": 1100.0,
+        "difference": 100.0,
+    }
+    assert result["decile"] == {
+        "average": {"1": 100.0, "2": 200.0},
+        "relative": {"1": 0.01, "2": 0.02},
+    }
+    assert result["inequality"]["gini"] == {"baseline": 0.31, "reform": 0.32}
+    assert result["poverty"] is poverty
+    assert result["poverty_by_gender"] is poverty_by_gender
+    assert result["poverty_by_race"] is poverty_by_race
+    assert result["intra_decile"]["all"]["Gain more than 5%"] == 0.2
+    assert result["intra_decile"]["deciles"]["Gain more than 5%"] == [0.6]
+    assert result["labor_supply_response"]["hours"]["baseline"] == 0.0
+    assert result["model_version"] == "1.500.0"
+    assert result["policyengine_version"] == "4.4.3"
+    assert result["data_version"] == "data-v1"
+    assert result["dataset"] == "dataset.h5"
+    assert result["decile_impacts"] == decile_rows
+    assert result["program_statistics"] == program_rows
+    assert result["intra_decile_rows"] == intra_decile_rows
+
+
+def test_budget_result_keeps_state_tax_field_for_all_countries(monkeypatch):
+    def fake_change_sum(baseline, reform, variable: str, entity=None):
+        return {
+            "household_tax": 100.0,
+            "household_benefits": 30.0,
+            "household_state_income_tax": 12.0,
+        }[variable]
+
+    monkeypatch.setattr(simulation_module, "_try_change_sum", fake_change_sum)
+    monkeypatch.setattr(
+        simulation_module,
+        "_try_aggregate_sum",
+        lambda simulation, variable, entity=None: 1000.0,
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "_try_aggregate_count",
+        lambda simulation, variable, entity=None: 10.0,
+    )
+
+    uk_budget = simulation_module._budget_result("uk", object(), object())
+    us_budget = simulation_module._budget_result("us", object(), object())
+
+    assert uk_budget == {
+        "tax_revenue_impact": 100.0,
+        "state_tax_revenue_impact": 0.0,
+        "benefit_spending_impact": 30.0,
+        "budgetary_impact": 70.0,
+        "baseline_net_income": 1000.0,
+        "households": 10.0,
+    }
+    assert us_budget["state_tax_revenue_impact"] == 12.0
+
+
+def test_congressional_district_rows_use_legacy_report_shape():
+    rows = simulation_module._congressional_district_rows(
+        [
+            {
+                "state_fips": 6,
+                "district_number": 12,
+                "average_household_income_change": 100.0,
+                "relative_household_income_change": 0.01,
+                "winner_percentage": 0.4,
+                "loser_percentage": 0.1,
+                "no_change_percentage": 0.5,
+                "district_geoid": 612,
+            }
+        ]
+    )
+
+    assert rows == [
+        {
+            "district": "06-12",
+            "average_household_income_change": 100.0,
+            "relative_household_income_change": 0.01,
+            "winner_percentage": 0.4,
+            "loser_percentage": 0.1,
+            "no_change_percentage": 0.5,
+        }
+    ]

--- a/projects/policyengine-apis-integ/tests/simulation/test_budget_window.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_budget_window.py
@@ -7,6 +7,7 @@ simulation workers, and the completed batch result has the public response
 shape expected by API consumers.
 """
 
+from collections.abc import Mapping
 from http import HTTPStatus
 
 import pytest
@@ -16,6 +17,55 @@ from policyengine_api_simulation_client.models import (
     BudgetWindowResult,
 )
 from policyengine_api_simulation_client.types import Unset
+
+
+FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS = {
+    "budget",
+    "detailed_budget",
+    "decile",
+    "inequality",
+    "poverty",
+    "poverty_by_gender",
+    "poverty_by_race",
+    "intra_decile",
+    "wealth_decile",
+    "intra_wealth_decile",
+    "labor_supply_response",
+    "constituency_impact",
+    "local_authority_impact",
+    "congressional_district_impact",
+    "cliff_impact",
+}
+BUDGET_OUTPUT_KEYS = {
+    "baseline_net_income",
+    "benefit_spending_impact",
+    "budgetary_impact",
+    "households",
+    "state_tax_revenue_impact",
+    "tax_revenue_impact",
+}
+
+
+def assert_full_single_year_macro_output(output: object) -> None:
+    payload = output.to_dict()
+    missing = FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS - payload.keys()
+    assert not missing, f"Missing full macro fields: {sorted(missing)}"
+    assert "annualImpacts" not in payload
+
+    budget = payload["budget"]
+    assert isinstance(budget, Mapping)
+    missing_budget_keys = BUDGET_OUTPUT_KEYS - budget.keys()
+    assert not missing_budget_keys, (
+        f"Missing budget fields: {sorted(missing_budget_keys)}"
+    )
+    assert isinstance(payload["detailed_budget"], Mapping)
+    assert isinstance(payload["decile"], Mapping)
+    assert isinstance(payload["poverty"], Mapping)
+    assert isinstance(payload["poverty_by_gender"], Mapping)
+    assert isinstance(payload["intra_decile"], Mapping)
+    assert isinstance(payload["labor_supply_response"], Mapping)
+    assert "decile_impacts" in payload
+    assert "program_statistics" in payload
 
 
 @pytest.mark.beta_only
@@ -68,4 +118,6 @@ def test_budget_window_multi_year_batch_completes(
         outputs_by_year[year].budget.budgetary_impact is not None
         for year in budget_window_years
     )
+    for year in budget_window_years:
+        assert_full_single_year_macro_output(outputs_by_year[year])
     assert isinstance(result.totals.budgetary_impact, int | float)

--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
@@ -5,6 +5,7 @@ These tests run against the staging Modal deployment and verify
 that economy-wide simulations complete successfully.
 """
 
+from collections.abc import Mapping
 import time
 from http import HTTPStatus
 
@@ -20,6 +21,61 @@ from policyengine_api_simulation_client.models import (
     JobSubmitResponse,
     SimulationRequest,
 )
+
+
+FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS = {
+    "budget",
+    "detailed_budget",
+    "decile",
+    "inequality",
+    "poverty",
+    "poverty_by_gender",
+    "poverty_by_race",
+    "intra_decile",
+    "wealth_decile",
+    "intra_wealth_decile",
+    "labor_supply_response",
+    "constituency_impact",
+    "local_authority_impact",
+    "congressional_district_impact",
+    "cliff_impact",
+}
+BUDGET_OUTPUT_KEYS = {
+    "baseline_net_income",
+    "benefit_spending_impact",
+    "budgetary_impact",
+    "households",
+    "state_tax_revenue_impact",
+    "tax_revenue_impact",
+}
+
+
+def assert_full_single_year_macro_result(
+    economy_result: object, *, country: str
+) -> None:
+    assert isinstance(economy_result, Mapping)
+    missing = FULL_SINGLE_YEAR_MACRO_OUTPUT_KEYS - economy_result.keys()
+    assert not missing, f"Missing full macro fields: {sorted(missing)}"
+    assert "annualImpacts" not in economy_result
+
+    budget = economy_result["budget"]
+    assert isinstance(budget, Mapping)
+    missing_budget_keys = BUDGET_OUTPUT_KEYS - budget.keys()
+    assert not missing_budget_keys, (
+        f"Missing budget fields: {sorted(missing_budget_keys)}"
+    )
+    assert isinstance(budget["state_tax_revenue_impact"], int | float)
+    if country == "uk":
+        assert budget["state_tax_revenue_impact"] == 0
+
+    assert isinstance(economy_result["detailed_budget"], Mapping)
+    assert isinstance(economy_result["decile"], Mapping)
+    assert isinstance(economy_result["poverty"], Mapping)
+    assert isinstance(economy_result["poverty_by_gender"], Mapping)
+    assert isinstance(economy_result["intra_decile"], Mapping)
+    assert isinstance(economy_result["labor_supply_response"], Mapping)
+    assert "decile_impacts" in economy_result
+    assert "program_statistics" in economy_result
 
 
 def test_generated_client_job_status_result_remains_pass_through_dict():
@@ -130,17 +186,8 @@ def test_calculate_default_model(
     assert result.status == "complete"
     assert result.result is not None
 
-    # Verify key economic impact sections are present
     economy_result = result.result
-    assert "budget" in economy_result, (
-        f"Missing 'budget' in result: {economy_result.keys()}"
-    )
-    assert "poverty" in economy_result, (
-        f"Missing 'poverty' in result: {economy_result.keys()}"
-    )
-    assert "inequality" in economy_result, (
-        f"Missing 'inequality' in result: {economy_result.keys()}"
-    )
+    assert_full_single_year_macro_result(economy_result, country="us")
 
 
 @pytest.mark.beta_only
@@ -191,9 +238,7 @@ def test_calculate_specific_model(
     assert result.result is not None
 
     economy_result = result.result
-    assert "budget" in economy_result
-    assert "poverty" in economy_result
-    assert "inequality" in economy_result
+    assert_full_single_year_macro_result(economy_result, country="us")
 
 
 @pytest.mark.beta_only
@@ -241,6 +286,4 @@ def test_calculate_uk_model(
     assert result.result is not None
 
     economy_result = result.result
-    assert "budget" in economy_result
-    assert "poverty" in economy_result
-    assert "inequality" in economy_result
+    assert_full_single_year_macro_result(economy_result, country="uk")


### PR DESCRIPTION
Fixes #483

## Summary

- Restore the simulation worker response to the full legacy single-year macro output shape while preserving the newer row-oriented PolicyEngine 4.4.x fields as passthrough data.
- Keep stable budget fields present across countries, including `state_tax_revenue_impact` defaulting to `0.0` for non-US outputs.
- Preserve null-valued legacy sections in completed `/jobs/{job_id}` and budget-window responses instead of letting route-level `exclude_none` strip them.
- Expand worker, budget-window, response serialization, and integration expectations so tests assert the full annual macro shape.

## Verification

- Not run after the final edits per request.
- Before that request, `ruff check` had passed and a focused regression subset had passed; the broader selected pytest run was stopped on request before completion.