### PR TITLE
[codex] Add country package update automation

### DIFF
--- a/.github/scripts/check-country-package-updates.py
+++ b/.github/scripts/check-country-package-updates.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Format country package changelog entries between two versions."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+
+REPO_MAP = {
+    "policyengine-us": "PolicyEngine/policyengine-us",
+    "policyengine-uk": "PolicyEngine/policyengine-uk",
+}
+
+
+def fetch_changelog(package: str) -> str | None:
+    repo = REPO_MAP.get(package)
+    if repo is None:
+        return None
+
+    for branch in ("main", "master"):
+        url = f"https://raw.githubusercontent.com/{repo}/{branch}/CHANGELOG.md"
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:
+                if response.status == 200:
+                    return response.read().decode("utf-8")
+        except (TimeoutError, urllib.error.URLError):
+            continue
+
+    return None
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    parts = tuple(int(part) for part in version.split("."))
+    if len(parts) != 3:
+        raise ValueError(f"Expected a semantic version, got {version!r}")
+    return parts
+
+
+def parse_changelog(text: str) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    current_entry: dict[str, object] | None = None
+    current_category: str | None = None
+
+    for line in text.splitlines():
+        version_match = re.match(r"^##\s+\[?(\d+\.\d+\.\d+)\]?", line)
+        if version_match:
+            current_entry = {"version": version_match.group(1), "changes": {}}
+            entries.append(current_entry)
+            current_category = None
+            continue
+
+        if current_entry is None:
+            continue
+
+        category_match = re.match(r"^###\s+(.+)", line)
+        if category_match:
+            current_category = category_match.group(1).strip().lower()
+            continue
+
+        item_match = re.match(r"^-\s+(.+)", line)
+        if item_match and current_category:
+            changes = current_entry["changes"]
+            assert isinstance(changes, dict)
+            changes.setdefault(current_category, [])
+            changes[current_category].append(item_match.group(1))
+
+    return entries
+
+
+def get_changes_between(
+    changelog: list[dict[str, object]], old_version: str, new_version: str
+) -> list[dict[str, object]]:
+    old_v = parse_version(old_version)
+    new_v = parse_version(new_version)
+    entries = []
+    for entry in changelog:
+        version = entry.get("version")
+        if isinstance(version, str) and old_v < parse_version(version) <= new_v:
+            entries.append(entry)
+    return entries
+
+
+def format_changes(entries: list[dict[str, object]]) -> str:
+    preferred_order = ("added", "changed", "fixed", "removed", "deprecated")
+    buckets: dict[str, list[str]] = {category: [] for category in preferred_order}
+    extra_buckets: dict[str, list[str]] = {}
+
+    for entry in entries:
+        changes = entry.get("changes", {})
+        if not isinstance(changes, dict):
+            continue
+        for category, items in changes.items():
+            if not isinstance(category, str) or not isinstance(items, list):
+                continue
+            target = buckets if category in buckets else extra_buckets
+            target.setdefault(category, [])
+            target[category].extend(str(item) for item in items)
+
+    sections = []
+    for category in (*preferred_order, *sorted(extra_buckets)):
+        items = buckets.get(category) or extra_buckets.get(category) or []
+        if items:
+            body = "\n".join(f"- {item}" for item in items)
+            sections.append(f"### {category.capitalize()}\n{body}")
+
+    return "\n\n".join(sections)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--package", required=True)
+    parser.add_argument("--old-version", required=True)
+    parser.add_argument("--new-version", required=True)
+    args = parser.parse_args()
+
+    changelog_text = fetch_changelog(args.package)
+    if changelog_text is None:
+        print(f"Could not fetch changelog for {args.package}.", file=sys.stderr)
+        return 0
+
+    changes = get_changes_between(
+        parse_changelog(changelog_text), args.old_version, args.new_version
+    )
+    if not changes:
+        print("No changelog entries found between these versions.")
+        return 0
+
+    print(format_changes(changes))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update-country-package.sh
+++ b/.github/scripts/update-country-package.sh
@@ -44,6 +44,34 @@ PYPROJECT="${PROJECT_PATH}/pyproject.toml"
 LOCKFILE="${PROJECT_PATH}/uv.lock"
 MODAL_APP="${PROJECT_PATH}/src/modal/app.py"
 
+create_pr_body_file() {
+  local changelog
+  local pr_body_file
+
+  changelog=$(python3 "${ROOT_DIR}/.github/scripts/check-country-package-updates.py" \
+    --package "$PACKAGE" \
+    --old-version "$CURRENT" \
+    --new-version "$LATEST" 2>/dev/null || true)
+
+  pr_body_file="$(mktemp)"
+  {
+    echo "## Summary"
+    echo
+    echo "Update ${DISPLAY_NAME} from ${CURRENT} to ${LATEST} in the simulation API runtime."
+    if [[ -n "$changelog" ]]; then
+      echo
+      echo "## What changed (${CURRENT} -> ${LATEST})"
+      echo
+      echo "$changelog"
+    fi
+    echo
+    echo "---"
+    echo "Generated automatically by GitHub Actions."
+  } > "$pr_body_file"
+
+  echo "$pr_body_file"
+}
+
 if [[ ! -f "$PYPROJECT" || ! -f "$LOCKFILE" || ! -f "$MODAL_APP" ]]; then
   echo "ERROR: Expected simulation project files were not found under ${PROJECT_DIR}." >&2
   exit 1
@@ -89,16 +117,37 @@ fi
 BRANCH="auto/update-${PACKAGE}-${LATEST}"
 echo "Update available: ${CURRENT} -> ${LATEST}"
 
-if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-  echo "Branch '${BRANCH}' already exists on remote. Skipping."
-  exit 0
-fi
-
 if [[ "$DRY_RUN" == "1" ]]; then
+  if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    echo "Dry run: remote branch '${BRANCH}' already exists; would ensure a PR exists for it."
+    exit 0
+  fi
   echo "Dry run: would create ${BRANCH} and update:"
   echo "  ${PROJECT_DIR}/pyproject.toml"
   echo "  ${PROJECT_DIR}/uv.lock"
   echo "  ${PROJECT_DIR}/src/modal/app.py"
+  exit 0
+fi
+
+EXISTING_PR=$(gh pr list \
+  --head "$BRANCH" \
+  --state open \
+  --json number \
+  --jq '.[0].number' 2>/dev/null || true)
+if [[ -n "$EXISTING_PR" ]]; then
+  echo "PR #${EXISTING_PR} already exists for ${BRANCH}. Skipping."
+  exit 0
+fi
+
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  echo "Remote branch '${BRANCH}' already exists without an open PR. Creating PR."
+  PR_BODY_FILE="$(create_pr_body_file)"
+  gh pr create \
+    --base main \
+    --head "$BRANCH" \
+    --title "chore(deps): update ${PACKAGE} to ${LATEST}" \
+    --body-file "$PR_BODY_FILE"
+  echo "PR created for existing branch ${BRANCH}"
   exit 0
 fi
 
@@ -141,26 +190,7 @@ if git diff --quiet -- "$PYPROJECT" "$LOCKFILE" "$MODAL_APP"; then
   exit 0
 fi
 
-CHANGELOG=$(python3 "${ROOT_DIR}/.github/scripts/check-country-package-updates.py" \
-  --package "$PACKAGE" \
-  --old-version "$CURRENT" \
-  --new-version "$LATEST" 2>/dev/null || true)
-
-PR_BODY_FILE="$(mktemp)"
-{
-  echo "## Summary"
-  echo
-  echo "Update ${DISPLAY_NAME} from ${CURRENT} to ${LATEST} in the simulation API runtime."
-  if [[ -n "$CHANGELOG" ]]; then
-    echo
-    echo "## What changed (${CURRENT} -> ${LATEST})"
-    echo
-    echo "$CHANGELOG"
-  fi
-  echo
-  echo "---"
-  echo "Generated automatically by GitHub Actions."
-} > "$PR_BODY_FILE"
+PR_BODY_FILE="$(create_pr_body_file)"
 
 git add "$PYPROJECT" "$LOCKFILE" "$MODAL_APP"
 git commit -m "chore(deps): update ${PACKAGE} to ${LATEST}"

--- a/.github/scripts/update-country-package.sh
+++ b/.github/scripts/update-country-package.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Check PyPI for a newer country package, update the simulation project pins,
+# and open a version-specific PR.
+#
+# Usage:
+#   .github/scripts/update-country-package.sh policyengine-us [--dry-run]
+#   .github/scripts/update-country-package.sh policyengine-uk [--dry-run]
+#
+# Optional environment:
+#   PROJECT_DIR      Project containing pyproject.toml and uv.lock.
+#   LATEST_OVERRIDE  Version to use instead of querying PyPI, for local checks.
+#   DRY_RUN=1        Report planned changes without editing files or opening a PR.
+
+set -euo pipefail
+
+PACKAGE="${1:?Usage: update-country-package.sh <policyengine-us|policyengine-uk> [--dry-run]}"
+DRY_RUN="${DRY_RUN:-0}"
+if [[ "${2:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+fi
+
+case "$PACKAGE" in
+  policyengine-us)
+    DISPLAY_NAME="PolicyEngine US"
+    CONSTANT_NAME="US_VERSION"
+    ENV_NAME="POLICYENGINE_US_VERSION"
+    ;;
+  policyengine-uk)
+    DISPLAY_NAME="PolicyEngine UK"
+    CONSTANT_NAME="UK_VERSION"
+    ENV_NAME="POLICYENGINE_UK_VERSION"
+    ;;
+  *)
+    echo "ERROR: Unsupported package '${PACKAGE}'." >&2
+    exit 1
+    ;;
+esac
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+PROJECT_DIR="${PROJECT_DIR:-projects/policyengine-api-simulation}"
+PROJECT_PATH="${ROOT_DIR}/${PROJECT_DIR}"
+PYPROJECT="${PROJECT_PATH}/pyproject.toml"
+LOCKFILE="${PROJECT_PATH}/uv.lock"
+MODAL_APP="${PROJECT_PATH}/src/modal/app.py"
+
+if [[ ! -f "$PYPROJECT" || ! -f "$LOCKFILE" || ! -f "$MODAL_APP" ]]; then
+  echo "ERROR: Expected simulation project files were not found under ${PROJECT_DIR}." >&2
+  exit 1
+fi
+
+CURRENT=$(python3 - "$LOCKFILE" "$PACKAGE" <<'PY'
+import re
+import sys
+
+lockfile, package = sys.argv[1:]
+text = open(lockfile, encoding="utf-8").read()
+pattern = rf'\[\[package\]\]\s+name = "{re.escape(package)}"\s+version = "([^"]+)"'
+match = re.search(pattern, text)
+if not match:
+    raise SystemExit(f"Package {package!r} not found in {lockfile}")
+print(match.group(1))
+PY
+)
+
+if [[ -n "${LATEST_OVERRIDE:-}" ]]; then
+  LATEST="$LATEST_OVERRIDE"
+else
+  LATEST=$(curl -fsSL "https://pypi.org/pypi/${PACKAGE}/json" | python3 -c 'import json, sys; print(json.load(sys.stdin)["info"]["version"])')
+  if [[ -z "$LATEST" ]]; then
+    echo "ERROR: Could not fetch latest version for ${PACKAGE} from PyPI." >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "$LATEST" ]]; then
+  echo "ERROR: Latest version for ${PACKAGE} is empty." >&2
+  exit 1
+fi
+
+echo "Current locked version: ${PACKAGE}==${CURRENT}"
+echo "Latest PyPI version:   ${PACKAGE}==${LATEST}"
+
+if [[ "$CURRENT" == "$LATEST" ]]; then
+  echo "Already up to date. Nothing to do."
+  exit 0
+fi
+
+BRANCH="auto/update-${PACKAGE}-${LATEST}"
+echo "Update available: ${CURRENT} -> ${LATEST}"
+
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  echo "Branch '${BRANCH}' already exists on remote. Skipping."
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "Dry run: would create ${BRANCH} and update:"
+  echo "  ${PROJECT_DIR}/pyproject.toml"
+  echo "  ${PROJECT_DIR}/uv.lock"
+  echo "  ${PROJECT_DIR}/src/modal/app.py"
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git checkout -b "$BRANCH"
+
+python3 - "$PYPROJECT" "$MODAL_APP" "$PACKAGE" "$CURRENT" "$LATEST" "$CONSTANT_NAME" "$ENV_NAME" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+pyproject_path, modal_app_path, package, current, latest, constant, env_name = sys.argv[1:]
+
+pyproject = Path(pyproject_path)
+pyproject_text = pyproject.read_text(encoding="utf-8")
+old_pin = f'"{package}=={current}"'
+new_pin = f'"{package}=={latest}"'
+if old_pin not in pyproject_text:
+    raise SystemExit(f"Could not find {old_pin} in {pyproject}")
+pyproject.write_text(pyproject_text.replace(old_pin, new_pin), encoding="utf-8")
+
+modal_app = Path(modal_app_path)
+modal_text = modal_app.read_text(encoding="utf-8")
+pattern = rf'{constant} = os\.environ\.get\("{env_name}", "[^"]+"\)'
+replacement = f'{constant} = os.environ.get("{env_name}", "{latest}")'
+updated, count = re.subn(pattern, replacement, modal_text, count=1)
+if count != 1:
+    raise SystemExit(f"Could not update {constant} in {modal_app}")
+modal_app.write_text(updated, encoding="utf-8")
+PY
+
+(
+  cd "$PROJECT_PATH"
+  uv lock --upgrade-package "$PACKAGE"
+)
+
+if git diff --quiet -- "$PYPROJECT" "$LOCKFILE" "$MODAL_APP"; then
+  echo "No changes after update. Nothing to do."
+  exit 0
+fi
+
+CHANGELOG=$(python3 "${ROOT_DIR}/.github/scripts/check-country-package-updates.py" \
+  --package "$PACKAGE" \
+  --old-version "$CURRENT" \
+  --new-version "$LATEST" 2>/dev/null || true)
+
+PR_BODY_FILE="$(mktemp)"
+{
+  echo "## Summary"
+  echo
+  echo "Update ${DISPLAY_NAME} from ${CURRENT} to ${LATEST} in the simulation API runtime."
+  if [[ -n "$CHANGELOG" ]]; then
+    echo
+    echo "## What changed (${CURRENT} -> ${LATEST})"
+    echo
+    echo "$CHANGELOG"
+  fi
+  echo
+  echo "---"
+  echo "Generated automatically by GitHub Actions."
+} > "$PR_BODY_FILE"
+
+git add "$PYPROJECT" "$LOCKFILE" "$MODAL_APP"
+git commit -m "chore(deps): update ${PACKAGE} to ${LATEST}"
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --base main \
+  --title "chore(deps): update ${PACKAGE} to ${LATEST}" \
+  --body-file "$PR_BODY_FILE"
+
+echo "PR created for ${PACKAGE} ${CURRENT} -> ${LATEST}"

--- a/.github/workflows/update-country-packages.yml
+++ b/.github/workflows/update-country-packages.yml
@@ -1,0 +1,49 @@
+name: Update country packages
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Update ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'PolicyEngine/policyengine-api-v2'
+    strategy:
+      matrix:
+        package: [policyengine-us, policyengine-uk]
+      fail-fast: false
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          save-cache: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Check for update and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: bash .github/scripts/update-country-package.sh ${{ matrix.package }}

--- a/projects/policyengine-api-simulation/fixtures/test_country_package_update_scripts.py
+++ b/projects/policyengine-api-simulation/fixtures/test_country_package_update_scripts.py
@@ -15,6 +15,24 @@ from fixtures.test_modal_scripts import REPO_ROOT, SCRIPTS_DIR
 
 SCRIPT = SCRIPTS_DIR / "update-country-package.sh"
 CHANGELOG_SCRIPT = SCRIPTS_DIR / "check-country-package-updates.py"
+SAMPLE_CHANGELOG = """
+# Changelog
+
+## 1.2.2
+### Added
+- New variable
+
+### Fixed
+- Important bug fix
+
+## [1.2.1]
+### Changed
+- Existing calculation changed
+
+## 1.2.0
+### Added
+- Old change
+"""
 
 
 @pytest.fixture

--- a/projects/policyengine-api-simulation/fixtures/test_country_package_update_scripts.py
+++ b/projects/policyengine-api-simulation/fixtures/test_country_package_update_scripts.py
@@ -1,0 +1,183 @@
+"""Fixtures and helpers for country package updater script tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from fixtures.test_modal_scripts import REPO_ROOT, SCRIPTS_DIR
+
+
+SCRIPT = SCRIPTS_DIR / "update-country-package.sh"
+CHANGELOG_SCRIPT = SCRIPTS_DIR / "check-country-package-updates.py"
+
+
+@pytest.fixture
+def changelog_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "check_country_package_updates", CHANGELOG_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    project = tmp_path / "simulation"
+    modal_dir = project / "src" / "modal"
+    modal_dir.mkdir(parents=True)
+
+    (project / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'dependencies = ["policyengine-us==1.0.0", "policyengine-uk==2.0.0"]',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (project / "uv.lock").write_text(
+        "\n".join(
+            [
+                "[[package]]",
+                'name = "policyengine-us"',
+                'version = "1.0.0"',
+                "",
+                "[[package]]",
+                'name = "policyengine-uk"',
+                'version = "2.0.0"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (modal_dir / "app.py").write_text(
+        "\n".join(
+            [
+                "import os",
+                'US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.0.0")',
+                'UK_VERSION = os.environ.get("POLICYENGINE_UK_VERSION", "2.0.0")',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    helper_dir = tmp_path / ".github" / "scripts"
+    helper_dir.mkdir(parents=True)
+    (helper_dir / "check-country-package-updates.py").write_text(
+        '#!/usr/bin/env python3\nprint("### Added\\n- Example upstream change")\n',
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+@pytest.fixture
+def fake_bin(tmp_path: Path) -> Path:
+    path = tmp_path / "bin"
+    path.mkdir()
+    return path
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def install_fake_git(
+    fake_bin: Path,
+    *,
+    root: Path,
+    log: Path,
+    remote_branch_exists: bool = False,
+    diff_has_changes: bool = False,
+) -> None:
+    write_executable(
+        fake_bin / "git",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'git %s\\n' "$*" >> "{log}"
+
+if [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
+  echo "{root}"
+  exit 0
+fi
+
+if [[ "$1" == "ls-remote" ]]; then
+  if [[ "{int(remote_branch_exists)}" == "1" ]]; then
+    exit 0
+  fi
+  exit 2
+fi
+
+if [[ "$1" == "diff" ]]; then
+  if [[ "{int(diff_has_changes)}" == "1" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 0
+""",
+    )
+
+
+def install_fake_gh(fake_bin: Path, *, log: Path, open_pr: str = "") -> None:
+    write_executable(
+        fake_bin / "gh",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh %s\\n' "$*" >> "{log}"
+
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf '%s\\n' "{open_pr}"
+  exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "create" ]]; then
+  exit 0
+fi
+
+exit 0
+""",
+    )
+
+
+def install_fake_uv(fake_bin: Path, *, log: Path) -> None:
+    write_executable(
+        fake_bin / "uv",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'uv %s\\n' "$*" >> "{log}"
+exit 0
+""",
+    )
+
+
+def updater_env(fake_bin: Path, fake_repo: Path, **extra: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "PROJECT_DIR": "simulation",
+        }
+    )
+    env.update(extra)
+    return env
+
+
+def run_updater(*args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -14,7 +14,7 @@ from src.modal._image_setup import snapshot_models
 from src.modal.logging_redaction import redact_params_for_logging
 
 # Get versions from environment or use defaults
-US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.690.7")
+US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.691.3")
 UK_VERSION = os.environ.get("POLICYENGINE_UK_VERSION", "2.88.14")
 
 

--- a/projects/policyengine-api-simulation/tests/test_country_package_update_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_country_package_update_scripts.py
@@ -1,0 +1,385 @@
+"""Unit tests for country package updater scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from fixtures.test_modal_scripts import REPO_ROOT, SCRIPTS_DIR
+
+
+SCRIPT = SCRIPTS_DIR / "update-country-package.sh"
+CHANGELOG_SCRIPT = SCRIPTS_DIR / "check-country-package-updates.py"
+
+
+@pytest.fixture
+def changelog_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "check_country_package_updates", CHANGELOG_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    project = tmp_path / "simulation"
+    modal_dir = project / "src" / "modal"
+    modal_dir.mkdir(parents=True)
+
+    (project / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'dependencies = ["policyengine-us==1.0.0", "policyengine-uk==2.0.0"]',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (project / "uv.lock").write_text(
+        "\n".join(
+            [
+                "[[package]]",
+                'name = "policyengine-us"',
+                'version = "1.0.0"',
+                "",
+                "[[package]]",
+                'name = "policyengine-uk"',
+                'version = "2.0.0"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (modal_dir / "app.py").write_text(
+        "\n".join(
+            [
+                "import os",
+                'US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.0.0")',
+                'UK_VERSION = os.environ.get("POLICYENGINE_UK_VERSION", "2.0.0")',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    helper_dir = tmp_path / ".github" / "scripts"
+    helper_dir.mkdir(parents=True)
+    (helper_dir / "check-country-package-updates.py").write_text(
+        '#!/usr/bin/env python3\nprint("### Added\\n- Example upstream change")\n',
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+@pytest.fixture
+def fake_bin(tmp_path: Path) -> Path:
+    path = tmp_path / "bin"
+    path.mkdir()
+    return path
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def install_fake_git(
+    fake_bin: Path,
+    *,
+    root: Path,
+    log: Path,
+    remote_branch_exists: bool = False,
+    diff_has_changes: bool = False,
+) -> None:
+    write_executable(
+        fake_bin / "git",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'git %s\\n' "$*" >> "{log}"
+
+if [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
+  echo "{root}"
+  exit 0
+fi
+
+if [[ "$1" == "ls-remote" ]]; then
+  if [[ "{int(remote_branch_exists)}" == "1" ]]; then
+    exit 0
+  fi
+  exit 2
+fi
+
+if [[ "$1" == "diff" ]]; then
+  if [[ "{int(diff_has_changes)}" == "1" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 0
+""",
+    )
+
+
+def install_fake_gh(fake_bin: Path, *, log: Path, open_pr: str = "") -> None:
+    write_executable(
+        fake_bin / "gh",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh %s\\n' "$*" >> "{log}"
+
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  printf '%s\\n' "{open_pr}"
+  exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "create" ]]; then
+  exit 0
+fi
+
+exit 0
+""",
+    )
+
+
+def install_fake_uv(fake_bin: Path, *, log: Path) -> None:
+    write_executable(
+        fake_bin / "uv",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'uv %s\\n' "$*" >> "{log}"
+exit 0
+""",
+    )
+
+
+def updater_env(fake_bin: Path, fake_repo: Path, **extra: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "PROJECT_DIR": "simulation",
+        }
+    )
+    env.update(extra)
+    return env
+
+
+def run_updater(*args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_update_country_package_script_has_valid_bash_syntax() -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_update_country_package_rejects_unknown_package(
+    fake_bin: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    git_log = tmp_path / "git.log"
+    install_fake_git(fake_bin, root=fake_repo, log=git_log)
+
+    result = run_updater(
+        "policyengine-ca",
+        env=updater_env(fake_bin, fake_repo, LATEST_OVERRIDE="1.1.0"),
+    )
+
+    assert result.returncode != 0
+    assert "Unsupported package 'policyengine-ca'" in result.stderr
+
+
+def test_update_country_package_dry_run_reports_planned_changes_without_editing(
+    fake_bin: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    git_log = tmp_path / "git.log"
+    install_fake_git(fake_bin, root=fake_repo, log=git_log)
+    pyproject = fake_repo / "simulation" / "pyproject.toml"
+    original_pyproject = pyproject.read_text(encoding="utf-8")
+
+    result = run_updater(
+        "policyengine-us",
+        "--dry-run",
+        env=updater_env(fake_bin, fake_repo, LATEST_OVERRIDE="1.1.0"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Update available: 1.0.0 -> 1.1.0" in result.stdout
+    assert "Dry run: would create auto/update-policyengine-us-1.1.0" in result.stdout
+    assert "simulation/pyproject.toml" in result.stdout
+    assert "simulation/uv.lock" in result.stdout
+    assert "simulation/src/modal/app.py" in result.stdout
+    assert pyproject.read_text(encoding="utf-8") == original_pyproject
+
+
+def test_update_country_package_dry_run_reports_existing_branch_recovery(
+    fake_bin: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    git_log = tmp_path / "git.log"
+    install_fake_git(
+        fake_bin,
+        root=fake_repo,
+        log=git_log,
+        remote_branch_exists=True,
+    )
+
+    result = run_updater(
+        "policyengine-us",
+        "--dry-run",
+        env=updater_env(fake_bin, fake_repo, LATEST_OVERRIDE="1.1.0"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "remote branch 'auto/update-policyengine-us-1.1.0' already exists; "
+        "would ensure a PR exists for it."
+    ) in result.stdout
+
+
+def test_update_country_package_skips_when_open_pr_exists(
+    fake_bin: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    git_log = tmp_path / "git.log"
+    gh_log = tmp_path / "gh.log"
+    install_fake_git(fake_bin, root=fake_repo, log=git_log)
+    install_fake_gh(fake_bin, log=gh_log, open_pr="123")
+
+    result = run_updater(
+        "policyengine-us",
+        env=updater_env(fake_bin, fake_repo, LATEST_OVERRIDE="1.1.0"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "PR #123 already exists for auto/update-policyengine-us-1.1.0" in result.stdout
+    )
+    assert "pr create" not in gh_log.read_text(encoding="utf-8")
+
+
+def test_update_country_package_opens_pr_for_existing_branch_without_open_pr(
+    fake_bin: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    git_log = tmp_path / "git.log"
+    gh_log = tmp_path / "gh.log"
+    install_fake_git(
+        fake_bin,
+        root=fake_repo,
+        log=git_log,
+        remote_branch_exists=True,
+    )
+    install_fake_gh(fake_bin, log=gh_log)
+
+    result = run_updater(
+        "policyengine-us",
+        env=updater_env(fake_bin, fake_repo, LATEST_OVERRIDE="1.1.0"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "already exists without an open PR. Creating PR." in result.stdout
+    gh_calls = gh_log.read_text(encoding="utf-8")
+    assert "pr list" in gh_calls
+    assert "pr create" in gh_calls
+    assert "--head auto/update-policyengine-us-1.1.0" in gh_calls
+
+
+def test_update_country_package_updates_files_and_opens_pr(
+    fake_bin: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    git_log = tmp_path / "git.log"
+    gh_log = tmp_path / "gh.log"
+    uv_log = tmp_path / "uv.log"
+    install_fake_git(fake_bin, root=fake_repo, log=git_log, diff_has_changes=True)
+    install_fake_gh(fake_bin, log=gh_log)
+    install_fake_uv(fake_bin, log=uv_log)
+
+    result = run_updater(
+        "policyengine-us",
+        env=updater_env(fake_bin, fake_repo, LATEST_OVERRIDE="1.1.0"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "PR created for policyengine-us 1.0.0 -> 1.1.0" in result.stdout
+
+    pyproject_text = (fake_repo / "simulation" / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    modal_text = (fake_repo / "simulation" / "src" / "modal" / "app.py").read_text(
+        encoding="utf-8"
+    )
+    assert "policyengine-us==1.1.0" in pyproject_text
+    assert (
+        'US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.1.0")' in modal_text
+    )
+    assert "lock --upgrade-package policyengine-us" in uv_log.read_text(
+        encoding="utf-8"
+    )
+    assert "checkout -b auto/update-policyengine-us-1.1.0" in git_log.read_text(
+        encoding="utf-8"
+    )
+    assert "pr create" in gh_log.read_text(encoding="utf-8")
+
+
+def test_parse_changelog_collects_versioned_category_items(
+    changelog_module: ModuleType,
+) -> None:
+    text = """
+# Changelog
+
+## 1.2.2
+### Added
+- New variable
+
+### Fixed
+- Important bug fix
+
+## [1.2.1]
+### Changed
+- Existing calculation changed
+
+## 1.2.0
+### Added
+- Old change
+"""
+
+    parsed = changelog_module.parse_changelog(text)
+    changes = changelog_module.get_changes_between(parsed, "1.2.0", "1.2.2")
+    formatted = changelog_module.format_changes(changes)
+
+    assert "### Added\n- New variable" in formatted
+    assert "### Changed\n- Existing calculation changed" in formatted
+    assert "### Fixed\n- Important bug fix" in formatted
+    assert "Old change" not in formatted
+
+
+def test_parse_version_requires_three_numeric_parts(
+    changelog_module: ModuleType,
+) -> None:
+    assert changelog_module.parse_version("1.2.3") == (1, 2, 3)
+
+    with pytest.raises(ValueError, match="Expected a semantic version"):
+        changelog_module.parse_version("1.2")
+
+
+def test_fetch_changelog_returns_none_for_unknown_package(
+    changelog_module: ModuleType,
+) -> None:
+    assert changelog_module.fetch_changelog("policyengine-ca") is None

--- a/projects/policyengine-api-simulation/tests/test_country_package_update_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_country_package_update_scripts.py
@@ -9,6 +9,7 @@ from types import ModuleType
 import pytest
 
 from fixtures.test_country_package_update_scripts import (
+    SAMPLE_CHANGELOG,
     SCRIPT,
     install_fake_gh,
     install_fake_git,
@@ -178,26 +179,7 @@ def test_update_country_package_updates_files_and_opens_pr(
 def test_parse_changelog_collects_versioned_category_items(
     changelog_module: ModuleType,
 ) -> None:
-    text = """
-# Changelog
-
-## 1.2.2
-### Added
-- New variable
-
-### Fixed
-- Important bug fix
-
-## [1.2.1]
-### Changed
-- Existing calculation changed
-
-## 1.2.0
-### Added
-- Old change
-"""
-
-    parsed = changelog_module.parse_changelog(text)
+    parsed = changelog_module.parse_changelog(SAMPLE_CHANGELOG)
     changes = changelog_module.get_changes_between(parsed, "1.2.0", "1.2.2")
     formatted = changelog_module.format_changes(changes)
 

--- a/projects/policyengine-api-simulation/tests/test_country_package_update_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_country_package_update_scripts.py
@@ -2,185 +2,22 @@
 
 from __future__ import annotations
 
-import importlib.util
-import os
 import subprocess
 from pathlib import Path
 from types import ModuleType
 
 import pytest
 
-from fixtures.test_modal_scripts import REPO_ROOT, SCRIPTS_DIR
+from fixtures.test_country_package_update_scripts import (
+    SCRIPT,
+    install_fake_gh,
+    install_fake_git,
+    install_fake_uv,
+    run_updater,
+    updater_env,
+)
 
-
-SCRIPT = SCRIPTS_DIR / "update-country-package.sh"
-CHANGELOG_SCRIPT = SCRIPTS_DIR / "check-country-package-updates.py"
-
-
-@pytest.fixture
-def changelog_module() -> ModuleType:
-    spec = importlib.util.spec_from_file_location(
-        "check_country_package_updates", CHANGELOG_SCRIPT
-    )
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-@pytest.fixture
-def fake_repo(tmp_path: Path) -> Path:
-    project = tmp_path / "simulation"
-    modal_dir = project / "src" / "modal"
-    modal_dir.mkdir(parents=True)
-
-    (project / "pyproject.toml").write_text(
-        "\n".join(
-            [
-                "[project]",
-                'dependencies = ["policyengine-us==1.0.0", "policyengine-uk==2.0.0"]',
-            ]
-        ),
-        encoding="utf-8",
-    )
-    (project / "uv.lock").write_text(
-        "\n".join(
-            [
-                "[[package]]",
-                'name = "policyengine-us"',
-                'version = "1.0.0"',
-                "",
-                "[[package]]",
-                'name = "policyengine-uk"',
-                'version = "2.0.0"',
-            ]
-        ),
-        encoding="utf-8",
-    )
-    (modal_dir / "app.py").write_text(
-        "\n".join(
-            [
-                "import os",
-                'US_VERSION = os.environ.get("POLICYENGINE_US_VERSION", "1.0.0")',
-                'UK_VERSION = os.environ.get("POLICYENGINE_UK_VERSION", "2.0.0")',
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    helper_dir = tmp_path / ".github" / "scripts"
-    helper_dir.mkdir(parents=True)
-    (helper_dir / "check-country-package-updates.py").write_text(
-        '#!/usr/bin/env python3\nprint("### Added\\n- Example upstream change")\n',
-        encoding="utf-8",
-    )
-
-    return tmp_path
-
-
-@pytest.fixture
-def fake_bin(tmp_path: Path) -> Path:
-    path = tmp_path / "bin"
-    path.mkdir()
-    return path
-
-
-def write_executable(path: Path, content: str) -> None:
-    path.write_text(content, encoding="utf-8")
-    path.chmod(0o755)
-
-
-def install_fake_git(
-    fake_bin: Path,
-    *,
-    root: Path,
-    log: Path,
-    remote_branch_exists: bool = False,
-    diff_has_changes: bool = False,
-) -> None:
-    write_executable(
-        fake_bin / "git",
-        f"""#!/usr/bin/env bash
-set -euo pipefail
-printf 'git %s\\n' "$*" >> "{log}"
-
-if [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
-  echo "{root}"
-  exit 0
-fi
-
-if [[ "$1" == "ls-remote" ]]; then
-  if [[ "{int(remote_branch_exists)}" == "1" ]]; then
-    exit 0
-  fi
-  exit 2
-fi
-
-if [[ "$1" == "diff" ]]; then
-  if [[ "{int(diff_has_changes)}" == "1" ]]; then
-    exit 1
-  fi
-  exit 0
-fi
-
-exit 0
-""",
-    )
-
-
-def install_fake_gh(fake_bin: Path, *, log: Path, open_pr: str = "") -> None:
-    write_executable(
-        fake_bin / "gh",
-        f"""#!/usr/bin/env bash
-set -euo pipefail
-printf 'gh %s\\n' "$*" >> "{log}"
-
-if [[ "$1" == "pr" && "$2" == "list" ]]; then
-  printf '%s\\n' "{open_pr}"
-  exit 0
-fi
-
-if [[ "$1" == "pr" && "$2" == "create" ]]; then
-  exit 0
-fi
-
-exit 0
-""",
-    )
-
-
-def install_fake_uv(fake_bin: Path, *, log: Path) -> None:
-    write_executable(
-        fake_bin / "uv",
-        f"""#!/usr/bin/env bash
-set -euo pipefail
-printf 'uv %s\\n' "$*" >> "{log}"
-exit 0
-""",
-    )
-
-
-def updater_env(fake_bin: Path, fake_repo: Path, **extra: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env.update(
-        {
-            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
-            "PROJECT_DIR": "simulation",
-        }
-    )
-    env.update(extra)
-    return env
-
-
-def run_updater(*args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", str(SCRIPT), *args],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+pytest_plugins = ("fixtures.test_country_package_update_scripts",)
 
 
 def test_update_country_package_script_has_valid_bash_syntax() -> None:


### PR DESCRIPTION
Fixes #492

## Summary
- Add a scheduled country package updater for `policyengine-us` and `policyengine-uk`.
- Create version-specific updater branches and PRs, preserving multiple independent update streams.
- Recover existing remote updater branches that do not have an open PR by opening the missing PR instead of silently skipping.
- Update simulation `pyproject.toml`, `uv.lock`, and Modal fallback constants when a country package moves.
- Add hermetic unit tests for the updater shell script and changelog parser.
- Align the existing `POLICYENGINE_US_VERSION` fallback with the currently pinned `policyengine-us` version.

## Why
The existing generic dependency updater only refreshes lockfiles and cannot move exact country package pins. This restores the explicit country-package update flow used in `policyengine-api` and `policyengine-api-v2-alpha`, adapted to the simulation project in this monorepo.

## Validation
- `bash -n .github/scripts/update-country-package.sh`
- Python compile check for `.github/scripts/check-country-package-updates.py`
- `uv run pytest tests/test_country_package_update_scripts.py`
- `ruff check tests/test_country_package_update_scripts.py`
- `ruff format --check tests/test_country_package_update_scripts.py`
- `git diff --check`
- Dry-run with PyPI lookup for `policyengine-us`: would update `1.691.3 -> 1.700.0`
- Dry-run with PyPI lookup for `policyengine-uk`: would update `2.88.14 -> 2.88.19`
