### PR TITLE
Support policyengine.py 4.18.6 US subnational simulations

### DIFF
--- a/.github/scripts/modal-extract-versions.sh
+++ b/.github/scripts/modal-extract-versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Extract policyengine.py, policyengine-core, policyengine-us,
-# policyengine-us-data, policyengine-uk, and policyengine-uk-data versions.
+# Extract policyengine.py, policyengine-core, country package versions, and
+# country data release versions.
 # Usage: ./modal-extract-versions.sh <project-dir>
 # Outputs: Sets policyengine_version, policyengine_core_version, us_version,
 # us_data_version, uk_version, and uk_data_version in GITHUB_OUTPUT

--- a/.github/workflows/modal-deploy.reusable.yml
+++ b/.github/workflows/modal-deploy.reusable.yml
@@ -30,13 +30,13 @@ on:
         description: 'The deployed policyengine-us package version'
         value: ${{ jobs.deploy.outputs.us_version }}
       us_data_version:
-        description: 'The bundled policyengine-us-data version'
+        description: 'The bundled US data release version'
         value: ${{ jobs.deploy.outputs.us_data_version }}
       uk_version:
         description: 'The deployed policyengine-uk package version'
         value: ${{ jobs.deploy.outputs.uk_version }}
       uk_data_version:
-        description: 'The bundled policyengine-uk-data version'
+        description: 'The bundled UK data release version'
         value: ${{ jobs.deploy.outputs.uk_data_version }}
 
 jobs:

--- a/projects/policyengine-api-simulation/pyproject.toml
+++ b/projects/policyengine-api-simulation/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings (>=2.7.1,<3.0.0)",
     "opentelemetry-instrumentation-fastapi (>=0.51b0,<0.52)",
     "policyengine-fastapi",
-    "policyengine==4.18.5",
+    "policyengine==4.18.6",
     "policyengine-core==3.28.0",
     "policyengine-uk==2.89.2",
     "policyengine-us==1.745.0",

--- a/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/endpoints.py
@@ -95,25 +95,6 @@ def _revision_from_dataset_uri(dataset_uri: str | None) -> str | None:
     return revision
 
 
-def _bundle_region_dataset_name(country: str, region: object) -> str | None:
-    if not isinstance(region, str) or not region.strip():
-        return None
-
-    country = country.lower()
-    raw = region.strip()
-    if raw.lower() == country:
-        return None
-
-    if country == "us":
-        if "/" not in raw and len(raw) == 2:
-            return f"states/{raw.upper()}"
-        prefix, separator, value = raw.partition("/")
-        if separator and prefix.lower() == "state" and value.strip():
-            return f"states/{value.strip().upper()}"
-
-    return None
-
-
 def _bundle_certified_hf_uri_roots(country_bundle: dict) -> set[str]:
     roots: set[str] = set()
     default_uri = country_bundle.get("default_dataset_uri")
@@ -135,37 +116,6 @@ def _is_bundle_certified_hf_uri(country_bundle: dict, dataset_uri: str) -> bool:
         return False
     return _without_revision(dataset_uri) in _bundle_certified_hf_uri_roots(
         country_bundle
-    )
-
-
-def _resolve_region_dataset_uri_from_app_bundle(
-    *,
-    app_bundle: dict,
-    country: str,
-    region: object,
-    requested_data_version: str | None = None,
-) -> str | None:
-    country_bundle = app_bundle.get(country.lower())
-    if not isinstance(country_bundle, dict):
-        return None
-
-    dataset_name = _bundle_region_dataset_name(country, region)
-    if dataset_name is None:
-        return None
-
-    dataset_uris = country_bundle.get("dataset_uris")
-    if not isinstance(dataset_uris, dict):
-        return None
-    dataset_uri = dataset_uris.get(dataset_name)
-    if not isinstance(dataset_uri, str):
-        return None
-
-    return runtime_dataset_uri(
-        dataset_uri,
-        default_revision=_country_bundle_data_version(country_bundle),
-        override_revision=requested_data_version,
-        artifact_revision=_country_bundle_data_artifact_revision(country_bundle),
-        validate_hf=False,
     )
 
 
@@ -550,21 +500,12 @@ def _build_policyengine_bundle(
     requested_data_version = (
         requested_data_version if isinstance(requested_data_version, str) else None
     )
-    resolved_dataset = None
-    if requested_dataset is None:
-        resolved_dataset = _resolve_region_dataset_uri_from_app_bundle(
-            app_bundle=app_bundle,
-            country=country,
-            region=payload.get("region"),
-            requested_data_version=requested_data_version,
-        )
-    if resolved_dataset is None:
-        resolved_dataset = _resolve_dataset_uri_from_app_bundle(
-            app_bundle=app_bundle,
-            country=country,
-            requested_data=requested_dataset,
-            requested_data_version=requested_data_version,
-        )
+    resolved_dataset = _resolve_dataset_uri_from_app_bundle(
+        app_bundle=app_bundle,
+        country=country,
+        requested_data=requested_dataset,
+        requested_data_version=requested_data_version,
+    )
     data_version = (
         requested_data_version
         if requested_data_version is not None

--- a/projects/policyengine-api-simulation/src/modal/gateway/models.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/models.py
@@ -93,7 +93,6 @@ class GatewayRequestBase(BaseModel):
     reform: Optional[dict[str, Any]] = None
     baseline: Optional[dict[str, Any]] = None
     region: Optional[str] = None
-    subsample: Optional[int] = None
     title: Optional[str] = None
     include_cliffs: Optional[bool] = None
     model_version: Optional[str] = None

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/compat_models.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/compat_models.py
@@ -19,7 +19,6 @@ class SimulationOptions(BaseModel):
     reform: Optional[dict[str, Any]] = None
     baseline: Optional[dict[str, Any]] = None
     region: Optional[str] = None
-    subsample: Optional[int] = None
     title: Optional[str] = None
     include_cliffs: Optional[bool] = None
     model_version: Optional[str] = None

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
@@ -361,27 +361,18 @@ def resolve_bundle_region_dataset_uri(
     region_code: str,
     requested_data_version: str | None = None,
 ) -> str | None:
-    """Resolve a certified regional dataset from policyengine.py metadata."""
+    """Resolve a certified regional dataset from policyengine.py metadata.
 
-    bundle = get_country_release_bundle(country)
-    region_code = region_code.lower()
-    dataset_name = None
-    if bundle.country == "us" and region_code.startswith("state/"):
-        state_code = region_code.removeprefix("state/").upper()
-        dataset_name = f"states/{state_code}"
-    if dataset_name is None:
-        return None
+    policyengine.py 4.18.6+ scopes US state and congressional district regions
+    from the certified national Populace dataset instead of certifying separate
+    regional H5 sidecars.
+    """
 
-    dataset_uri = bundle.dataset_uris.get(dataset_name)
-    if dataset_uri is None:
+    _normalise_country(country)
+    if not region_code.strip():
         return None
-    return runtime_dataset_uri(
-        dataset_uri,
-        default_revision=bundle.data_version,
-        override_revision=requested_data_version,
-        artifact_revision=bundle.data_artifact_revision,
-        validate_hf=False,
-    )
+    del requested_data_version
+    return None
 
 
 def _receipt_path() -> Path:

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/release_bundle.py
@@ -356,25 +356,6 @@ def resolve_bundle_dataset_uri(country: str, requested_data: str | None) -> str:
     return bundle.dataset_uris.get(dataset_name, dataset_name)
 
 
-def resolve_bundle_region_dataset_uri(
-    country: str,
-    region_code: str,
-    requested_data_version: str | None = None,
-) -> str | None:
-    """Resolve a certified regional dataset from policyengine.py metadata.
-
-    policyengine.py 4.18.6+ scopes US state and congressional district regions
-    from the certified national Populace dataset instead of certifying separate
-    regional H5 sidecars.
-    """
-
-    _normalise_country(country)
-    if not region_code.strip():
-        return None
-    del requested_data_version
-    return None
-
-
 def _receipt_path() -> Path:
     explicit = os.environ.get("POLICYENGINE_BUNDLE_RECEIPT")
     if explicit:

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
@@ -272,8 +272,14 @@ def _region_parent_dataset_reference(
     params: dict[str, Any],
 ) -> str:
     parent_code = getattr(region, "parent_code", None)
-    if parent_code:
-        requested_data_version = _requested_data_version(params)
+    requested_data_version = _requested_data_version(params)
+    visited: set[str] = set()
+
+    while isinstance(parent_code, str) and parent_code:
+        if parent_code in visited:
+            raise ValueError(f"Region hierarchy cycle at {parent_code}")
+        visited.add(parent_code)
+
         bundle_dataset_reference = resolve_bundle_region_dataset_uri(
             country,
             parent_code,
@@ -281,6 +287,7 @@ def _region_parent_dataset_reference(
         )
         if bundle_dataset_reference is not None:
             return bundle_dataset_reference
+
         parent_region = country_module.model.get_region(parent_code)
         parent_dataset_path = getattr(parent_region, "dataset_path", None)
         if isinstance(parent_dataset_path, str):
@@ -290,8 +297,24 @@ def _region_parent_dataset_reference(
                 default_revision=bundle.data_version,
                 override_revision=requested_data_version,
                 artifact_revision=bundle.data_artifact_revision,
+                validate_hf=False,
             )
+        parent_code = getattr(parent_region, "parent_code", None)
+
     return _resolve_dataset_reference(country, params)
+
+
+def _reject_unscoped_us_place_region(region_code: str, region) -> None:
+    if not region_code.startswith("place/"):
+        return
+    if getattr(region, "dataset_path", None) is not None:
+        return
+    if getattr(region, "scoping_strategy", None) is not None:
+        return
+    raise ValueError(
+        "US place regions are not yet supported for runtime simulation because "
+        "policyengine.py does not expose place-level dataset scoping."
+    )
 
 
 def _resolve_region(
@@ -312,6 +335,8 @@ def _resolve_region(
         region = _build_uk_weight_replacement_region(region_code)
     if region is None:
         raise ValueError(f"Unsupported {country.upper()} region: {region_code}")
+    if country == "us":
+        _reject_unscoped_us_place_region(region_code, region)
 
     dataset_path = getattr(region, "dataset_path", None)
     requested_data_version = _requested_data_version(params)
@@ -328,6 +353,7 @@ def _resolve_region(
                 default_revision=bundle.data_version,
                 override_revision=requested_data_version,
                 artifact_revision=bundle.data_artifact_revision,
+                validate_hf=False,
             )
     else:
         dataset_reference = _region_parent_dataset_reference(

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
@@ -19,7 +19,6 @@ from policyengine_api_simulation.dataset_uri import runtime_dataset_uri
 from policyengine_api_simulation.release_bundle import (
     get_country_release_bundle,
     resolve_bundle_dataset_name,
-    resolve_bundle_region_dataset_uri,
     resolve_runtime_bundle_dataset_uri,
 )
 from policyengine_api_simulation.simulation_output_builder import (
@@ -280,14 +279,6 @@ def _region_parent_dataset_reference(
             raise ValueError(f"Region hierarchy cycle at {parent_code}")
         visited.add(parent_code)
 
-        bundle_dataset_reference = resolve_bundle_region_dataset_uri(
-            country,
-            parent_code,
-            requested_data_version,
-        )
-        if bundle_dataset_reference is not None:
-            return bundle_dataset_reference
-
         parent_region = country_module.model.get_region(parent_code)
         parent_dataset_path = getattr(parent_region, "dataset_path", None)
         if isinstance(parent_dataset_path, str):
@@ -341,20 +332,14 @@ def _resolve_region(
     dataset_path = getattr(region, "dataset_path", None)
     requested_data_version = _requested_data_version(params)
     if isinstance(dataset_path, str):
-        dataset_reference = resolve_bundle_region_dataset_uri(
-            country,
-            region_code,
-            requested_data_version,
+        bundle = get_country_release_bundle(country)
+        dataset_reference = runtime_dataset_uri(
+            dataset_path,
+            default_revision=bundle.data_version,
+            override_revision=requested_data_version,
+            artifact_revision=bundle.data_artifact_revision,
+            validate_hf=False,
         )
-        if dataset_reference is None:
-            bundle = get_country_release_bundle(country)
-            dataset_reference = runtime_dataset_uri(
-                dataset_path,
-                default_revision=bundle.data_version,
-                override_revision=requested_data_version,
-                artifact_revision=bundle.data_artifact_revision,
-                validate_hf=False,
-            )
     else:
         dataset_reference = _region_parent_dataset_reference(
             country_module,
@@ -367,70 +352,6 @@ def _resolve_region(
         code=region_code,
         dataset_reference=dataset_reference,
         scoping_strategy=getattr(region, "scoping_strategy", None),
-    )
-
-
-def _microframe_like(frame, weights: str):
-    from microdf import MicroDataFrame
-
-    return MicroDataFrame(frame.copy(), weights=weights)
-
-
-def _person_group_column(person, entity: str) -> str:
-    prefixed = f"person_{entity}_id"
-    if prefixed in person.columns:
-        return prefixed
-    return f"{entity}_id"
-
-
-def _subsample_us_dataset(dataset, subsample: int | None):
-    if not subsample:
-        return dataset
-
-    from policyengine.tax_benefit_models.us.datasets import (
-        PolicyEngineUSDataset,
-        USYearData,
-    )
-
-    dataset.load()
-    data = dataset.data
-    household = data.household.head(int(subsample)).copy()
-    household_ids = set(household["household_id"])
-
-    person_household_col = _person_group_column(data.person, "household")
-    person = data.person[data.person[person_household_col].isin(household_ids)].copy()
-
-    def group_subset(entity: str):
-        person_col = _person_group_column(person, entity)
-        entity_id_col = f"{entity}_id"
-        ids = set(person[person_col])
-        frame = getattr(data, entity)
-        return frame[frame[entity_id_col].isin(ids)].copy()
-
-    subset_data = USYearData(
-        person=_microframe_like(person, "person_weight"),
-        marital_unit=_microframe_like(
-            group_subset("marital_unit"), "marital_unit_weight"
-        ),
-        family=_microframe_like(group_subset("family"), "family_weight"),
-        spm_unit=_microframe_like(group_subset("spm_unit"), "spm_unit_weight"),
-        tax_unit=_microframe_like(group_subset("tax_unit"), "tax_unit_weight"),
-        household=_microframe_like(household, "household_weight"),
-    )
-    subset_path = os.path.join(
-        os.environ.get("POLICYENGINE_DATA_FOLDER", "/tmp/policyengine-data"),
-        f"{dataset.id}_subsample_{subsample}.h5",
-    )
-    return PolicyEngineUSDataset(
-        id=f"{dataset.id}_subsample_{subsample}",
-        name=f"{dataset.name} subsample {subsample}",
-        description=dataset.description,
-        filepath=subset_path,
-        year=dataset.year,
-        is_output_dataset=dataset.is_output_dataset,
-        metadata=getattr(dataset, "metadata", {}),
-        metadata_filepath=getattr(dataset, "metadata_filepath", None),
-        data=subset_data,
     )
 
 
@@ -463,10 +384,7 @@ def _load_dataset(
             "POLICYENGINE_DATA_FOLDER", "/tmp/policyengine-data"
         ),
     )
-    dataset = next(iter(datasets.values()))
-    if country == "us":
-        return _subsample_us_dataset(dataset, params.get("subsample"))
-    return dataset
+    return next(iter(datasets.values()))
 
 
 def _build_simulation(

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -563,9 +563,9 @@ class TestSubmitSimulationEndpoint:
         bundle["policyengine_version"] = "4.13.1"
         bundle["uk"]["model_version"] = "2.88.20"
         bundle["uk"]["data_version"] = "1.55.10"
-        bundle["uk"][
-            "data_artifact_revision"
-        ] = "655dd07e4bb9c777b00dac044949611f1feb824f"
+        bundle["uk"]["data_artifact_revision"] = (
+            "655dd07e4bb9c777b00dac044949611f1feb824f"
+        )
         bundle["uk"]["default_dataset_uri"] = manifest_uri
         bundle["uk"]["dataset_uris"]["enhanced_frs_2023_24"] = manifest_uri
         state = deepcopy(TEST_ROUTING_STATE)

--- a/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_endpoints.py
@@ -398,7 +398,7 @@ class TestSubmitSimulationEndpoint:
             "us", "enhanced_cps_2024"
         )
 
-    def test__given_us_state_region_without_data__then_bundle_metadata_uses_state_dataset(
+    def test__given_us_state_region_without_data__then_keeps_contract_and_uses_default_dataset(
         self, mock_modal, client: TestClient
     ):
         mock_modal["dicts"]["simulation-api-us-versions"] = {
@@ -411,7 +411,7 @@ class TestSubmitSimulationEndpoint:
             json={
                 "country": "us",
                 "scope": "macro",
-                "region": "state/ut",
+                "region": "state/UT",
                 "reform": {},
             },
         )
@@ -420,8 +420,6 @@ class TestSubmitSimulationEndpoint:
         assert response.json()["policyengine_bundle"] == expected_bundle(
             "us",
             "1.500.0",
-            dataset="states/UT",
-            data_version="1.115.5",
         )
 
     def test__given_submission_with_logical_revision__then_bundle_dataset_uses_revision(

--- a/projects/policyengine-api-simulation/tests/gateway/test_models.py
+++ b/projects/policyengine-api-simulation/tests/gateway/test_models.py
@@ -208,6 +208,8 @@ class TestSimulationRequest:
             SimulationRequest(country="us", dataset="enhanced_cps_2024")
         with pytest.raises(ValidationError):
             SimulationRequest(country="us", mystery_flag=True)
+        with pytest.raises(ValidationError):
+            SimulationRequest(country="us", subsample=100)
 
     def test_simulation_request_rejects_oversized_payload(self):
         """Payloads that exceed the gateway max should 422 before Pydantic

--- a/projects/policyengine-api-simulation/tests/test_modal_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_scripts.py
@@ -618,6 +618,6 @@ class TestAllScriptsHaveShebang:
                 capture_output=True,
                 text=True,
             )
-            assert (
-                result.returncode == 0
-            ), f"{script.name} has syntax errors: {result.stderr}"
+            assert result.returncode == 0, (
+                f"{script.name} has syntax errors: {result.stderr}"
+            )

--- a/projects/policyengine-api-simulation/tests/test_policyengine_package_update_scripts.py
+++ b/projects/policyengine-api-simulation/tests/test_policyengine_package_update_scripts.py
@@ -152,6 +152,8 @@ def test_update_policyengine_package_updates_py_and_bundled_runtime_pins(
     assert "policyengine-core==999.999.999" in pyproject_text
     assert "policyengine-us==1.1.0" in pyproject_text
     assert "policyengine-uk==2.1.0" in pyproject_text
+    assert "policyengine-us-data" not in pyproject_text
+    assert "policyengine-uk-data" not in pyproject_text
     uv_calls = uv_log.read_text(encoding="utf-8")
     assert "lock --upgrade-package policyengine" in uv_calls
     assert "run python -m src.modal.utils.extract_bundle_versions --shell" in uv_calls

--- a/projects/policyengine-api-simulation/tests/test_release_bundle.py
+++ b/projects/policyengine-api-simulation/tests/test_release_bundle.py
@@ -6,7 +6,6 @@ from policyengine_api_simulation.release_bundle import (
     BUNDLE_RECEIPT_FILENAME,
     get_country_release_bundle,
     resolve_bundle_dataset_name,
-    resolve_bundle_region_dataset_uri,
     resolve_bundle_dataset_uri,
     resolve_runtime_bundle_dataset_uri,
 )
@@ -80,11 +79,6 @@ def test_resolve_bundle_dataset_uri_does_not_certify_us_state_sidecars():
 
     assert "states/UT" not in bundle.dataset_uris
     assert resolve_bundle_dataset_uri("us", "states/UT") == "states/UT"
-
-
-def test_resolve_bundle_region_dataset_uri_does_not_map_us_states_to_sidecars():
-    assert resolve_bundle_region_dataset_uri("us", "state/ut") is None
-    assert resolve_bundle_region_dataset_uri("us", "state/ut", "1.77.0") is None
 
 
 def test_resolve_bundle_dataset_uri_keeps_legacy_aliases_as_explicit_overrides():

--- a/projects/policyengine-api-simulation/tests/test_release_bundle.py
+++ b/projects/policyengine-api-simulation/tests/test_release_bundle.py
@@ -91,8 +91,9 @@ def test_resolve_bundle_dataset_uri_keeps_legacy_aliases_as_explicit_overrides()
     assert resolve_bundle_dataset_uri("us", "enhanced_cps") == (
         "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.110.12"
     )
-    assert resolve_bundle_dataset_uri("uk", "enhanced_frs") == (
-        get_country_release_bundle("uk").dataset_uris["enhanced_frs_2023_24"]
+    assert (
+        resolve_bundle_dataset_uri("uk", "enhanced_frs")
+        == (get_country_release_bundle("uk").dataset_uris["enhanced_frs_2023_24"])
     )
 
 

--- a/projects/policyengine-api-simulation/tests/test_release_bundle.py
+++ b/projects/policyengine-api-simulation/tests/test_release_bundle.py
@@ -75,27 +75,16 @@ def test_resolve_bundle_dataset_uri_maps_certified_defaults_to_manifest_uris():
     )
 
 
-def test_resolve_bundle_dataset_uri_maps_certified_us_state_datasets():
+def test_resolve_bundle_dataset_uri_does_not_certify_us_state_sidecars():
     bundle = get_country_release_bundle("us")
 
-    assert bundle.dataset_uris["states/UT"] == (
-        "hf://policyengine/policyengine-us-data/states/UT.h5@1.115.5"
-    )
-    assert resolve_bundle_dataset_uri("us", "states/UT") == (
-        "hf://policyengine/policyengine-us-data/states/UT.h5@1.115.5"
-    )
+    assert "states/UT" not in bundle.dataset_uris
+    assert resolve_bundle_dataset_uri("us", "states/UT") == "states/UT"
 
 
-def test_resolve_bundle_region_dataset_uri_maps_us_state_to_certified_dataset():
-    assert resolve_bundle_region_dataset_uri("us", "state/ut") == (
-        "gs://policyengine-us-data/states/UT.h5@1.115.5"
-    )
-
-
-def test_resolve_bundle_region_dataset_uri_applies_requested_version():
-    assert resolve_bundle_region_dataset_uri("us", "state/ut", "1.77.0") == (
-        "gs://policyengine-us-data/states/UT.h5@1.77.0"
-    )
+def test_resolve_bundle_region_dataset_uri_does_not_map_us_states_to_sidecars():
+    assert resolve_bundle_region_dataset_uri("us", "state/ut") is None
+    assert resolve_bundle_region_dataset_uri("us", "state/ut", "1.77.0") is None
 
 
 def test_resolve_bundle_dataset_uri_keeps_legacy_aliases_as_explicit_overrides():

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
@@ -552,6 +552,97 @@ def test_load_dataset_passes_bundle_default_name_to_country_loader_with_receipt(
     ]
 
 
+def test_resolve_region_scopes_us_state_from_national_populace_dataset():
+    bundle = get_country_release_bundle("us")
+    scoping_strategy = object()
+    state = SimpleNamespace(
+        dataset_path=None,
+        scoping_strategy=scoping_strategy,
+        parent_code="us",
+    )
+    national = SimpleNamespace(
+        dataset_path=bundle.default_dataset_uri,
+        scoping_strategy=None,
+        parent_code=None,
+    )
+    regions = {"state/ut": state, "us": national}
+    country_module = SimpleNamespace(
+        model=SimpleNamespace(get_region=lambda code: regions.get(code))
+    )
+
+    resolution = _resolve_region(
+        country_module=country_module,
+        country="us",
+        params={"region": "state/UT"},
+    )
+
+    assert resolution.code == "state/ut"
+    assert resolution.dataset_reference == bundle.default_dataset_uri
+    assert resolution.scoping_strategy is scoping_strategy
+
+
+def test_resolve_region_scopes_us_congressional_district_from_national_dataset():
+    bundle = get_country_release_bundle("us")
+    scoping_strategy = object()
+    district = SimpleNamespace(
+        dataset_path=None,
+        scoping_strategy=scoping_strategy,
+        parent_code="state/ut",
+    )
+    state = SimpleNamespace(
+        dataset_path=None,
+        scoping_strategy=object(),
+        parent_code="us",
+    )
+    national = SimpleNamespace(
+        dataset_path=bundle.default_dataset_uri,
+        scoping_strategy=None,
+        parent_code=None,
+    )
+    regions = {
+        "congressional_district/UT-01": district,
+        "state/ut": state,
+        "us": national,
+    }
+    country_module = SimpleNamespace(
+        model=SimpleNamespace(get_region=lambda code: regions.get(code))
+    )
+
+    resolution = _resolve_region(
+        country_module=country_module,
+        country="us",
+        params={"region": "congressional_district/ut-01"},
+    )
+
+    assert resolution.code == "congressional_district/UT-01"
+    assert resolution.dataset_reference == bundle.default_dataset_uri
+    assert resolution.scoping_strategy is scoping_strategy
+
+
+def test_resolve_region_rejects_unscoped_us_place_region():
+    place = SimpleNamespace(
+        dataset_path=None,
+        scoping_strategy=None,
+        parent_code="state/ut",
+    )
+    state = SimpleNamespace(
+        dataset_path=None,
+        scoping_strategy=object(),
+        parent_code="us",
+    )
+    regions = {"place/UT-67000": place, "state/ut": state}
+    country_module = SimpleNamespace(
+        model=SimpleNamespace(get_region=lambda code: regions.get(code))
+    )
+
+    with pytest.raises(ValueError, match="US place regions are not yet supported"):
+        _resolve_region(
+            country_module=country_module,
+            country="us",
+            params={"region": "place/ut-67000"},
+        )
+
+
 def test_resolve_region_scopes_us_place_from_parent_state_dataset(monkeypatch):
     monkeypatch.setattr(
         "policyengine_api_simulation.dataset_uri.with_hf_revision",
@@ -583,7 +674,7 @@ def test_resolve_region_scopes_us_place_from_parent_state_dataset(monkeypatch):
 
     assert resolution.code == "place/CA-57000"
     assert resolution.dataset_reference == (
-        "gs://policyengine-us-data/states/CA.h5@1.115.5"
+        "gs://policyengine-us-data/states/CA.h5@1.110.12"
     )
     assert resolution.scoping_strategy is scoping_strategy
 

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
@@ -404,6 +404,65 @@ def test_run_simulation_impl_core_builds_and_serializes_macro_output(monkeypatch
     ]
 
 
+def test_run_simulation_impl_core_passes_region_scoping_to_simulations(monkeypatch):
+    dataset = object()
+    country_module = SimpleNamespace(model=SimpleNamespace(version="1.715.2"))
+    baseline_simulation = object()
+    reform_simulation = object()
+    scoping_strategy = object()
+    region_resolution = RegionResolution(
+        code="state/ut",
+        dataset_reference="dataset",
+        scoping_strategy=scoping_strategy,
+    )
+    build_calls = []
+
+    def fake_build_simulation(params, *, dataset, policy, scoping_strategy=None):
+        build_calls.append((params, dataset, policy, scoping_strategy))
+        return baseline_simulation if len(build_calls) == 1 else reform_simulation
+
+    class FakeSimulationOutputBuilder:
+        def __init__(self, **kwargs):
+            pass
+
+        def serialize(self):
+            return CURRENT_SINGLE_YEAR_MACRO_RESULT
+
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime._country_module",
+        lambda country: country_module,
+    )
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime._resolve_region",
+        lambda **kwargs: region_resolution,
+    )
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime._load_dataset",
+        lambda params, country_module, region_resolution: dataset,
+    )
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime._build_simulation",
+        fake_build_simulation,
+    )
+    monkeypatch.setattr(
+        "policyengine_api_simulation.simulation_runtime.SimulationOutputBuilder",
+        FakeSimulationOutputBuilder,
+    )
+
+    result = _run_simulation_impl_core(
+        {
+            "country": "us",
+            "region": "state/ut",
+            "baseline": {},
+            "reform": {},
+        }
+    )
+
+    assert result == CURRENT_SINGLE_YEAR_MACRO_RESULT
+    assert build_calls[0][3] is scoping_strategy
+    assert build_calls[1][3] is scoping_strategy
+
+
 def test_resolve_region_uses_dedicated_region_dataset_with_requested_version(
     monkeypatch,
 ):
@@ -439,10 +498,6 @@ def test_resolve_region_uses_dedicated_region_dataset_with_requested_version(
 
 def test_resolve_region_maps_bundle_manifest_revision_to_data_version(monkeypatch):
     manifest_revision = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
-    monkeypatch.setattr(
-        "policyengine_api_simulation.simulation_runtime.resolve_bundle_region_dataset_uri",
-        lambda country, region_code, requested_data_version=None: None,
-    )
     monkeypatch.setattr(
         "policyengine_api_simulation.simulation_runtime.get_country_release_bundle",
         lambda country: SimpleNamespace(
@@ -681,10 +736,6 @@ def test_resolve_region_scopes_us_place_from_parent_state_dataset(monkeypatch):
 
 def test_resolve_region_maps_parent_manifest_revision_to_data_version(monkeypatch):
     manifest_revision = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
-    monkeypatch.setattr(
-        "policyengine_api_simulation.simulation_runtime.resolve_bundle_region_dataset_uri",
-        lambda country, region_code, requested_data_version=None: None,
-    )
     monkeypatch.setattr(
         "policyengine_api_simulation.simulation_runtime.get_country_release_bundle",
         lambda country: SimpleNamespace(

--- a/projects/policyengine-api-simulation/tests/test_standalone_simulation_contract.py
+++ b/projects/policyengine-api-simulation/tests/test_standalone_simulation_contract.py
@@ -51,6 +51,10 @@ def test_standalone_simulation_openapi_keeps_legacy_schema_names():
         "telemetry"
         not in spec["components"]["schemas"]["SimulationOptions"]["properties"]
     )
+    assert (
+        "subsample"
+        not in spec["components"]["schemas"]["SimulationOptions"]["properties"]
+    )
 
 
 def test_standalone_simulation_route_returns_legacy_macro_contract(monkeypatch):

--- a/projects/policyengine-api-simulation/uv.lock
+++ b/projects/policyengine-api-simulation/uv.lock
@@ -1635,7 +1635,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1675,7 +1675,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.18.5"
+version = "4.18.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -1689,9 +1689,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/2c/5e600a757fd03e227b99009067c6e4e05c97c9d05cc1e28410f7a3fef9b5/policyengine-4.18.5.tar.gz", hash = "sha256:a4d484964856debd1ce18fcf71ac9957e8a4cf897a2bb2652953bd191695b8c7", size = 697884, upload-time = "2026-06-27T06:44:22.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/18/9d1351b5212887a5ea440538d31e4916824a6f3ecdd3426da722e4d7c1bf/policyengine-4.18.6.tar.gz", hash = "sha256:e20a5ce0a190a07ff22aa4a676aa4099295a8939acbe9aa79de6f865c9d353b4", size = 696623, upload-time = "2026-06-28T13:05:13.858Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/b7/d2abead0bb24e497950b2e2cbd847c544c25d97dd4ad6c641084e6f754ed/policyengine-4.18.5-py3-none-any.whl", hash = "sha256:960469cec0ad47d85e64151c3c9cf0db6b38624b2bae66cedbd993ae32ee7a55", size = 211057, upload-time = "2026-06-27T06:44:20.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/76/489694ea25fa4644e36d2e94ab55f7e4d24b7a1655be39cd599d6dba16bd/policyengine-4.18.6-py3-none-any.whl", hash = "sha256:09c7556ca26d35ddd438381d342ea53595b6440c2f05b0101b7bf527f816a8a2", size = 208900, upload-time = "2026-06-28T13:05:12.44Z" },
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ requires-dist = [
     { name = "openapi-python-client", marker = "extra == 'build'", specifier = ">=0.21.6" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.51b0,<0.52" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.51b0,<0.52" },
-    { name = "policyengine", specifier = "==4.18.5" },
+    { name = "policyengine", specifier = "==4.18.6" },
     { name = "policyengine-core", specifier = "==3.28.0" },
     { name = "policyengine-fastapi", editable = "../../libs/policyengine-fastapi" },
     { name = "policyengine-uk", specifier = "==2.89.2" },


### PR DESCRIPTION
Fixes #584

## Summary

Update the simulation API for policyengine.py 4.18.6 and the new US subnational data behavior.

This PR:

- updates the simulation API runtime to policyengine.py 4.18.6
- syncs policyengine-core, policyengine-us, and policyengine-uk pins to the bundle versions
- resolves US subnational simulations from the national Populace-backed dataset/scoping path
- keeps the public API contract for existing region strings such as state/... and congressional_district/...
- keeps gateway bundle metadata aligned with the deployed policyengine.py bundle
- adds coverage for bundle-driven dependency updates and regional simulation behavior

## Validation

- Local pytest was started with the same command as CI: uv run pytest tests/ -v from projects/policyengine-api-simulation.
- The run was interrupted by the user after the dependency-source and bundle/version tests had passed, before final completion.
