### PR TITLE
Sync Hugging Face token to Modal deploys

### DIFF
--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Sync secrets from GitHub to Modal environment
 # Usage: ./modal-sync-secrets.sh <modal-environment> <gh-environment>
-# Required env vars: LOGFIRE_TOKEN, GCP_CREDENTIALS_JSON (optional)
+# Required env vars: LOGFIRE_TOKEN, HF_TOKEN
+# Optional env vars: GCP_CREDENTIALS_JSON
 
 set -euo pipefail
 
@@ -16,6 +17,12 @@ truthy() {
 }
 
 echo "Syncing secrets to Modal environment: $MODAL_ENV"
+
+if [ -z "${HF_TOKEN:-}" ]; then
+  echo "HF_TOKEN is required to sync the Hugging Face dataset secret." >&2
+  echo "Add HF_TOKEN to the GitHub environment secrets for '$GH_ENV'." >&2
+  exit 1
+fi
 
 GATEWAY_AUTH_VARS=(
   GATEWAY_AUTH_ISSUER
@@ -61,6 +68,13 @@ if [ -n "${GCP_CREDENTIALS_JSON:-}" ]; then
     --env="$MODAL_ENV" \
     --force || true
 fi
+
+# Sync Hugging Face token for private certified datasets used during bundle
+# image build and worker runtime.
+uv run modal secret create huggingface-token \
+  "HF_TOKEN=$HF_TOKEN" \
+  --env="$MODAL_ENV" \
+  --force
 
 # Sync gateway auth config. The gateway runtime only needs issuer/audience and
 # the explicit requirement flag; client credentials stay on the GitHub side and

--- a/.github/workflows/modal-deploy.reusable.yml
+++ b/.github/workflows/modal-deploy.reusable.yml
@@ -82,6 +82,7 @@ jobs:
         MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
         MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
         GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
         GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
         GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -88,6 +88,7 @@ app = modal.App(APP_NAME)
 # GCP credentials are shared across environments (always from main)
 gcp_secret = modal.Secret.from_name("gcp-credentials", environment_name="main")
 data_secret = modal.Secret.from_name("policyengine-data-credentials")
+hf_secret = modal.Secret.from_name("huggingface-token")
 # Logfire secret is environment-specific
 logfire_secret = modal.Secret.from_name("policyengine-logfire")
 
@@ -124,7 +125,10 @@ simulation_image = (
         "tables>=3.10.2",
         "logfire",
     )
-    .run_commands(bundle_install_command(POLICYENGINE_VERSION), secrets=[data_secret])
+    .run_commands(
+        bundle_install_command(POLICYENGINE_VERSION),
+        secrets=[data_secret, hf_secret],
+    )
     .env(VERSION_ENV)
     .add_local_python_source(
         "src.modal",
@@ -158,7 +162,7 @@ def configure_logfire(service_name: str = "policyengine-simulation"):
     timeout=3600,
     retries=0,
     max_containers=100,
-    secrets=[gcp_secret, data_secret, logfire_secret],
+    secrets=[gcp_secret, data_secret, hf_secret, logfire_secret],
 )
 def run_simulation(params: dict) -> dict:
     """
@@ -196,7 +200,7 @@ def run_simulation(params: dict) -> dict:
     timeout=3600,
     retries=0,
     max_containers=100,
-    secrets=[gcp_secret, data_secret, logfire_secret],
+    secrets=[gcp_secret, data_secret, hf_secret, logfire_secret],
 )
 def run_budget_window_batch(params: dict) -> dict:
     """Execute a multi-year budget-window batch orchestration."""

--- a/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
@@ -43,9 +43,11 @@ class FakeSecret:
 class FakeApp:
     def __init__(self, name):
         self.name = name
+        self.function_calls = []
 
     def function(self, **kwargs):
         def decorator(function):
+            self.function_calls.append((function.__name__, kwargs))
             return function
 
         return decorator
@@ -84,4 +86,14 @@ def test_modal_image_uses_policyengine_bundle_install(monkeypatch):
     assert app.VERSION_ENV["POLICYENGINE_BUNDLE_RECEIPT"].endswith(
         "/.policyengine-bundle-receipt.json"
     )
-    assert command_calls[0][2]["secrets"] == [app.data_secret]
+    assert command_calls[0][2]["secrets"] == [app.data_secret, app.hf_secret]
+    runtime_secret_sets = {
+        name: kwargs["secrets"] for name, kwargs in app.app.function_calls
+    }
+    for function_name in ("run_simulation", "run_budget_window_batch"):
+        assert runtime_secret_sets[function_name] == [
+            app.gcp_secret,
+            app.data_secret,
+            app.hf_secret,
+            app.logfire_secret,
+        ]

--- a/projects/policyengine-api-simulation/tests/test_modal_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_scripts.py
@@ -242,6 +242,7 @@ class TestModalSyncSecrets:
     def test_fails_when_gateway_auth_config_is_partial(self):
         """Should fail before touching Modal when auth config is partial."""
         env = os.environ.copy()
+        env["HF_TOKEN"] = "hf_test"
         env["GATEWAY_AUTH_ISSUER"] = "https://tenant.auth0.com"
         env.pop("GATEWAY_AUTH_AUDIENCE", None)
         env.pop("GATEWAY_AUTH_CLIENT_ID", None)
@@ -260,6 +261,7 @@ class TestModalSyncSecrets:
     def test_fails_when_auth_required_but_gateway_auth_vars_missing(self):
         """Required auth must refuse deploy when the GitHub secrets are absent."""
         env = os.environ.copy()
+        env["HF_TOKEN"] = "hf_test"
         env["GATEWAY_AUTH_REQUIRED"] = "1"
         for key in (
             "GATEWAY_AUTH_ISSUER",
@@ -279,8 +281,23 @@ class TestModalSyncSecrets:
         assert result.returncode != 0
         assert "GATEWAY_AUTH_REQUIRED is enabled" in result.stderr
 
+    def test_requires_hf_token(self):
+        """Should fail before touching Modal when HF_TOKEN is absent."""
+        env = os.environ.copy()
+        env.pop("HF_TOKEN", None)
+
+        result = subprocess.run(
+            ["bash", str(self.script), "staging", "beta"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        assert "HF_TOKEN is required" in result.stderr
+
     def test_creates_gateway_secret_with_normalized_issuer(self, tmp_path):
-        """Should sync only runtime gateway values and normalize issuer."""
+        """Should sync HF and runtime gateway values and normalize issuer."""
         uv_calls_log = tmp_path / "uv_calls.log"
         fake_bin = tmp_path / "bin"
         fake_bin.mkdir()
@@ -293,6 +310,7 @@ class TestModalSyncSecrets:
             {
                 "PATH": f"{fake_bin}:{env['PATH']}",
                 "UV_CALLS_LOG": str(uv_calls_log),
+                "HF_TOKEN": "hf_test",
                 "GATEWAY_AUTH_ISSUER": "https://tenant.auth0.com",
                 "GATEWAY_AUTH_AUDIENCE": "https://simulation-api-beta.policyengine.org",
                 "GATEWAY_AUTH_CLIENT_ID": "client-id",
@@ -310,6 +328,8 @@ class TestModalSyncSecrets:
 
         assert result.returncode == 0, result.stderr
         calls = uv_calls_log.read_text()
+        assert "run modal secret create huggingface-token" in calls
+        assert "HF_TOKEN=hf_test" in calls
         assert "run modal secret create policyengine-gateway-auth" in calls
         assert "GATEWAY_AUTH_ISSUER=https://tenant.auth0.com/" in calls
         assert (


### PR DESCRIPTION
Fixes #578

## Summary
- Pass `HF_TOKEN` from GitHub Actions secrets into the Modal secret sync step.
- Sync a dedicated Modal secret named `huggingface-token` for private Hugging Face dataset access.
- Mount the Hugging Face token during simulation image bundle installation and worker runtime.
- Add focused tests for the sync script and Modal app secret wiring.

## Why
Certified UK bundle datasets can resolve to private Hugging Face artifacts. The deploy path previously synced GCP credentials but did not sync Hugging Face credentials, so workers could fail with a Hugging Face 401 while loading `policyengine/populace-uk-private` datasets.

## Validation
- `uv run pytest tests/test_modal_scripts.py tests/test_modal_bundle_image.py -q`
- `uv run black --check src/modal/app.py tests/test_modal_bundle_image.py tests/test_modal_scripts.py`