### PR TITLE
Use policyengine 4.18.3 bundle datasets in simulation API

### DIFF
--- a/projects/policyengine-api-simulation/fixtures/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/fixtures/gateway/test_endpoints.py
@@ -17,6 +17,7 @@ TEST_APP_RELEASE_BUNDLE = {
             "enhanced_cps_2024": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.110.12",
             "cps_2023": "hf://policyengine/policyengine-us-data/cps_2023.h5@1.110.12",
             "pooled_3_year_cps_2023": "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5@1.110.12",
+            "states/UT": "hf://policyengine/policyengine-us-data/states/UT.h5@1.115.5",
         },
         "dataset_aliases": {
             "enhanced_cps": "enhanced_cps_2024",

--- a/projects/policyengine-api-simulation/pyproject.toml
+++ b/projects/policyengine-api-simulation/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings (>=2.7.1,<3.0.0)",
     "opentelemetry-instrumentation-fastapi (>=0.51b0,<0.52)",
     "policyengine-fastapi",
-    "policyengine==4.18.2",
+    "policyengine==4.18.3",
     "policyengine-core==3.27.1",
     "policyengine-uk==2.89.2",
     "policyengine-us==1.729.0",

--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -88,6 +88,32 @@ def _without_revision(dataset_uri: str) -> str:
     return _split_requested_revision(dataset_uri)[0]
 
 
+def _revision_from_dataset_uri(dataset_uri: str | None) -> str | None:
+    if not isinstance(dataset_uri, str) or "@" not in dataset_uri:
+        return None
+    _, revision = _split_requested_revision(dataset_uri)
+    return revision
+
+
+def _bundle_region_dataset_name(country: str, region: object) -> str | None:
+    if not isinstance(region, str) or not region.strip():
+        return None
+
+    country = country.lower()
+    raw = region.strip()
+    if raw.lower() == country:
+        return None
+
+    if country == "us":
+        if "/" not in raw and len(raw) == 2:
+            return f"states/{raw.upper()}"
+        prefix, separator, value = raw.partition("/")
+        if separator and prefix.lower() == "state" and value.strip():
+            return f"states/{value.strip().upper()}"
+
+    return None
+
+
 def _bundle_certified_hf_uri_roots(country_bundle: dict) -> set[str]:
     roots: set[str] = set()
     default_uri = country_bundle.get("default_dataset_uri")
@@ -109,6 +135,37 @@ def _is_bundle_certified_hf_uri(country_bundle: dict, dataset_uri: str) -> bool:
         return False
     return _without_revision(dataset_uri) in _bundle_certified_hf_uri_roots(
         country_bundle
+    )
+
+
+def _resolve_region_dataset_uri_from_app_bundle(
+    *,
+    app_bundle: dict,
+    country: str,
+    region: object,
+    requested_data_version: str | None = None,
+) -> str | None:
+    country_bundle = app_bundle.get(country.lower())
+    if not isinstance(country_bundle, dict):
+        return None
+
+    dataset_name = _bundle_region_dataset_name(country, region)
+    if dataset_name is None:
+        return None
+
+    dataset_uris = country_bundle.get("dataset_uris")
+    if not isinstance(dataset_uris, dict):
+        return None
+    dataset_uri = dataset_uris.get(dataset_name)
+    if not isinstance(dataset_uri, str):
+        return None
+
+    return runtime_dataset_uri(
+        dataset_uri,
+        default_revision=_country_bundle_data_version(country_bundle),
+        override_revision=requested_data_version,
+        artifact_revision=_country_bundle_data_artifact_revision(country_bundle),
+        validate_hf=False,
     )
 
 
@@ -489,18 +546,30 @@ def _build_policyengine_bundle(
         country_bundle = {}
     dataset = payload.get("data")
     requested_data_version = payload.get("data_version")
-    resolved_dataset = _resolve_dataset_uri_from_app_bundle(
-        app_bundle=app_bundle,
-        country=country,
-        requested_data=dataset if isinstance(dataset, str) else None,
-        requested_data_version=(
-            requested_data_version if isinstance(requested_data_version, str) else None
-        ),
+    requested_dataset = dataset if isinstance(dataset, str) else None
+    requested_data_version = (
+        requested_data_version if isinstance(requested_data_version, str) else None
     )
+    resolved_dataset = None
+    if requested_dataset is None:
+        resolved_dataset = _resolve_region_dataset_uri_from_app_bundle(
+            app_bundle=app_bundle,
+            country=country,
+            region=payload.get("region"),
+            requested_data_version=requested_data_version,
+        )
+    if resolved_dataset is None:
+        resolved_dataset = _resolve_dataset_uri_from_app_bundle(
+            app_bundle=app_bundle,
+            country=country,
+            requested_data=requested_dataset,
+            requested_data_version=requested_data_version,
+        )
     data_version = (
         requested_data_version
-        if isinstance(requested_data_version, str)
-        else country_bundle.get("data_version")
+        if requested_data_version is not None
+        else _revision_from_dataset_uri(resolved_dataset)
+        or country_bundle.get("data_version")
     )
     model_version = country_bundle.get("model_version") or resolution.response_version
     policyengine_version = app_bundle.get(

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
@@ -288,9 +288,11 @@ def get_country_release_bundle(country: str) -> CountryReleaseBundle:
         release_data_package = _mapping(release_data_package)
         dataset_repo_types.setdefault(
             default_dataset,
-            str(release_data_package.get("repo_type", "model"))
-            if bundle_metadata is not None
-            else manifest.data_package.repo_type,
+            (
+                str(release_data_package.get("repo_type", "model"))
+                if bundle_metadata is not None
+                else manifest.data_package.repo_type
+            ),
         )
 
     return CountryReleaseBundle(
@@ -352,6 +354,34 @@ def resolve_bundle_dataset_uri(country: str, requested_data: str | None) -> str:
     if "://" in dataset_name:
         return dataset_name
     return bundle.dataset_uris.get(dataset_name, dataset_name)
+
+
+def resolve_bundle_region_dataset_uri(
+    country: str,
+    region_code: str,
+    requested_data_version: str | None = None,
+) -> str | None:
+    """Resolve a certified regional dataset from policyengine.py metadata."""
+
+    bundle = get_country_release_bundle(country)
+    region_code = region_code.lower()
+    dataset_name = None
+    if bundle.country == "us" and region_code.startswith("state/"):
+        state_code = region_code.removeprefix("state/").upper()
+        dataset_name = f"states/{state_code}"
+    if dataset_name is None:
+        return None
+
+    dataset_uri = bundle.dataset_uris.get(dataset_name)
+    if dataset_uri is None:
+        return None
+    return runtime_dataset_uri(
+        dataset_uri,
+        default_revision=bundle.data_version,
+        override_revision=requested_data_version,
+        artifact_revision=bundle.data_artifact_revision,
+        validate_hf=False,
+    )
 
 
 def _receipt_path() -> Path:
@@ -435,16 +465,19 @@ def resolve_runtime_bundle_dataset_uri(
     country: str,
     requested_data: str | None,
     requested_data_version: str | None = None,
+    *,
+    prefer_local: bool = True,
 ) -> str:
     """Resolve a request dataset to the reference the worker should load."""
 
-    local_path = resolve_local_bundle_dataset_path(
-        country,
-        requested_data,
-        requested_data_version,
-    )
-    if local_path is not None:
-        return local_path
+    if prefer_local:
+        local_path = resolve_local_bundle_dataset_path(
+            country,
+            requested_data,
+            requested_data_version,
+        )
+        if local_path is not None:
+            return local_path
 
     bundle = get_country_release_bundle(country)
     if requested_data is None:

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
@@ -18,6 +18,8 @@ from typing import Any, Iterator
 from policyengine_api_simulation.dataset_uri import runtime_dataset_uri
 from policyengine_api_simulation.release_bundle import (
     get_country_release_bundle,
+    resolve_bundle_dataset_name,
+    resolve_bundle_region_dataset_uri,
     resolve_runtime_bundle_dataset_uri,
 )
 from policyengine_api_simulation.simulation_output_builder import (
@@ -188,10 +190,14 @@ def _requested_data_version(params: dict[str, Any]) -> str | None:
 def _resolve_dataset_reference(country: str, params: dict[str, Any]) -> str:
     requested_data = params.get("data")
     requested_data = requested_data if isinstance(requested_data, str) else None
+    requested_data_version = _requested_data_version(params)
+    if requested_data is None and requested_data_version is None:
+        return resolve_bundle_dataset_name(country, requested_data)
     return resolve_runtime_bundle_dataset_uri(
         country,
         requested_data,
-        _requested_data_version(params),
+        requested_data_version,
+        prefer_local=False,
     )
 
 
@@ -267,11 +273,18 @@ def _region_parent_dataset_reference(
 ) -> str:
     parent_code = getattr(region, "parent_code", None)
     if parent_code:
+        requested_data_version = _requested_data_version(params)
+        bundle_dataset_reference = resolve_bundle_region_dataset_uri(
+            country,
+            parent_code,
+            requested_data_version,
+        )
+        if bundle_dataset_reference is not None:
+            return bundle_dataset_reference
         parent_region = country_module.model.get_region(parent_code)
         parent_dataset_path = getattr(parent_region, "dataset_path", None)
         if isinstance(parent_dataset_path, str):
             bundle = get_country_release_bundle(country)
-            requested_data_version = _requested_data_version(params)
             return runtime_dataset_uri(
                 parent_dataset_path,
                 default_revision=bundle.data_version,
@@ -303,13 +316,19 @@ def _resolve_region(
     dataset_path = getattr(region, "dataset_path", None)
     requested_data_version = _requested_data_version(params)
     if isinstance(dataset_path, str):
-        bundle = get_country_release_bundle(country)
-        dataset_reference = runtime_dataset_uri(
-            dataset_path,
-            default_revision=bundle.data_version,
-            override_revision=requested_data_version,
-            artifact_revision=bundle.data_artifact_revision,
+        dataset_reference = resolve_bundle_region_dataset_uri(
+            country,
+            region_code,
+            requested_data_version,
         )
+        if dataset_reference is None:
+            bundle = get_country_release_bundle(country)
+            dataset_reference = runtime_dataset_uri(
+                dataset_path,
+                default_revision=bundle.data_version,
+                override_revision=requested_data_version,
+                artifact_revision=bundle.data_artifact_revision,
+            )
     else:
         dataset_reference = _region_parent_dataset_reference(
             country_module,

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -372,6 +372,7 @@ class TestSubmitSimulationEndpoint:
             "us",
             "1.500.0",
             dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.115.5",
+            data_version="1.115.5",
         )
 
     def test__given_submission_with_alias_data__then_bundle_dataset_uses_manifest_uri(
@@ -397,6 +398,32 @@ class TestSubmitSimulationEndpoint:
             "us", "enhanced_cps_2024"
         )
 
+    def test__given_us_state_region_without_data__then_bundle_metadata_uses_state_dataset(
+        self, mock_modal, client: TestClient
+    ):
+        mock_modal["dicts"]["simulation-api-us-versions"] = {
+            "latest": "1.500.0",
+            "1.500.0": "policyengine-simulation-py4-10-0",
+        }
+
+        response = client.post(
+            "/simulate/economy/comparison",
+            json={
+                "country": "us",
+                "scope": "macro",
+                "region": "state/ut",
+                "reform": {},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["policyengine_bundle"] == expected_bundle(
+            "us",
+            "1.500.0",
+            dataset="states/UT",
+            data_version="1.115.5",
+        )
+
     def test__given_submission_with_logical_revision__then_bundle_dataset_uses_revision(
         self, mock_modal, client: TestClient
     ):
@@ -416,9 +443,36 @@ class TestSubmitSimulationEndpoint:
         )
 
         assert response.status_code == 200
-        assert response.json()["policyengine_bundle"]["dataset"] == (
+        bundle = response.json()["policyengine_bundle"]
+        assert bundle["dataset"] == (
             "gs://policyengine-us-data/enhanced_cps_2024.h5@1.77.0"
         )
+        assert bundle["data_version"] == "1.77.0"
+
+    def test__given_submission_with_explicit_uri_revision__then_bundle_data_version_uses_revision(
+        self, mock_modal, client: TestClient
+    ):
+        mock_modal["dicts"]["simulation-api-us-versions"] = {
+            "latest": "1.500.0",
+            "1.500.0": "policyengine-simulation-py4-10-0",
+        }
+
+        response = client.post(
+            "/simulate/economy/comparison",
+            json={
+                "country": "us",
+                "scope": "macro",
+                "reform": {},
+                "data": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.77.0",
+            },
+        )
+
+        assert response.status_code == 200
+        bundle = response.json()["policyengine_bundle"]
+        assert bundle["dataset"] == (
+            "gs://policyengine-us-data/enhanced_cps_2024.h5@1.77.0"
+        )
+        assert bundle["data_version"] == "1.77.0"
 
     def test__given_submission_with_conflicting_data_versions__then_returns_400(
         self, mock_modal, client: TestClient
@@ -511,9 +565,9 @@ class TestSubmitSimulationEndpoint:
         bundle["policyengine_version"] = "4.13.1"
         bundle["uk"]["model_version"] = "2.88.20"
         bundle["uk"]["data_version"] = "1.55.10"
-        bundle["uk"]["data_artifact_revision"] = (
-            "655dd07e4bb9c777b00dac044949611f1feb824f"
-        )
+        bundle["uk"][
+            "data_artifact_revision"
+        ] = "655dd07e4bb9c777b00dac044949611f1feb824f"
         bundle["uk"]["default_dataset_uri"] = manifest_uri
         bundle["uk"]["dataset_uris"]["enhanced_frs_2023_24"] = manifest_uri
         state = deepcopy(TEST_ROUTING_STATE)
@@ -640,6 +694,7 @@ class TestSubmitSimulationEndpoint:
             "us",
             "1.500.0",
             dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.115.5",
+            data_version="1.115.5",
         )
 
     def test__given_submitted_job_with_telemetry__then_polling_echoes_run_id(

--- a/projects/policyengine-api-simulation/tests/test_modal_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_scripts.py
@@ -342,7 +342,7 @@ class TestModalDeployApp:
             {
                 "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
                 "UV_FAKE_LOG": str(log_path),
-                "POLICYENGINE_VERSION": "4.18.2",
+                "POLICYENGINE_VERSION": "4.18.3",
                 "POLICYENGINE_CORE_VERSION": "3.27.1",
                 "POLICYENGINE_US_VERSION": "1.729.0",
                 "POLICYENGINE_UK_VERSION": "2.89.2",
@@ -598,6 +598,6 @@ class TestAllScriptsHaveShebang:
                 capture_output=True,
                 text=True,
             )
-            assert result.returncode == 0, (
-                f"{script.name} has syntax errors: {result.stderr}"
-            )
+            assert (
+                result.returncode == 0
+            ), f"{script.name} has syntax errors: {result.stderr}"

--- a/projects/policyengine-api-simulation/tests/test_policyengine_dependency_source.py
+++ b/projects/policyengine-api-simulation/tests/test_policyengine_dependency_source.py
@@ -17,7 +17,7 @@ COUNTRY_PACKAGES = {
 }
 MODAL_APP_MODULE = "src.modal.app"
 VERSION_ENV = {
-    "POLICYENGINE_VERSION": "4.18.2",
+    "POLICYENGINE_VERSION": "4.18.3",
     "POLICYENGINE_CORE_VERSION": "3.27.1",
     "POLICYENGINE_US_VERSION": "1.729.0",
     "POLICYENGINE_UK_VERSION": "2.89.2",
@@ -152,7 +152,7 @@ print(json.dumps({
     output = result.stdout.strip()
     assert '"version_env":' in output
     assert '"POLICYENGINE_CORE_VERSION": "3.27.1"' in output
-    assert '"app_name": "policyengine-simulation-py4-18-2"' in output
+    assert '"app_name": "policyengine-simulation-py4-18-3"' in output
 
 
 def test_modal_app_remote_import_fails_clearly_without_version_env():

--- a/projects/policyengine-api-simulation/tests/test_release_bundle.py
+++ b/projects/policyengine-api-simulation/tests/test_release_bundle.py
@@ -6,6 +6,7 @@ from policyengine_api_simulation.release_bundle import (
     BUNDLE_RECEIPT_FILENAME,
     get_country_release_bundle,
     resolve_bundle_dataset_name,
+    resolve_bundle_region_dataset_uri,
     resolve_bundle_dataset_uri,
     resolve_runtime_bundle_dataset_uri,
 )
@@ -74,13 +75,35 @@ def test_resolve_bundle_dataset_uri_maps_certified_defaults_to_manifest_uris():
     )
 
 
+def test_resolve_bundle_dataset_uri_maps_certified_us_state_datasets():
+    bundle = get_country_release_bundle("us")
+
+    assert bundle.dataset_uris["states/UT"] == (
+        "hf://policyengine/policyengine-us-data/states/UT.h5@1.115.5"
+    )
+    assert resolve_bundle_dataset_uri("us", "states/UT") == (
+        "hf://policyengine/policyengine-us-data/states/UT.h5@1.115.5"
+    )
+
+
+def test_resolve_bundle_region_dataset_uri_maps_us_state_to_certified_dataset():
+    assert resolve_bundle_region_dataset_uri("us", "state/ut") == (
+        "gs://policyengine-us-data/states/UT.h5@1.115.5"
+    )
+
+
+def test_resolve_bundle_region_dataset_uri_applies_requested_version():
+    assert resolve_bundle_region_dataset_uri("us", "state/ut", "1.77.0") == (
+        "gs://policyengine-us-data/states/UT.h5@1.77.0"
+    )
+
+
 def test_resolve_bundle_dataset_uri_keeps_legacy_aliases_as_explicit_overrides():
     assert resolve_bundle_dataset_uri("us", "enhanced_cps") == (
         "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.110.12"
     )
-    assert (
-        resolve_bundle_dataset_uri("uk", "enhanced_frs")
-        == (get_country_release_bundle("uk").dataset_uris["enhanced_frs_2023_24"])
+    assert resolve_bundle_dataset_uri("uk", "enhanced_frs") == (
+        get_country_release_bundle("uk").dataset_uris["enhanced_frs_2023_24"]
     )
 
 
@@ -198,8 +221,8 @@ def test_resolve_runtime_bundle_dataset_uri_prefers_installed_default_dataset(
     receipt_path.write_text(
         """
         {
-          "bundle_version": "4.18.2",
-          "policyengine_version": "4.18.2",
+          "bundle_version": "4.18.3",
+          "policyengine_version": "4.18.3",
           "datasets": [
             {
               "country": "us",

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pandas as pd
@@ -22,7 +23,10 @@ from fixtures.test_simulation_output_builder import (
     FakeModelOutput,
     fake_analysis,
 )
+from policyengine_api_simulation.release_bundle import BUNDLE_RECEIPT_FILENAME
+from policyengine_api_simulation.release_bundle import get_country_release_bundle
 from policyengine_api_simulation.simulation_runtime import RegionResolution
+from policyengine_api_simulation.simulation_runtime import _load_dataset
 from policyengine_api_simulation.simulation_runtime import _normalise_policy
 from policyengine_api_simulation.simulation_runtime import _resolve_dataset_reference
 from policyengine_api_simulation.simulation_runtime import _resolve_region
@@ -436,6 +440,10 @@ def test_resolve_region_uses_dedicated_region_dataset_with_requested_version(
 def test_resolve_region_maps_bundle_manifest_revision_to_data_version(monkeypatch):
     manifest_revision = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
     monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime.resolve_bundle_region_dataset_uri",
+        lambda country, region_code, requested_data_version=None: None,
+    )
+    monkeypatch.setattr(
         "policyengine_api_simulation.simulation_runtime.get_country_release_bundle",
         lambda country: SimpleNamespace(
             data_version="1.115.5",
@@ -489,6 +497,61 @@ def test_resolve_dataset_reference_applies_data_version_to_logical_dataset(
     )
 
 
+@pytest.mark.parametrize("country", ["us", "uk"])
+def test_load_dataset_passes_bundle_default_name_to_country_loader_with_receipt(
+    country,
+    tmp_path,
+    monkeypatch,
+):
+    bundle = get_country_release_bundle(country)
+    installed_dataset_path = tmp_path / f"{bundle.default_dataset}.h5"
+    installed_dataset_path.write_bytes(b"data")
+    receipt_path = tmp_path / BUNDLE_RECEIPT_FILENAME
+    receipt_path.write_text(
+        json.dumps(
+            {
+                "bundle_version": "4.18.3",
+                "policyengine_version": "4.18.3",
+                "datasets": [
+                    {
+                        "country": country,
+                        "dataset": bundle.default_dataset,
+                        "version": bundle.data_version,
+                        "path": str(installed_dataset_path),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLICYENGINE_BUNDLE_RECEIPT", str(receipt_path))
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+    get_country_release_bundle.cache_clear()
+
+    dataset = SimpleNamespace()
+    ensure_calls = []
+
+    def ensure_datasets(**kwargs):
+        ensure_calls.append(kwargs)
+        return {"dataset": dataset}
+
+    assert (
+        _load_dataset(
+            {"country": country, "time_period": "2026"},
+            country_module=SimpleNamespace(ensure_datasets=ensure_datasets),
+        )
+        is dataset
+    )
+
+    assert ensure_calls == [
+        {
+            "datasets": [bundle.default_dataset],
+            "years": [2026],
+            "data_folder": str(tmp_path),
+        }
+    ]
+
+
 def test_resolve_region_scopes_us_place_from_parent_state_dataset(monkeypatch):
     monkeypatch.setattr(
         "policyengine_api_simulation.dataset_uri.with_hf_revision",
@@ -520,13 +583,17 @@ def test_resolve_region_scopes_us_place_from_parent_state_dataset(monkeypatch):
 
     assert resolution.code == "place/CA-57000"
     assert resolution.dataset_reference == (
-        "gs://policyengine-us-data/states/CA.h5@1.110.12"
+        "gs://policyengine-us-data/states/CA.h5@1.115.5"
     )
     assert resolution.scoping_strategy is scoping_strategy
 
 
 def test_resolve_region_maps_parent_manifest_revision_to_data_version(monkeypatch):
     manifest_revision = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime.resolve_bundle_region_dataset_uri",
+        lambda country, region_code, requested_data_version=None: None,
+    )
     monkeypatch.setattr(
         "policyengine_api_simulation.simulation_runtime.get_country_release_bundle",
         lambda country: SimpleNamespace(

--- a/projects/policyengine-api-simulation/uv.lock
+++ b/projects/policyengine-api-simulation/uv.lock
@@ -1675,7 +1675,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.18.2"
+version = "4.18.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -1689,9 +1689,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/99/8fd6f6cc9f7f2c7ea164c721a3d0f913e3f92640750e2cc111f0a80481ae/policyengine-4.18.2.tar.gz", hash = "sha256:ed32bedf3479a92bb700b1ccc0cb0565500cac34e69907038f5496f79cabfcf8", size = 690487, upload-time = "2026-06-23T21:32:37.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/13/0dd4f39d7ec5d14add10c08e4d61aad296831802edae526e1907fc023aec/policyengine-4.18.3.tar.gz", hash = "sha256:ed95cfea02770e62bc0945a9e88bcbc96c94bf1fc717162c194b33948564a089", size = 697659, upload-time = "2026-06-25T19:05:19.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/39/f5ee85c28067cf853e5ff21869129e67ab013a14e26a9e76035dfd922052/policyengine-4.18.2-py3-none-any.whl", hash = "sha256:0649a6acd6d9841a8ae65735168220e72ef17a059aee2de54ae025b0f46d6749", size = 207260, upload-time = "2026-06-23T21:32:36.043Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/b3651013363f71c90795c7fd11ae7eed2b9acb2bafeb743260b972f2d58b/policyengine-4.18.3-py3-none-any.whl", hash = "sha256:fe2adbb576c08acb874ad98b5b03b8c41c38f654cd41ad6ada14a32427774aa0", size = 211031, upload-time = "2026-06-25T19:05:17.906Z" },
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ requires-dist = [
     { name = "openapi-python-client", marker = "extra == 'build'", specifier = ">=0.21.6" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.51b0,<0.52" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.51b0,<0.52" },
-    { name = "policyengine", specifier = "==4.18.2" },
+    { name = "policyengine", specifier = "==4.18.3" },
     { name = "policyengine-core", specifier = "==3.27.1" },
     { name = "policyengine-fastapi", editable = "../../libs/policyengine-fastapi" },
     { name = "policyengine-uk", specifier = "==2.89.2" },

--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
@@ -166,7 +166,6 @@ def test_calculate_us_state_region_model(
             },
             "subsample": 200,
             "time_period": "2026",
-            "data": "gs://policyengine-us-data/states/UT.h5",
         }
     )
 


### PR DESCRIPTION
Fixes #576

## Summary
- Update the simulation project to `policyengine==4.18.3`.
- Resolve certified US state datasets from `.py` bundle metadata for worker execution.
- Return gateway `policyengine_bundle` metadata that matches the resolved dataset and data version, including state regions and explicit dataset revisions.
- Update gateway and simulation tests for state sidecar datasets and explicit revision provenance.

## Testing
- `uv run pytest tests/gateway/test_endpoints.py tests/test_release_bundle.py tests/test_simulation_output_builder.py tests/test_policyengine_dependency_source.py tests/test_modal_scripts.py tests/test_update_version_registry.py -q`
- `uv run black --check src/modal/gateway/endpoints.py tests/gateway/test_endpoints.py fixtures/gateway/test_endpoints.py`