### PR TITLE
Fix regional simulation dataset revisions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,5 @@
 - bump: patch
   changes:
-    changed:
-      - Bumped policyengine-core minimum version to 3.23.5 for pandas 3.0 compatibility
+    fixed:
+      - Resolved PolicyEngine-managed regional datasets using bundled data versions instead of release-manifest commit hashes when loading from GCS
+      - Added a Modal app-release bundle backfill for missing data artifact revisions

--- a/projects/policyengine-api-simulation/fixtures/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/fixtures/gateway/test_endpoints.py
@@ -8,6 +8,7 @@ TEST_APP_RELEASE_BUNDLE = {
     "us": {
         "model_version": "1.500.0",
         "data_version": "1.110.12",
+        "data_artifact_revision": "1.110.12",
         "default_dataset": "enhanced_cps_2024",
         "default_dataset_uri": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.110.12",
         "dataset_uris": {
@@ -27,6 +28,7 @@ TEST_APP_RELEASE_BUNDLE = {
     "uk": {
         "model_version": "2.66.0",
         "data_version": "1.40.3",
+        "data_artifact_revision": "1.40.3",
         "default_dataset": "enhanced_frs_2023_24",
         "default_dataset_uri": "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@1.40.3",
         "dataset_uris": {
@@ -62,6 +64,11 @@ def _runtime_dataset_uri(
     selected_revision = revision or existing_revision
 
     if dataset_without_revision.startswith("hf://policyengine/"):
+        if (
+            selected_revision == country_bundle.get("data_artifact_revision")
+            and revision is None
+        ):
+            selected_revision = country_bundle["data_version"]
         remainder = dataset_without_revision.removeprefix("hf://policyengine/")
         bucket, _, path = remainder.partition("/")
         dataset_without_revision = f"gs://{bucket}/{path}"

--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -76,6 +76,11 @@ def _country_bundle_data_version(country_bundle: dict) -> str | None:
     return data_version if isinstance(data_version, str) else None
 
 
+def _country_bundle_data_artifact_revision(country_bundle: dict) -> str | None:
+    artifact_revision = country_bundle.get("data_artifact_revision")
+    return artifact_revision if isinstance(artifact_revision, str) else None
+
+
 def _resolve_dataset_uri_from_app_bundle(
     *,
     app_bundle: dict,
@@ -93,9 +98,9 @@ def _resolve_dataset_uri_from_app_bundle(
             return None
         return runtime_dataset_uri(
             default_uri,
-            default_revision=(
-                requested_data_version or _country_bundle_data_version(country_bundle)
-            ),
+            default_revision=_country_bundle_data_version(country_bundle),
+            override_revision=requested_data_version,
+            artifact_revision=_country_bundle_data_artifact_revision(country_bundle),
         )
 
     requested_without_revision, requested_revision = _split_requested_revision(
@@ -110,16 +115,30 @@ def _resolve_dataset_uri_from_app_bundle(
         if isinstance(country_bundle, dict)
         else None
     )
+    artifact_revision = (
+        _country_bundle_data_artifact_revision(country_bundle)
+        if isinstance(country_bundle, dict)
+        else None
+    )
 
     if "://" in requested_without_revision:
+        runtime_input = (
+            requested_data
+            if requested_revision is not None and requested_data_version is None
+            else requested_without_revision
+        )
         if requested_without_revision.startswith("hf://"):
             return runtime_dataset_uri(
-                requested_without_revision,
-                default_revision=revision or bundle_data_version,
+                runtime_input,
+                default_revision=bundle_data_version,
+                override_revision=(
+                    revision if requested_data_version is not None else None
+                ),
+                artifact_revision=artifact_revision,
             )
         if requested_without_revision.startswith("gs://"):
             return runtime_dataset_uri(
-                requested_without_revision,
+                runtime_input,
                 default_revision=revision,
             )
         return requested_data
@@ -135,7 +154,9 @@ def _resolve_dataset_uri_from_app_bundle(
     if "://" in dataset_name:
         return runtime_dataset_uri(
             dataset_name,
-            default_revision=revision or bundle_data_version,
+            default_revision=bundle_data_version,
+            override_revision=revision,
+            artifact_revision=artifact_revision,
         )
 
     dataset_uris = country_bundle.get("dataset_uris")
@@ -146,7 +167,9 @@ def _resolve_dataset_uri_from_app_bundle(
         return requested_data
     return runtime_dataset_uri(
         dataset_uri,
-        default_revision=revision or bundle_data_version,
+        default_revision=bundle_data_version,
+        override_revision=revision,
+        artifact_revision=artifact_revision,
     )
 
 

--- a/projects/policyengine-api-simulation/src/modal/utils/update_version_registry.py
+++ b/projects/policyengine-api-simulation/src/modal/utils/update_version_registry.py
@@ -19,12 +19,18 @@ Usage:
         --us-version 1.459.0 \
         --uk-version 2.65.9 \
         --environment staging
+
+    uv run python -m src.modal.utils.update_version_registry \
+        --environment staging \
+        --backfill-app-release-bundles
 """
 
 import argparse
 import modal
 from packaging.version import InvalidVersion, Version
-from typing import TypedDict
+from typing import Any, TypedDict
+
+from policyengine_api_simulation.dataset_uri import split_dataset_revision
 
 POLICYENGINE_VERSION_DICT_NAME = "simulation-api-policyengine-versions"
 US_VERSION_DICT_NAME = "simulation-api-us-versions"
@@ -38,6 +44,7 @@ class CountryBundleMetadata(TypedDict):
     model_version: str
     data_package_name: str
     data_version: str
+    data_artifact_revision: str
     default_dataset: str
     default_dataset_uri: str
     dataset_uris: dict[str, str]
@@ -149,6 +156,7 @@ def _country_bundle_metadata(country: str) -> CountryBundleMetadata:
         "model_version": bundle.model_version,
         "data_package_name": bundle.data_package_name,
         "data_version": bundle.data_version,
+        "data_artifact_revision": bundle.data_artifact_revision,
         "default_dataset": bundle.default_dataset,
         "default_dataset_uri": bundle.default_dataset_uri,
         "dataset_uris": dict(bundle.dataset_uris),
@@ -167,6 +175,91 @@ def build_app_release_bundle_metadata(
         "us": _country_bundle_metadata("us"),
         "uk": _country_bundle_metadata("uk"),
     }
+
+
+def _dataset_revision(dataset_uri: object) -> str | None:
+    if not isinstance(dataset_uri, str):
+        return None
+    try:
+        _, revision = split_dataset_revision(dataset_uri)
+    except ValueError:
+        return None
+    return revision
+
+
+def _infer_data_artifact_revision(country_bundle: dict[str, Any]) -> str | None:
+    candidates: list[object] = [country_bundle.get("default_dataset_uri")]
+    default_dataset = country_bundle.get("default_dataset")
+    dataset_uris = country_bundle.get("dataset_uris")
+    if isinstance(default_dataset, str) and isinstance(dataset_uris, dict):
+        candidates.append(dataset_uris.get(default_dataset))
+    if isinstance(dataset_uris, dict):
+        candidates.extend(dataset_uris.values())
+
+    for candidate in candidates:
+        revision = _dataset_revision(candidate)
+        if revision is not None:
+            return revision
+
+    data_version = country_bundle.get("data_version")
+    return data_version if isinstance(data_version, str) and data_version else None
+
+
+def _backfill_country_bundle(
+    country_bundle: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    existing_revision = country_bundle.get("data_artifact_revision")
+    if isinstance(existing_revision, str) and existing_revision:
+        return country_bundle, False
+
+    artifact_revision = _infer_data_artifact_revision(country_bundle)
+    if artifact_revision is None:
+        return country_bundle, False
+
+    updated = dict(country_bundle)
+    updated["data_artifact_revision"] = artifact_revision
+    return updated, True
+
+
+def backfill_app_release_bundle_metadata(
+    metadata: object,
+) -> tuple[dict[str, Any] | None, bool]:
+    if not isinstance(metadata, dict):
+        return None, False
+
+    updated_metadata = dict(metadata)
+    changed = False
+    for country in ("us", "uk"):
+        country_bundle = metadata.get(country)
+        if not isinstance(country_bundle, dict):
+            continue
+        updated_country_bundle, country_changed = _backfill_country_bundle(
+            country_bundle
+        )
+        if country_changed:
+            updated_metadata[country] = updated_country_bundle
+            changed = True
+
+    return updated_metadata, changed
+
+
+def backfill_app_release_bundles(*, environment: str) -> int:
+    bundle_store = modal.Dict.from_name(
+        APP_RELEASE_BUNDLES_DICT_NAME,
+        environment_name=environment,
+        create_if_missing=True,
+    )
+
+    updated_count = 0
+    for key, metadata in list(bundle_store.items()):
+        updated_metadata, changed = backfill_app_release_bundle_metadata(metadata)
+        if not changed or updated_metadata is None:
+            continue
+        bundle_store[key] = updated_metadata
+        updated_count += 1
+        print(f"  {APP_RELEASE_BUNDLES_DICT_NAME}[{key}]: backfilled")
+
+    return updated_count
 
 
 def put_app_release_bundle_metadata(
@@ -195,22 +288,18 @@ def main():
     )
     parser.add_argument(
         "--app-name",
-        required=True,
         help="Versioned app name (e.g., policyengine-simulation-py4-10-0)",
     )
     parser.add_argument(
         "--policyengine-version",
-        required=True,
         help="policyengine.py package version (e.g., 4.10.0)",
     )
     parser.add_argument(
         "--us-version",
-        required=True,
         help="US package version (e.g., 1.459.0)",
     )
     parser.add_argument(
         "--uk-version",
-        required=True,
         help="UK package version (e.g., 2.65.9)",
     )
     parser.add_argument(
@@ -226,7 +315,37 @@ def main():
             "the currently recorded latest (use for intentional rollbacks)."
         ),
     )
+    parser.add_argument(
+        "--backfill-app-release-bundles",
+        action="store_true",
+        help=(
+            "Populate missing data_artifact_revision fields in existing app-release "
+            "bundle metadata without changing version routing."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.backfill_app_release_bundles:
+        print(
+            "Backfilling app release bundle metadata in Modal environment: "
+            f"{args.environment}"
+        )
+        updated_count = backfill_app_release_bundles(environment=args.environment)
+        print(f"Backfilled {updated_count} app release bundle entries.")
+        return
+
+    required_args = {
+        "--app-name": args.app_name,
+        "--policyengine-version": args.policyengine_version,
+        "--us-version": args.us_version,
+        "--uk-version": args.uk_version,
+    }
+    missing_args = [name for name, value in required_args.items() if not value]
+    if missing_args:
+        parser.error(
+            "the following arguments are required unless "
+            f"--backfill-app-release-bundles is set: {', '.join(missing_args)}"
+        )
 
     print(f"Updating version registries in Modal environment: {args.environment}")
     print(f"  App name: {args.app_name}")

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/dataset_uri.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/dataset_uri.py
@@ -60,11 +60,13 @@ def runtime_dataset_uri(
     dataset_uri: str,
     *,
     default_revision: str | None = None,
+    override_revision: str | None = None,
+    artifact_revision: str | None = None,
 ) -> str:
     """Convert PolicyEngine HF data artifacts to their GCS runtime URI."""
 
     if dataset_uri.startswith("gs://"):
-        return _with_gs_revision(dataset_uri, default_revision)
+        return _with_gs_revision(dataset_uri, override_revision or default_revision)
 
     if not dataset_uri.startswith("hf://"):
         return dataset_uri
@@ -74,9 +76,21 @@ def runtime_dataset_uri(
         return dataset_uri
 
     bucket = _policyengine_gcs_bucket_for_hf_repo(parsed.repo_id)
-    selected_revision = default_revision or parsed.revision
+    selected_revision = parsed.revision
+    if override_revision is not None:
+        selected_revision = override_revision
+    elif (
+        default_revision is not None
+        and artifact_revision is not None
+        and parsed.revision == artifact_revision
+    ):
+        selected_revision = default_revision
+    elif selected_revision is None:
+        selected_revision = default_revision
     if bucket is None:
-        if default_revision is not None:
+        if override_revision is not None:
+            return with_hf_revision(dataset_uri, override_revision)
+        if default_revision is not None and parsed.revision is None:
             return with_hf_revision(dataset_uri, default_revision)
         return validate_hf_dataset_uri(dataset_uri)
 

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
@@ -51,6 +51,7 @@ class CountryReleaseBundle:
     model_version: str
     data_package_name: str
     data_version: str
+    data_artifact_revision: str
     default_dataset: str
     default_dataset_uri: str
     dataset_uris: Mapping[str, str]
@@ -91,6 +92,7 @@ def get_country_release_bundle(country: str) -> CountryReleaseBundle:
         model_version=manifest.model_package.version,
         data_package_name=manifest.data_package.name,
         data_version=manifest.data_package.version,
+        data_artifact_revision=_artifact_revision(manifest.data_package),
         default_dataset=manifest.default_dataset,
         default_dataset_uri=manifest.default_dataset_uri,
         dataset_uris=dataset_uris,
@@ -154,7 +156,9 @@ def resolve_runtime_bundle_dataset_uri(
     if requested_data is None:
         return runtime_dataset_uri(
             bundle.default_dataset_uri,
-            default_revision=requested_data_version or bundle.data_version,
+            default_revision=bundle.data_version,
+            override_revision=requested_data_version,
+            artifact_revision=bundle.data_artifact_revision,
         )
 
     requested_without_revision, requested_revision = split_dataset_revision(
@@ -166,12 +170,21 @@ def resolve_runtime_bundle_dataset_uri(
     )
 
     if "://" in requested_without_revision:
-        default_revision = revision
-        if requested_without_revision.startswith("hf://"):
-            default_revision = revision or bundle.data_version
+        override_revision = revision if requested_data_version is not None else None
+        runtime_input = (
+            requested_data
+            if requested_revision is not None and requested_data_version is None
+            else requested_without_revision
+        )
         return runtime_dataset_uri(
-            requested_without_revision,
-            default_revision=default_revision,
+            runtime_input,
+            default_revision=(
+                bundle.data_version
+                if requested_without_revision.startswith("hf://")
+                else None
+            ),
+            override_revision=override_revision,
+            artifact_revision=bundle.data_artifact_revision,
         )
 
     dataset_uri = resolve_bundle_dataset_uri(country, requested_without_revision)
@@ -185,5 +198,7 @@ def resolve_runtime_bundle_dataset_uri(
 
     return runtime_dataset_uri(
         dataset_uri,
-        default_revision=revision or bundle.data_version,
+        default_revision=bundle.data_version,
+        override_revision=revision,
+        artifact_revision=bundle.data_artifact_revision,
     )

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
@@ -17,6 +17,7 @@ from typing import Any, Iterator
 
 from policyengine_api_simulation.dataset_uri import runtime_dataset_uri
 from policyengine_api_simulation.release_bundle import (
+    get_country_release_bundle,
     resolve_runtime_bundle_dataset_uri,
 )
 from policyengine_api_simulation.simulation_output_builder import (
@@ -269,10 +270,13 @@ def _region_parent_dataset_reference(
         parent_region = country_module.model.get_region(parent_code)
         parent_dataset_path = getattr(parent_region, "dataset_path", None)
         if isinstance(parent_dataset_path, str):
+            bundle = get_country_release_bundle(country)
             requested_data_version = _requested_data_version(params)
             return runtime_dataset_uri(
                 parent_dataset_path,
-                default_revision=requested_data_version,
+                default_revision=bundle.data_version,
+                override_revision=requested_data_version,
+                artifact_revision=bundle.data_artifact_revision,
             )
     return _resolve_dataset_reference(country, params)
 
@@ -299,9 +303,12 @@ def _resolve_region(
     dataset_path = getattr(region, "dataset_path", None)
     requested_data_version = _requested_data_version(params)
     if isinstance(dataset_path, str):
+        bundle = get_country_release_bundle(country)
         dataset_reference = runtime_dataset_uri(
             dataset_path,
-            default_revision=requested_data_version,
+            default_revision=bundle.data_version,
+            override_revision=requested_data_version,
+            artifact_revision=bundle.data_artifact_revision,
         )
     else:
         dataset_reference = _region_parent_dataset_reference(

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -396,11 +396,11 @@ class TestSubmitSimulationEndpoint:
             "1.500.0": "policyengine-simulation-py4-10-0",
         }
 
-        def reject_revision(dataset_uri, revision):
+        def reject_revision(dataset_uri):
             raise HuggingFaceDatasetReferenceError("revision missing")
 
         monkeypatch.setattr(
-            "policyengine_api_simulation.dataset_uri.with_hf_revision",
+            "policyengine_api_simulation.dataset_uri.validate_hf_dataset_uri",
             reject_revision,
         )
 
@@ -457,6 +457,9 @@ class TestSubmitSimulationEndpoint:
         bundle["policyengine_version"] = "4.13.1"
         bundle["uk"]["model_version"] = "2.88.20"
         bundle["uk"]["data_version"] = "1.55.10"
+        bundle["uk"]["data_artifact_revision"] = (
+            "655dd07e4bb9c777b00dac044949611f1feb824f"
+        )
         bundle["uk"]["default_dataset_uri"] = manifest_uri
         bundle["uk"]["dataset_uris"]["enhanced_frs_2023_24"] = manifest_uri
         mock_modal["dicts"]["simulation-api-uk-versions"] = {

--- a/projects/policyengine-api-simulation/tests/test_dataset_uri.py
+++ b/projects/policyengine-api-simulation/tests/test_dataset_uri.py
@@ -23,8 +23,32 @@ def test_runtime_dataset_uri_converts_policyengine_hf_to_gcs_without_hf_validati
             "hf://policyengine/policyengine-uk-data-private/"
             "enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f",
             default_revision="1.55.10",
+            artifact_revision="655dd07e4bb9c777b00dac044949611f1feb824f",
         )
         == "gs://policyengine-uk-data-private/enhanced_frs_2023_24.h5@1.55.10"
+    )
+
+
+def test_runtime_dataset_uri_preserves_explicit_policyengine_hf_data_version():
+    assert (
+        runtime_dataset_uri(
+            "hf://policyengine/policyengine-us-data/states/CA.h5@1.110.12",
+            default_revision="1.115.5",
+            artifact_revision="d47fb5475144260a75467d2f2e22b2d5d53d4d57",
+        )
+        == "gs://policyengine-us-data/states/CA.h5@1.110.12"
+    )
+
+
+def test_runtime_dataset_uri_override_revision_wins_for_policyengine_hf_uri():
+    assert (
+        runtime_dataset_uri(
+            "hf://policyengine/policyengine-us-data/states/CA.h5@1.110.12",
+            default_revision="1.115.5",
+            override_revision="1.77.0",
+            artifact_revision="d47fb5475144260a75467d2f2e22b2d5d53d4d57",
+        )
+        == "gs://policyengine-us-data/states/CA.h5@1.77.0"
     )
 
 
@@ -40,7 +64,7 @@ def test_runtime_dataset_uri_still_validates_unmanaged_hf_revisions(monkeypatch)
     assert (
         runtime_dataset_uri(
             "hf://external/example-data/file.h5@old",
-            default_revision="new",
+            override_revision="new",
         )
         == "hf://external/example-data/file.h5@new"
     )

--- a/projects/policyengine-api-simulation/tests/test_release_bundle.py
+++ b/projects/policyengine-api-simulation/tests/test_release_bundle.py
@@ -37,10 +37,12 @@ def test_country_release_bundle_exposes_model_and_data_versions():
     assert us_bundle.model_version
     assert us_bundle.data_package_name == "policyengine-us-data"
     assert us_bundle.data_version
+    assert us_bundle.data_artifact_revision
     assert uk_bundle.model_package_name == "policyengine-uk"
     assert uk_bundle.model_version
     assert uk_bundle.data_package_name == "policyengine-uk-data"
     assert uk_bundle.data_version
+    assert uk_bundle.data_artifact_revision
 
 
 def test_resolve_bundle_dataset_name_uses_manifest_default():
@@ -133,6 +135,26 @@ def test_resolve_runtime_bundle_dataset_uri_applies_requested_version():
             "us",
             "enhanced_cps_2024",
             "1.77.0",
+        )
+        == "gs://policyengine-us-data/enhanced_cps_2024.h5@1.77.0"
+    )
+
+
+def test_resolve_runtime_bundle_dataset_uri_preserves_explicit_hf_data_version():
+    assert (
+        resolve_runtime_bundle_dataset_uri(
+            "us",
+            "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0",
+        )
+        == "gs://policyengine-us-data/enhanced_cps_2024.h5@1.77.0"
+    )
+
+
+def test_resolve_runtime_bundle_dataset_uri_preserves_explicit_gcs_data_version():
+    assert (
+        resolve_runtime_bundle_dataset_uri(
+            "us",
+            "gs://policyengine-us-data/enhanced_cps_2024.h5@1.77.0",
         )
         == "gs://policyengine-us-data/enhanced_cps_2024.h5@1.77.0"
     )

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
@@ -433,6 +433,43 @@ def test_resolve_region_uses_dedicated_region_dataset_with_requested_version(
     assert resolution.scoping_strategy is None
 
 
+def test_resolve_region_maps_bundle_manifest_revision_to_data_version(monkeypatch):
+    manifest_revision = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime.get_country_release_bundle",
+        lambda country: SimpleNamespace(
+            data_version="1.115.5",
+            data_artifact_revision=manifest_revision,
+        ),
+    )
+    state = SimpleNamespace(
+        dataset_path=(
+            f"hf://policyengine/policyengine-us-data/states/UT.h5@{manifest_revision}"
+        ),
+        scoping_strategy=None,
+        parent_code="us",
+    )
+    country_module = SimpleNamespace(
+        model=SimpleNamespace(
+            get_region=lambda code: state if code == "state/ut" else None
+        )
+    )
+
+    resolution = _resolve_region(
+        country_module=country_module,
+        country="us",
+        params={
+            "region": "state/ut",
+            "data": "gs://policyengine-us-data/states/UT.h5",
+        },
+    )
+
+    assert resolution.code == "state/ut"
+    assert resolution.dataset_reference == (
+        "gs://policyengine-us-data/states/UT.h5@1.115.5"
+    )
+
+
 def test_resolve_dataset_reference_applies_data_version_to_logical_dataset(
     monkeypatch,
 ):
@@ -484,6 +521,46 @@ def test_resolve_region_scopes_us_place_from_parent_state_dataset(monkeypatch):
     assert resolution.code == "place/CA-57000"
     assert resolution.dataset_reference == (
         "gs://policyengine-us-data/states/CA.h5@1.110.12"
+    )
+    assert resolution.scoping_strategy is scoping_strategy
+
+
+def test_resolve_region_maps_parent_manifest_revision_to_data_version(monkeypatch):
+    manifest_revision = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime.get_country_release_bundle",
+        lambda country: SimpleNamespace(
+            data_version="1.115.5",
+            data_artifact_revision=manifest_revision,
+        ),
+    )
+    scoping_strategy = object()
+    place = SimpleNamespace(
+        dataset_path=None,
+        scoping_strategy=scoping_strategy,
+        parent_code="state/ca",
+    )
+    state = SimpleNamespace(
+        dataset_path=(
+            f"hf://policyengine/policyengine-us-data/states/CA.h5@{manifest_revision}"
+        ),
+        scoping_strategy=None,
+        parent_code="us",
+    )
+    regions = {"place/CA-57000": place, "state/ca": state}
+    country_module = SimpleNamespace(
+        model=SimpleNamespace(get_region=lambda code: regions.get(code))
+    )
+
+    resolution = _resolve_region(
+        country_module=country_module,
+        country="us",
+        params={"region": "place/ca-57000"},
+    )
+
+    assert resolution.code == "place/CA-57000"
+    assert resolution.dataset_reference == (
+        "gs://policyengine-us-data/states/CA.h5@1.115.5"
     )
     assert resolution.scoping_strategy is scoping_strategy
 

--- a/projects/policyengine-api-simulation/tests/test_update_version_registry.py
+++ b/projects/policyengine-api-simulation/tests/test_update_version_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
 
 from src.modal.utils import update_version_registry as registry
@@ -19,6 +21,9 @@ class FakeDict:
 
     def get(self, key, default=None):
         return self._data.get(key, default)
+
+    def items(self):
+        return self._data.items()
 
     def snapshot(self) -> dict:
         return dict(self._data)
@@ -153,6 +158,7 @@ def test_put_app_release_bundle_metadata_records_app_and_py_version_aliases(
                 "policyengine-us-data" if country == "us" else "policyengine-uk-data"
             ),
             "data_version": "3.0.0" if country == "us" else "4.0.0",
+            "data_artifact_revision": "sha-us" if country == "us" else "sha-uk",
             "default_dataset": "default",
             "default_dataset_uri": f"hf://datasets/policyengine/{country}/default",
             "dataset_uris": {"default": f"hf://datasets/policyengine/{country}"},
@@ -174,3 +180,123 @@ def test_put_app_release_bundle_metadata_records_app_and_py_version_aliases(
     assert snapshot["4.10.0"] == metadata
     assert metadata["policyengine_version"] == "4.10.0"
     assert metadata["us"]["dataset_aliases"] == {"alias": "default"}
+
+
+def test_backfill_app_release_bundle_metadata_adds_artifact_revision_from_uri():
+    metadata = {
+        "app_name": "policyengine-simulation-py4-13-1",
+        "policyengine_version": "4.13.1",
+        "us": {
+            "data_version": "1.115.5",
+            "default_dataset": "enhanced_cps_2024",
+            "default_dataset_uri": (
+                "hf://policyengine/policyengine-us-data/"
+                "enhanced_cps_2024.h5@d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+            ),
+            "dataset_uris": {},
+        },
+        "uk": {
+            "data_version": "1.55.10",
+            "default_dataset": "enhanced_frs_2023_24",
+            "default_dataset_uri": (
+                "hf://policyengine/policyengine-uk-data-private/"
+                "enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
+            ),
+            "dataset_uris": {},
+        },
+    }
+
+    updated, changed = registry.backfill_app_release_bundle_metadata(metadata)
+
+    assert changed is True
+    assert updated is not None
+    assert (
+        updated["us"]["data_artifact_revision"]
+        == "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+    )
+    assert (
+        updated["uk"]["data_artifact_revision"]
+        == "655dd07e4bb9c777b00dac044949611f1feb824f"
+    )
+    assert "data_artifact_revision" not in metadata["us"]
+
+
+def test_backfill_app_release_bundle_metadata_preserves_existing_revision():
+    metadata = {
+        "app_name": "policyengine-simulation-py4-10-0",
+        "policyengine_version": "4.10.0",
+        "us": {
+            "data_version": "1.110.12",
+            "data_artifact_revision": "existing-us-revision",
+            "default_dataset": "enhanced_cps_2024",
+            "default_dataset_uri": (
+                "hf://policyengine/policyengine-us-data/"
+                "enhanced_cps_2024.h5@new-us-revision"
+            ),
+            "dataset_uris": {},
+        },
+        "uk": {
+            "data_version": "1.40.3",
+            "data_artifact_revision": "existing-uk-revision",
+            "default_dataset": "enhanced_frs_2023_24",
+            "default_dataset_uri": (
+                "hf://policyengine/policyengine-uk-data-private/"
+                "enhanced_frs_2023_24.h5@new-uk-revision"
+            ),
+            "dataset_uris": {},
+        },
+    }
+
+    updated, changed = registry.backfill_app_release_bundle_metadata(metadata)
+
+    assert changed is False
+    assert updated == metadata
+    assert updated["us"]["data_artifact_revision"] == "existing-us-revision"
+    assert updated["uk"]["data_artifact_revision"] == "existing-uk-revision"
+
+
+def test_backfill_app_release_bundles_updates_all_alias_entries(patched_modal):
+    legacy_bundle = {
+        "app_name": "policyengine-simulation-py4-13-1",
+        "policyengine_version": "4.13.1",
+        "us": {
+            "data_version": "1.115.5",
+            "default_dataset": "enhanced_cps_2024",
+            "default_dataset_uri": (
+                "hf://policyengine/policyengine-us-data/"
+                "enhanced_cps_2024.h5@d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+            ),
+            "dataset_uris": {},
+        },
+        "uk": {
+            "data_version": "1.55.10",
+            "default_dataset": "enhanced_frs_2023_24",
+            "default_dataset_uri": (
+                "hf://policyengine/policyengine-uk-data-private/"
+                "enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
+            ),
+            "dataset_uris": {},
+        },
+    }
+    patched_modal["main/simulation-api-app-release-bundles"] = FakeDict(
+        {
+            "policyengine-simulation-py4-13-1": deepcopy(legacy_bundle),
+            "4.13.1": deepcopy(legacy_bundle),
+            "policyengine-simulation-py4-10-0": {
+                "us": {"data_artifact_revision": "already-present"},
+            },
+        }
+    )
+
+    updated_count = registry.backfill_app_release_bundles(environment="main")
+
+    assert updated_count == 2
+    snapshot = patched_modal["main/simulation-api-app-release-bundles"].snapshot()
+    for key in ("policyengine-simulation-py4-13-1", "4.13.1"):
+        assert (
+            snapshot[key]["uk"]["data_artifact_revision"]
+            == "655dd07e4bb9c777b00dac044949611f1feb824f"
+        )
+    assert snapshot["policyengine-simulation-py4-10-0"] == {
+        "us": {"data_artifact_revision": "already-present"},
+    }

--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
@@ -141,6 +141,61 @@ def test_calculate_default_model(
 
 
 @pytest.mark.beta_only
+def test_calculate_us_state_region_model(
+    client: Client | AuthenticatedClient,
+    us_model_version: str,
+    max_wait_seconds: float,
+    poll_interval: float,
+):
+    """
+    Given a US state-region simulation request
+    When the simulation is submitted and polled to completion
+    Then the worker can load the region dataset from its bundled manifest.
+    """
+    # Given
+    request = SimulationRequest.from_dict(
+        {
+            "country": "us",
+            "version": us_model_version,
+            "region": "state/ut",
+            "scope": "macro",
+            "reform": {
+                "gov.irs.credits.ctc.refundable.fully_refundable": {
+                    "2023-01-01.2100-12-31": True
+                }
+            },
+            "subsample": 200,
+            "time_period": "2026",
+            "data": "gs://policyengine-us-data/states/UT.h5",
+        }
+    )
+
+    # When - submit job
+    submit_response = submit_simulation_request(client, request)
+    assert submit_response.version == us_model_version
+    job_id = submit_response.job_id
+
+    # When - poll for completion
+    result = poll_for_completion(client, job_id, max_wait_seconds, poll_interval)
+
+    # Then - verify result structure
+    assert result.status == "complete"
+    assert result.result is not None
+
+    # Verify key economic impact sections are present
+    economy_result = result.result
+    assert "budget" in economy_result, (
+        f"Missing 'budget' in result: {economy_result.keys()}"
+    )
+    assert "poverty" in economy_result, (
+        f"Missing 'poverty' in result: {economy_result.keys()}"
+    )
+    assert "inequality" in economy_result, (
+        f"Missing 'inequality' in result: {economy_result.keys()}"
+    )
+
+
+@pytest.mark.beta_only
 def test_calculate_specific_model(
     client: Client | AuthenticatedClient,
     us_model_version: str,


### PR DESCRIPTION
Fixes #553

## Summary
- Distinguish bundled data package versions from release-manifest artifact revisions when resolving PolicyEngine-managed datasets.
- Resolve regional HF dataset paths to GCS with the bundled data version while preserving explicit user-requested revisions.
- Add Modal app-release bundle metadata support and a backfill mode for missing `data_artifact_revision` fields.
- Add regression coverage for direct region dataset paths, parent-region fallback paths, gateway metadata, registry backfill, and a beta integration state-region simulation.

## Validation
- `uv run --frozen ruff check src/modal/utils/update_version_registry.py src/modal/gateway/endpoints.py src/policyengine_api_simulation/dataset_uri.py src/policyengine_api_simulation/release_bundle.py src/policyengine_api_simulation/simulation_runtime.py tests/test_update_version_registry.py tests/test_dataset_uri.py tests/test_release_bundle.py tests/test_simulation_output_builder.py tests/gateway/test_endpoints.py`
- `uv run --frozen pytest tests/test_update_version_registry.py tests/test_dataset_uri.py tests/test_release_bundle.py tests/test_simulation_output_builder.py tests/gateway/test_endpoints.py -q`

## Operational Note
- Ran the new app-release bundle backfill against Modal environments: `staging` updated one entry; `main` had no app-release-bundle entries to update.