### PR TITLE
Fix private UK dataset resolution

### DIFF
--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/dataset_uri.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/dataset_uri.py
@@ -81,7 +81,6 @@ def runtime_dataset_uri(
         return validate_hf_dataset_uri(dataset_uri)
 
     if selected_revision is not None:
-        with_hf_revision(dataset_uri, selected_revision)
         return f"gs://{bucket}/{parsed.path}@{selected_revision}"
 
     return f"gs://{bucket}/{parsed.path}"

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -5,10 +5,15 @@ Tests verify the endpoint correctly resolves app names and routes
 simulation requests.
 """
 
+from copy import deepcopy
+
 import pytest
 from fastapi.testclient import TestClient
 
-from fixtures.gateway.test_endpoints import resolve_test_dataset_uri
+from fixtures.gateway.test_endpoints import (
+    TEST_APP_RELEASE_BUNDLE,
+    resolve_test_dataset_uri,
+)
 from policyengine_api_simulation.hf_dataset import HuggingFaceDatasetReferenceError
 
 
@@ -383,7 +388,7 @@ class TestSubmitSimulationEndpoint:
         assert response.status_code == 400
         assert mock_modal["func"].last_payload is None
 
-    def test__given_submission_with_invalid_hf_revision__then_returns_400_before_spawn(
+    def test__given_submission_with_invalid_unmanaged_hf_revision__then_returns_400_before_spawn(
         self, mock_modal, client: TestClient, monkeypatch
     ):
         mock_modal["dicts"]["simulation-api-us-versions"] = {
@@ -405,7 +410,7 @@ class TestSubmitSimulationEndpoint:
                 "country": "us",
                 "scope": "macro",
                 "reform": {},
-                "data": "enhanced_cps_2024@does-not-exist",
+                "data": "hf://external/example-data/file.h5@does-not-exist",
             },
         )
 
@@ -434,6 +439,54 @@ class TestSubmitSimulationEndpoint:
         data = response.json()
         assert data["policyengine_bundle"]["dataset"] == resolve_test_dataset_uri(
             "uk", "enhanced_frs"
+        )
+
+    def test__given_uk_submission_without_data_and_manifest_commit__then_resolves_gcs_default(
+        self,
+        mock_modal,
+        client: TestClient,
+        monkeypatch,
+    ):
+        app_name = "policyengine-simulation-py4-13-1"
+        manifest_uri = (
+            "hf://policyengine/policyengine-uk-data-private/"
+            "enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
+        )
+        bundle = deepcopy(TEST_APP_RELEASE_BUNDLE)
+        bundle["app_name"] = app_name
+        bundle["policyengine_version"] = "4.13.1"
+        bundle["uk"]["model_version"] = "2.88.20"
+        bundle["uk"]["data_version"] = "1.55.10"
+        bundle["uk"]["default_dataset_uri"] = manifest_uri
+        bundle["uk"]["dataset_uris"]["enhanced_frs_2023_24"] = manifest_uri
+        mock_modal["dicts"]["simulation-api-uk-versions"] = {
+            "2.88.20": app_name,
+        }
+        mock_modal["dicts"]["simulation-api-app-release-bundles"][app_name] = bundle
+
+        def reject_revision(dataset_uri, revision):
+            raise HuggingFaceDatasetReferenceError(
+                f"HF validation should not run for private GCS data: {dataset_uri}@{revision}"
+            )
+
+        monkeypatch.setattr(
+            "policyengine_api_simulation.dataset_uri.with_hf_revision",
+            reject_revision,
+        )
+
+        response = client.post(
+            "/simulate/economy/comparison",
+            json={
+                "country": "uk",
+                "version": "2.88.20",
+                "scope": "macro",
+                "reform": {},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["policyengine_bundle"]["dataset"] == (
+            "gs://policyengine-uk-data-private/enhanced_frs_2023_24.h5@1.55.10"
         )
 
     def test__given_submission_with_runtime_bundle__then_accepts_internal_provenance(

--- a/projects/policyengine-api-simulation/tests/test_dataset_uri.py
+++ b/projects/policyengine-api-simulation/tests/test_dataset_uri.py
@@ -1,0 +1,54 @@
+"""Tests for dataset URI normalization."""
+
+import pytest
+
+from policyengine_api_simulation.dataset_uri import runtime_dataset_uri
+
+
+def test_runtime_dataset_uri_converts_policyengine_hf_to_gcs_without_hf_validation(
+    monkeypatch,
+):
+    def reject_hf_validation(dataset_uri: str, revision: str) -> str:
+        raise AssertionError(
+            f"HF validation should not run for PolicyEngine GCS data: {dataset_uri}@{revision}"
+        )
+
+    monkeypatch.setattr(
+        "policyengine_api_simulation.dataset_uri.with_hf_revision",
+        reject_hf_validation,
+    )
+
+    assert (
+        runtime_dataset_uri(
+            "hf://policyengine/policyengine-uk-data-private/"
+            "enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f",
+            default_revision="1.55.10",
+        )
+        == "gs://policyengine-uk-data-private/enhanced_frs_2023_24.h5@1.55.10"
+    )
+
+
+def test_runtime_dataset_uri_still_validates_unmanaged_hf_revisions(monkeypatch):
+    def pin_hf_revision(dataset_uri: str, revision: str) -> str:
+        return f"{dataset_uri.rsplit('@', maxsplit=1)[0]}@{revision}"
+
+    monkeypatch.setattr(
+        "policyengine_api_simulation.dataset_uri.with_hf_revision",
+        pin_hf_revision,
+    )
+
+    assert (
+        runtime_dataset_uri(
+            "hf://external/example-data/file.h5@old",
+            default_revision="new",
+        )
+        == "hf://external/example-data/file.h5@new"
+    )
+
+
+def test_runtime_dataset_uri_rejects_conflicting_gcs_revisions():
+    with pytest.raises(ValueError, match="Conflicting dataset revisions"):
+        runtime_dataset_uri(
+            "gs://policyengine-uk-data-private/enhanced_frs_2023_24.h5@commit",
+            default_revision="1.55.10",
+        )

--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
@@ -72,6 +72,24 @@ def poll_for_completion(
     raise TimeoutError(f"Job {job_id} did not complete within {max_wait_seconds}s")
 
 
+def submit_simulation_request(
+    client: Client | AuthenticatedClient,
+    request: SimulationRequest,
+) -> JobSubmitResponse:
+    response = submit_simulation_simulate_economy_comparison_post.sync_detailed(
+        client=client,
+        body=request,
+    )
+    assert response.status_code == HTTPStatus.OK, (
+        f"Simulation submit failed with status {response.status_code}: "
+        f"{response.content!r}"
+    )
+    assert isinstance(response.parsed, JobSubmitResponse), (
+        f"Unexpected response type: {type(response.parsed)}"
+    )
+    return response.parsed
+
+
 @pytest.mark.beta_only
 def test_calculate_default_model(
     client: Client | AuthenticatedClient,
@@ -99,12 +117,7 @@ def test_calculate_default_model(
     )
 
     # When - submit job
-    submit_response = submit_simulation_simulate_economy_comparison_post.sync(
-        client=client, body=request
-    )
-    assert isinstance(submit_response, JobSubmitResponse), (
-        f"Unexpected response type: {type(submit_response)}"
-    )
+    submit_response = submit_simulation_request(client, request)
     job_id = submit_response.job_id
 
     # When - poll for completion
@@ -156,12 +169,7 @@ def test_calculate_specific_model(
     )
 
     # When - submit job
-    submit_response = submit_simulation_simulate_economy_comparison_post.sync(
-        client=client, body=request
-    )
-    assert isinstance(submit_response, JobSubmitResponse), (
-        f"Unexpected response type: {type(submit_response)}"
-    )
+    submit_response = submit_simulation_request(client, request)
     assert submit_response.version == us_model_version, (
         f"Version mismatch: expected {us_model_version}, got {submit_response.version}"
     )
@@ -206,12 +214,7 @@ def test_calculate_uk_model(
     )
 
     # When - submit job
-    submit_response = submit_simulation_simulate_economy_comparison_post.sync(
-        client=client, body=request
-    )
-    assert isinstance(submit_response, JobSubmitResponse), (
-        f"Unexpected response type: {type(submit_response)}"
-    )
+    submit_response = submit_simulation_request(client, request)
     assert submit_response.version == uk_model_version, (
         f"Version mismatch: expected {uk_model_version}, got {submit_response.version}"
     )


### PR DESCRIPTION
Fixes #547

Failed deploy: https://github.com/PolicyEngine/policyengine-api-v2/actions/runs/26779067327

## Summary
- Convert PolicyEngine-managed HF dataset URIs directly to GCS runtime URIs without gateway-side HF validation.
- Preserve HF revision validation for unmanaged external HF dataset URIs.
- Add regression coverage for UK no-`data` submissions where the bundle default is a private HF manifest URI with a separate data package version.
- Make simulation integration submit failures report status/body via `sync_detailed()`.

## Tests
- `uv run pytest tests/test_dataset_uri.py tests/gateway/test_endpoints.py -q`
- `uv run ruff check src/policyengine_api_simulation/dataset_uri.py tests/test_dataset_uri.py tests/gateway/test_endpoints.py`
- `uv run ruff format --check src/policyengine_api_simulation/dataset_uri.py tests/test_dataset_uri.py tests/gateway/test_endpoints.py`
- `uv run ruff check tests/simulation/test_calculate.py`
- `uv run ruff format --check tests/simulation/test_calculate.py`