### PR TITLE
Preserve nullable budget-window output fields

### DIFF
--- a/projects/policyengine-api-simulation/src/modal/gateway/responses.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/responses.py
@@ -37,6 +37,8 @@ def batch_status_response(response: BudgetWindowBatchStatusResponse):
         return AcceptedResponse(payload)
     if response.status == "failed":
         return ServerErrorResponse(payload)
+    if response.status == "complete":
+        return JSONResponse(status_code=200, content=payload)
     return response
 
 

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -733,6 +733,13 @@ class TestBudgetWindowBatchEndpoints:
         assert response.json()["status"] == "complete"
         assert response.json()["result"]["years"] == ["2026", "2027"]
         assert "annualImpacts" not in response.json()["result"]
+        output = response.json()["result"]["outputsByYear"]["2026"]
+        assert output["poverty_by_race"] is None
+        assert output["wealth_decile"] is None
+        assert output["intra_wealth_decile"] is None
+        assert output["constituency_impact"] is None
+        assert output["local_authority_impact"] is None
+        assert output["cliff_impact"] is None
         assert response.json()["result"]["totals"]["budgetaryImpact"] == 32
         assert response.json()["run_id"] == "batch-run-123"
 


### PR DESCRIPTION
## Summary

- Return completed budget-window status responses through `JSONResponse` using the full serialized payload so nullable single-year output fields remain present as `null`.
- Add a gateway regression assertion that completed budget-window JSON retains nullable output keys required by the generated client parser.

## Verification

- `uv run pytest tests/gateway/test_endpoints.py::TestBudgetWindowBatchEndpoints::test__given_batch_state__then_poll_returns_completed_response -q`
- `uv run ruff check src/modal/gateway/responses.py tests/gateway/test_endpoints.py`
- Generated-client parse reproduction: missing nullable keys parsed as raw `dict`; present `null` keys parsed as `BudgetWindowResult`.