### PR TITLE
Raise simulation integration timeout to 15 minutes

### DIFF
--- a/projects/policyengine-apis-integ/tests/simulation/conftest.py
+++ b/projects/policyengine-apis-integ/tests/simulation/conftest.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
     base_url: str = "http://localhost:8082"
     access_token: str | None = None
     gateway_auth_required: bool = False
-    timeout_in_millis: int = 600_000  # 10 minutes for full simulations
+    timeout_in_millis: int = 900_000  # 15 minutes for full simulations
     poll_interval_seconds: float = 5.0
     us_model_version: str = "1.690.7"
     uk_model_version: str = "2.88.14"


### PR DESCRIPTION
Fixes #591

## Summary
- Raise the simulation integration-test timeout from 10 minutes to 15 minutes.
- Keep the change scoped to the generated-client integration test settings.

## Validation
- uv run pytest tests/simulation/test_calculate.py --collect-only -q from projects/policyengine-apis-integ

## Not run
- Full live simulation integration tests; those submit real Modal jobs and are the deploy check this timeout affects.