### PR TITLE
Install FastAPI in simulation worker image

### DIFF
--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -63,6 +63,7 @@ simulation_image = (
         f"policyengine-uk=={UK_VERSION}",
         f"policyengine=={POLICYENGINE_VERSION}",
         f"policyengine-core=={POLICYENGINE_CORE_VERSION}",
+        "fastapi>=0.115.0",
         "tables>=3.10.2",
         "logfire",
     )


### PR DESCRIPTION
Fixes #535

## Summary
- Add `fastapi>=0.115.0` to the Modal simulation worker image so importing `policyengine_api_simulation.*` does not crash at container startup.
- This should unblock both `run_simulation` and `run_budget_window_batch`, which were crash-looping on the same missing dependency.

## Failed deploy evidence
- Deploy run: https://github.com/PolicyEngine/policyengine-api-v2/actions/runs/26595200602
- Beta integration job: https://github.com/PolicyEngine/policyengine-api-v2/actions/runs/26595200602/job/78364306774
- Observed failed tests: `test_calculate_specific_model`, `test_budget_window_multi_year_batch_completes`
- Modal worker logs for `policyengine-simulation-py4-12-0` showed `ModuleNotFoundError: No module named 'fastapi'` while importing `policyengine_api_simulation.release_bundle` through package `__init__`.

## Testing
- `uv run ruff format --check src/modal/app.py`
- `uv run pytest tests/test_policyengine_dependency_source.py -q`
- `uv run python -c "import src.modal.app; print(src.modal.app.APP_NAME)"`