### PR TITLE
Prebuild single-year datasets into the Modal simulation image (temporary)

### DIFF
--- a/projects/policyengine-api-simulation/README.md
+++ b/projects/policyengine-api-simulation/README.md
@@ -18,8 +18,13 @@ Operational notes:
   `modal deploy`, and only rebuilds when `POLICYENGINE_*` versions change or
   the prebuild function itself is edited (even comment changes). It sits
   before `add_local_python_source` on purpose — do not reorder.
-- The first deploy after a version bump pays the multi-hour build; consider
-  pre-warming with a scratch `MODAL_APP_NAME` deploy before merging.
+- The first deploy after a version bump pays the multi-hour build. Pre-warm
+  it off the deploy path with the minimum-reproduction app, which builds
+  only the layers up to the prebuild and then verifies the baked files and
+  load path from inside a container:
+  `uv run modal run --env=staging src/modal/prewarm_app.py`.
+  Because it shares the layer construction with `app.py`, a successful run
+  leaves the layers cached and the next real deploy fast-forwards.
 - To force a rebuild of a cached layer (e.g. a data re-release under the
   same revision label), temporarily add `force_build=True` to the affected
   `run_function` call in `src/modal/app.py` for one deploy.

--- a/projects/policyengine-api-simulation/README.md
+++ b/projects/policyengine-api-simulation/README.md
@@ -1,3 +1,26 @@
 # policyengine-api-simulation
 
 PolicyEngine Simulation API service.
+
+## Temporary: prebuilt single-year datasets in the Modal image
+
+The Modal image prebuilds single-year datasets (2025–2027, US + UK national
+defaults) into `POLICYENGINE_DATA_FOLDER` at image build time
+(`src/modal/_image_setup.py:prebuild_country_datasets`), so cold containers
+skip the slow runtime `ensure_datasets()` build. This is temporary until
+Populace publishes single-year datasets to Hugging Face — see issue #596 for
+the removal checklist; all code sites are greppable via `TEMPORARY`.
+
+Operational notes:
+
+- The prebuild layers run in series on Modal's cloud image builder during
+  `modal deploy`, and only rebuild when `POLICYENGINE_*` versions change or
+  the prebuild function itself is edited (even comment changes). They sit
+  before `add_local_python_source` on purpose — do not reorder.
+- The first deploy after a version bump pays the multi-hour build; consider
+  pre-warming with a scratch `MODAL_APP_NAME` deploy before merging.
+- To force a rebuild of a cached layer (e.g. a data re-release under the
+  same revision label), temporarily add `force_build=True` to the affected
+  `run_function` call in `src/modal/app.py` for one deploy.
+- Requests pinning a non-default `data_version` bypass the baked folder
+  (see `_load_dataset` in `simulation_runtime.py`).

--- a/projects/policyengine-api-simulation/README.md
+++ b/projects/policyengine-api-simulation/README.md
@@ -23,5 +23,6 @@ Operational notes:
 - To force a rebuild of a cached layer (e.g. a data re-release under the
   same revision label), temporarily add `force_build=True` to the affected
   `run_function` call in `src/modal/app.py` for one deploy.
-- Requests pinning a non-default `data_version` bypass the baked folder
-  (see `_load_dataset` in `simulation_runtime.py`).
+- Only pure default requests read the baked folder: any request naming an
+  explicit `data` dataset or pinning a `data_version` bypasses it (see
+  `_load_dataset` in `simulation_runtime.py`).

--- a/projects/policyengine-api-simulation/README.md
+++ b/projects/policyengine-api-simulation/README.md
@@ -4,8 +4,9 @@ PolicyEngine Simulation API service.
 
 ## Temporary: prebuilt single-year datasets in the Modal image
 
-The Modal image prebuilds single-year datasets (2025–2027, US + UK national
-defaults) into `POLICYENGINE_DATA_FOLDER` at image build time
+The Modal image prebuilds single-year datasets (2025–2027, US national
+default only — UK deliberately excluded to keep image builds short) into
+`POLICYENGINE_DATA_FOLDER` at image build time
 (`src/modal/_image_setup.py:prebuild_country_datasets`), so cold containers
 skip the slow runtime `ensure_datasets()` build. This is temporary until
 Populace publishes single-year datasets to Hugging Face — see issue #596 for
@@ -13,9 +14,9 @@ the removal checklist; all code sites are greppable via `TEMPORARY`.
 
 Operational notes:
 
-- The prebuild layers run in series on Modal's cloud image builder during
-  `modal deploy`, and only rebuild when `POLICYENGINE_*` versions change or
-  the prebuild function itself is edited (even comment changes). They sit
+- The prebuild layer runs on Modal's cloud image builder during
+  `modal deploy`, and only rebuilds when `POLICYENGINE_*` versions change or
+  the prebuild function itself is edited (even comment changes). It sits
   before `add_local_python_source` on purpose — do not reorder.
 - The first deploy after a version bump pays the multi-hour build; consider
   pre-warming with a scratch `MODAL_APP_NAME` deploy before merging.

--- a/projects/policyengine-api-simulation/src/modal/_image_setup.py
+++ b/projects/policyengine-api-simulation/src/modal/_image_setup.py
@@ -11,7 +11,7 @@ so policyengine_api_simulation is not importable there at all.
 # These years are baked into the image; uncovered years still build at runtime.
 # NOTE: this constant is a referenced global of prebuild_country_datasets, so
 # changing it (like editing the function body, even comments) invalidates the
-# cached multi-hour image layers.
+# cached multi-hour image layer.
 PREBUILD_DATASET_YEARS = [2025, 2026, 2027]
 
 

--- a/projects/policyengine-api-simulation/src/modal/_image_setup.py
+++ b/projects/policyengine-api-simulation/src/modal/_image_setup.py
@@ -3,7 +3,83 @@ Standalone image setup functions.
 
 These functions are executed during Modal image build and must not
 import any other modules from this package to avoid dependency issues.
+The dataset prebuild additionally runs BEFORE add_local_python_source,
+so policyengine_api_simulation is not importable there at all.
 """
+
+# TEMPORARY: remove once single-year datasets are published (see issue #596).
+# These years are baked into the image; uncovered years still build at runtime.
+# NOTE: this constant is a referenced global of prebuild_country_datasets, so
+# changing it (like editing the function body, even comments) invalidates the
+# cached multi-hour image layers.
+PREBUILD_DATASET_YEARS = [2025, 2026, 2027]
+
+
+def prebuild_country_datasets(country: str):
+    """TEMPORARY: bake single-year national datasets into the image layer.
+
+    Remove once single-year datasets are published (see issue #596).
+
+    policyengine.py's ensure_datasets() rebuilds missing
+    ``{stem}_year_{year}.h5`` files at runtime with a full Microsimulation
+    pass, which dominates cold-container latency. Building them here bakes
+    the files into the image at POLICYENGINE_DATA_FOLDER so the runtime
+    existence check hits immediately.
+    """
+    import logging
+    import os
+    from importlib import import_module
+    from pathlib import Path
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    os.environ.setdefault("POLICYENGINE_SKIP_COUNTRY_IMPORTS", "1")
+
+    from policyengine.provenance.manifest import (
+        dataset_logical_name,
+        get_release_manifest,
+        resolve_dataset_reference,
+    )
+
+    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    # Pass the dataset name explicitly: the UK ensure_datasets has no
+    # datasets=None fallback, and the explicit name mirrors the runtime
+    # call shape in simulation_runtime._load_dataset.
+    default_dataset = get_release_manifest(country).default_dataset
+    stem = dataset_logical_name(resolve_dataset_reference(country, default_dataset))
+    targets = {
+        year: Path(data_folder) / f"{stem}_year_{year}.h5"
+        for year in PREBUILD_DATASET_YEARS
+    }
+    missing_years = [year for year, path in targets.items() if not path.exists()]
+    if not missing_years:
+        logger.info("All %s single-year datasets already present", country)
+        return
+
+    logger.info(
+        "Prebuilding %s dataset %s for years %s into %s",
+        country,
+        default_dataset,
+        missing_years,
+        data_folder,
+    )
+    country_module = import_module(f"policyengine.tax_benefit_models.{country}")
+    country_module.ensure_datasets(
+        datasets=[default_dataset],
+        years=missing_years,
+        data_folder=data_folder,
+    )
+
+    still_missing = [str(path) for path in targets.values() if not path.exists()]
+    if still_missing:
+        # Fail the image build loudly rather than shipping an image that
+        # silently falls back to per-request dataset builds.
+        raise RuntimeError(
+            f"Prebuild did not produce expected dataset files: {still_missing}"
+        )
+    for year, path in targets.items():
+        logger.info("Prebuilt %s (%.1f MB)", path, path.stat().st_size / 1e6)
 
 
 def snapshot_models():

--- a/projects/policyengine-api-simulation/src/modal/_image_setup.py
+++ b/projects/policyengine-api-simulation/src/modal/_image_setup.py
@@ -43,9 +43,9 @@ def prebuild_country_datasets(country: str):
     )
 
     data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
-    # Pass the dataset name explicitly: the UK ensure_datasets has no
-    # datasets=None fallback, and the explicit name mirrors the runtime
-    # call shape in simulation_runtime._load_dataset.
+    # Pass the dataset name explicitly to mirror the runtime call shape in
+    # simulation_runtime._load_dataset (not every country module accepts
+    # datasets=None).
     default_dataset = get_release_manifest(country).default_dataset
     stem = dataset_logical_name(resolve_dataset_reference(country, default_dataset))
     targets = {

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -116,37 +116,50 @@ def bundle_install_command(policyengine_version: str) -> str:
     )
 
 
+def build_base_simulation_image() -> modal.Image:
+    """Image layers up to and including the dataset prebuild.
+
+    Shared by the deployed app and the prewarm app
+    (src/modal/prewarm_app.py): both must construct these layers through
+    this one code path so their definitions — and therefore Modal's
+    content-addressed layer cache keys — are identical.
+    """
+    return (
+        modal.Image.debian_slim(python_version="3.13")
+        .pip_install(
+            "uv",
+            "fastapi>=0.115.0",
+            "tables>=3.10.2",
+            "logfire",
+        )
+        .run_commands(
+            bundle_install_command(POLICYENGINE_VERSION),
+            secrets=[data_secret, hf_secret],
+        )
+        .env(VERSION_ENV)
+        # TEMPORARY: remove once single-year datasets are published (issue
+        # #596). Prebuild US single-year datasets into the image so cold
+        # containers skip the slow runtime build. US only for now, to keep
+        # image build time low — UK requests still build at request time.
+        # This layer MUST stay before add_local_python_source — that layer
+        # is keyed on source file hashes, so anything after it rebuilds on
+        # every code change, and this layer takes hours. To force a rebuild
+        # of a cached layer (e.g. after a data re-release under the same
+        # revision), temporarily add force_build=True.
+        .run_function(
+            prebuild_country_datasets,
+            args=("us",),
+            secrets=[data_secret, hf_secret],
+            cpu=8.0,
+            memory=65536,
+            timeout=4 * 60 * 60,
+        )
+    )
+
+
 # Heavy image with model snapshot for simulation
 simulation_image = (
-    modal.Image.debian_slim(python_version="3.13")
-    .pip_install(
-        "uv",
-        "fastapi>=0.115.0",
-        "tables>=3.10.2",
-        "logfire",
-    )
-    .run_commands(
-        bundle_install_command(POLICYENGINE_VERSION),
-        secrets=[data_secret, hf_secret],
-    )
-    .env(VERSION_ENV)
-    # TEMPORARY: remove once single-year datasets are published (issue #596).
-    # Prebuild US single-year datasets into the image so cold containers
-    # skip the slow runtime build. US only for now, to keep image build
-    # time low — UK requests still build at request time. This layer MUST
-    # stay before add_local_python_source — that layer is keyed on source
-    # file hashes, so anything after it rebuilds on every code change, and
-    # this layer takes hours. To force a rebuild of a cached layer (e.g.
-    # after a data re-release under the same revision), temporarily add
-    # force_build=True.
-    .run_function(
-        prebuild_country_datasets,
-        args=("us",),
-        secrets=[data_secret, hf_secret],
-        cpu=8.0,
-        memory=65536,
-        timeout=4 * 60 * 60,
-    )
+    build_base_simulation_image()
     .add_local_python_source(
         "src.modal",
         "policyengine_api_simulation",

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -131,27 +131,20 @@ simulation_image = (
     )
     .env(VERSION_ENV)
     # TEMPORARY: remove once single-year datasets are published (issue #596).
-    # Prebuild single-year datasets into the image so cold containers skip
-    # the slow runtime build. One layer per country: independent cache
-    # entries and resumable builds. These layers MUST stay before
-    # add_local_python_source — that layer is keyed on source file hashes,
-    # so anything after it rebuilds on every code change, and these layers
-    # take hours. To force a rebuild of a cached layer (e.g. after a data
-    # re-release under the same revision), temporarily add force_build=True.
+    # Prebuild US single-year datasets into the image so cold containers
+    # skip the slow runtime build. US only for now, to keep image build
+    # time low — UK requests still build at request time. This layer MUST
+    # stay before add_local_python_source — that layer is keyed on source
+    # file hashes, so anything after it rebuilds on every code change, and
+    # this layer takes hours. To force a rebuild of a cached layer (e.g.
+    # after a data re-release under the same revision), temporarily add
+    # force_build=True.
     .run_function(
         prebuild_country_datasets,
         args=("us",),
         secrets=[data_secret, hf_secret],
         cpu=8.0,
         memory=65536,
-        timeout=4 * 60 * 60,
-    )
-    .run_function(
-        prebuild_country_datasets,
-        args=("uk",),
-        secrets=[data_secret, hf_secret],
-        cpu=8.0,
-        memory=32768,
         timeout=4 * 60 * 60,
     )
     .add_local_python_source(

--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -10,7 +10,7 @@ The gateway app (policyengine-simulation-gateway) routes requests to these versi
 import modal
 import os
 
-from src.modal._image_setup import snapshot_models
+from src.modal._image_setup import prebuild_country_datasets, snapshot_models
 from src.modal.dependency_pins import project_dependency_pin
 from src.modal.logging_redaction import redact_params_for_logging
 from policyengine_api_simulation.release_bundle import get_bundled_country_model_version
@@ -130,6 +130,30 @@ simulation_image = (
         secrets=[data_secret, hf_secret],
     )
     .env(VERSION_ENV)
+    # TEMPORARY: remove once single-year datasets are published (issue #596).
+    # Prebuild single-year datasets into the image so cold containers skip
+    # the slow runtime build. One layer per country: independent cache
+    # entries and resumable builds. These layers MUST stay before
+    # add_local_python_source — that layer is keyed on source file hashes,
+    # so anything after it rebuilds on every code change, and these layers
+    # take hours. To force a rebuild of a cached layer (e.g. after a data
+    # re-release under the same revision), temporarily add force_build=True.
+    .run_function(
+        prebuild_country_datasets,
+        args=("us",),
+        secrets=[data_secret, hf_secret],
+        cpu=8.0,
+        memory=65536,
+        timeout=4 * 60 * 60,
+    )
+    .run_function(
+        prebuild_country_datasets,
+        args=("uk",),
+        secrets=[data_secret, hf_secret],
+        cpu=8.0,
+        memory=32768,
+        timeout=4 * 60 * 60,
+    )
     .add_local_python_source(
         "src.modal",
         "policyengine_api_simulation",

--- a/projects/policyengine-api-simulation/src/modal/prewarm_app.py
+++ b/projects/policyengine-api-simulation/src/modal/prewarm_app.py
@@ -1,0 +1,91 @@
+"""TEMPORARY: minimum reproduction / pre-warm app for the dataset prebuild.
+
+Remove once single-year datasets are published (see issue #596).
+
+Builds ONLY the image layers up to and including the single-year dataset
+prebuild (no local source, no model snapshot), then runs a container from
+that image to verify the baked files exist and that the runtime load path
+cache-hits. Because the layers are constructed via
+``app.build_base_simulation_image()``, they are byte-identical to the real
+app's layers, so a successful run leaves them in Modal's workspace image
+cache and the next real deploy fast-forwards through them.
+
+Usage (from projects/policyengine-api-simulation):
+
+    uv run modal run --env=staging src/modal/prewarm_app.py
+
+The slow part is the image build (streamed before the function runs); the
+verification function itself takes seconds. Interrupting the local client
+mid-build does not deploy anything — the app here is ephemeral.
+"""
+
+import json
+
+import modal
+
+from src.modal._image_setup import PREBUILD_DATASET_YEARS
+from src.modal.app import build_base_simulation_image
+
+app = modal.App("policyengine-simulation-prebuild-prewarm")
+
+
+@app.function(
+    image=build_base_simulation_image(),
+    cpu=4.0,
+    memory=32768,
+    timeout=1800,
+    serialized=True,
+)
+def verify_prebuilt_datasets(years: list[int]) -> dict:
+    """Verify baked datasets from inside a container on the built image.
+
+    Serialized so the container never imports this module (the base image
+    deliberately lacks the local source packages).
+    """
+    import os
+    import time
+    from importlib import import_module
+    from pathlib import Path
+
+    os.environ.setdefault("POLICYENGINE_SKIP_COUNTRY_IMPORTS", "1")
+    from policyengine.provenance.manifest import (
+        dataset_logical_name,
+        get_release_manifest,
+        resolve_dataset_reference,
+    )
+
+    data_folder = Path(
+        os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    )
+    default_dataset = get_release_manifest("us").default_dataset
+    stem = dataset_logical_name(resolve_dataset_reference("us", default_dataset))
+
+    report: dict[str, str] = {}
+    missing = []
+    for year in years:
+        path = data_folder / f"{stem}_year_{year}.h5"
+        if path.exists():
+            report[path.name] = f"{path.stat().st_size / 1e6:.1f} MB"
+        else:
+            missing.append(path.name)
+    if missing:
+        raise RuntimeError(f"Baked datasets missing from image: {missing}")
+
+    # Time the exact runtime load path: a cache hit loads the baked h5 in
+    # seconds; minutes would mean ensure_datasets fell back to a rebuild
+    # (i.e. the stems do not match what the runtime resolves).
+    start = time.monotonic()
+    country_module = import_module("policyengine.tax_benefit_models.us")
+    country_module.ensure_datasets(
+        datasets=[default_dataset],
+        years=[years[0]],
+        data_folder=str(data_folder),
+    )
+    report["ensure_datasets_load_seconds"] = f"{time.monotonic() - start:.1f}"
+    return report
+
+
+@app.local_entrypoint()
+def main():
+    report = verify_prebuilt_datasets.remote(years=PREBUILD_DATASET_YEARS)
+    print(json.dumps(report, indent=2))

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
@@ -382,9 +382,11 @@ def _load_dataset(
     # TEMPORARY: remove once single-year datasets are published (issue #596).
     # The image bakes default-revision single-year files into
     # POLICYENGINE_DATA_FOLDER, and ensure_datasets keys its cache on a
-    # revision-stripped stem, so requests pinning a non-default data
-    # revision must not read the baked folder.
-    if _requested_data_version(params) is not None:
+    # revision-stripped filename stem — a custom dataset or revision whose
+    # stem matches the default would silently read the baked files. Only
+    # pure default requests may use the baked folder. (Region requests
+    # resolve their dataset without the "data" param, so they keep it.)
+    if params.get("data") is not None or params.get("data_version") is not None:
         data_folder = "/tmp/policyengine-data"
 
     start = time.monotonic()

--- a/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
+++ b/projects/policyengine-api-simulation/src/policyengine_api_simulation/simulation_runtime.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import tempfile
+import time
 from dataclasses import dataclass
 from importlib import import_module
 from typing import Any, Iterator
@@ -377,12 +378,27 @@ def _load_dataset(
         if region_resolution is not None and region_resolution.dataset_reference
         else _resolve_dataset_reference(country, params)
     )
+    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/tmp/policyengine-data")
+    # TEMPORARY: remove once single-year datasets are published (issue #596).
+    # The image bakes default-revision single-year files into
+    # POLICYENGINE_DATA_FOLDER, and ensure_datasets keys its cache on a
+    # revision-stripped stem, so requests pinning a non-default data
+    # revision must not read the baked folder.
+    if _requested_data_version(params) is not None:
+        data_folder = "/tmp/policyengine-data"
+
+    start = time.monotonic()
     datasets = country_module.ensure_datasets(
         datasets=[dataset_name],
         years=[year],
-        data_folder=os.environ.get(
-            "POLICYENGINE_DATA_FOLDER", "/tmp/policyengine-data"
-        ),
+        data_folder=data_folder,
+    )
+    logger.info(
+        "Loaded dataset %s year %s from %s in %.1fs",
+        dataset_name,
+        year,
+        data_folder,
+        time.monotonic() - start,
     )
     return next(iter(datasets.values()))
 

--- a/projects/policyengine-api-simulation/tests/test_image_setup_prebuild.py
+++ b/projects/policyengine-api-simulation/tests/test_image_setup_prebuild.py
@@ -1,0 +1,143 @@
+"""Tests for the TEMPORARY single-year dataset prebuild (see issue #596).
+
+These pin the coupling between the image-build prebuild and the runtime
+dataset lookup: both must resolve the same ``{stem}_year_{year}.h5`` cache
+paths, otherwise the baked files are silently ignored and every cold
+container falls back to the slow runtime build.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from policyengine.provenance.manifest import (
+    dataset_logical_name,
+    get_release_manifest,
+    resolve_dataset_reference,
+)
+
+from policyengine_api_simulation.release_bundle import (
+    get_country_release_bundle,
+    resolve_bundle_dataset_name,
+)
+from policyengine_api_simulation.simulation_runtime import DEFAULT_YEAR
+from src.modal._image_setup import (
+    PREBUILD_DATASET_YEARS,
+    prebuild_country_datasets,
+)
+
+
+def _expected_stem(country: str) -> str:
+    default_dataset = get_release_manifest(country).default_dataset
+    return dataset_logical_name(resolve_dataset_reference(country, default_dataset))
+
+
+def _install_country_stub(monkeypatch, country: str, ensure_datasets):
+    monkeypatch.setitem(
+        sys.modules,
+        f"policyengine.tax_benefit_models.{country}",
+        SimpleNamespace(ensure_datasets=ensure_datasets),
+    )
+
+
+@pytest.mark.parametrize("country", ["us", "uk"])
+def test_prebuild_stem_matches_runtime_default_lookup(country, monkeypatch):
+    """The critical coupling pin: the stem the prebuild writes must equal the
+    stem the runtime resolves for default requests. If bundle metadata ever
+    diverges from the packaged manifest default, the baked files would be
+    silently unused — this test turns that into a CI failure on every
+    policyengine version bump."""
+    monkeypatch.delenv("POLICYENGINE_BUNDLE_RECEIPT", raising=False)
+    get_country_release_bundle.cache_clear()
+
+    runtime_stem = dataset_logical_name(
+        resolve_dataset_reference(country, resolve_bundle_dataset_name(country, None))
+    )
+
+    assert _expected_stem(country) == runtime_stem
+
+
+def test_prebuild_years_cover_runtime_default_year():
+    assert PREBUILD_DATASET_YEARS == [2025, 2026, 2027]
+    assert DEFAULT_YEAR in PREBUILD_DATASET_YEARS
+
+
+@pytest.mark.parametrize("country", ["us", "uk"])
+def test_prebuild_passes_explicit_manifest_default(country, tmp_path, monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+    stem = _expected_stem(country)
+    calls = []
+
+    def ensure_datasets(**kwargs):
+        calls.append(kwargs)
+        for year in kwargs["years"]:
+            Path(kwargs["data_folder"], f"{stem}_year_{year}.h5").write_bytes(b"h5")
+        return {}
+
+    _install_country_stub(monkeypatch, country, ensure_datasets)
+
+    prebuild_country_datasets(country)
+
+    assert calls == [
+        {
+            "datasets": [get_release_manifest(country).default_dataset],
+            "years": [2025, 2026, 2027],
+            "data_folder": str(tmp_path),
+        }
+    ]
+
+
+def test_prebuild_skips_years_that_already_exist(tmp_path, monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+    stem = _expected_stem("us")
+    (tmp_path / f"{stem}_year_2025.h5").write_bytes(b"h5")
+    calls = []
+
+    def ensure_datasets(**kwargs):
+        calls.append(kwargs)
+        for year in kwargs["years"]:
+            Path(kwargs["data_folder"], f"{stem}_year_{year}.h5").write_bytes(b"h5")
+        return {}
+
+    _install_country_stub(monkeypatch, "us", ensure_datasets)
+
+    prebuild_country_datasets("us")
+
+    assert calls == [
+        {
+            "datasets": [get_release_manifest("us").default_dataset],
+            "years": [2026, 2027],
+            "data_folder": str(tmp_path),
+        }
+    ]
+
+
+def test_prebuild_skips_entirely_when_all_years_exist(tmp_path, monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+    stem = _expected_stem("us")
+    for year in PREBUILD_DATASET_YEARS:
+        (tmp_path / f"{stem}_year_{year}.h5").write_bytes(b"h5")
+    calls = []
+
+    def ensure_datasets(**kwargs):
+        calls.append(kwargs)
+        return {}
+
+    _install_country_stub(monkeypatch, "us", ensure_datasets)
+
+    prebuild_country_datasets("us")
+
+    assert calls == []
+
+
+def test_prebuild_raises_when_files_not_produced(tmp_path, monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+
+    def ensure_datasets(**kwargs):
+        return {}
+
+    _install_country_stub(monkeypatch, "us", ensure_datasets)
+
+    with pytest.raises(RuntimeError, match="did not produce"):
+        prebuild_country_datasets("us")

--- a/projects/policyengine-api-simulation/tests/test_image_setup_prebuild.py
+++ b/projects/policyengine-api-simulation/tests/test_image_setup_prebuild.py
@@ -41,8 +41,7 @@ def _install_country_stub(monkeypatch, country: str, ensure_datasets):
     )
 
 
-@pytest.mark.parametrize("country", ["us", "uk"])
-def test_prebuild_stem_matches_runtime_default_lookup(country, monkeypatch):
+def test_prebuild_stem_matches_runtime_default_lookup(monkeypatch):
     """The critical coupling pin: the stem the prebuild writes must equal the
     stem the runtime resolves for default requests. If bundle metadata ever
     diverges from the packaged manifest default, the baked files would be
@@ -52,10 +51,10 @@ def test_prebuild_stem_matches_runtime_default_lookup(country, monkeypatch):
     get_country_release_bundle.cache_clear()
 
     runtime_stem = dataset_logical_name(
-        resolve_dataset_reference(country, resolve_bundle_dataset_name(country, None))
+        resolve_dataset_reference("us", resolve_bundle_dataset_name("us", None))
     )
 
-    assert _expected_stem(country) == runtime_stem
+    assert _expected_stem("us") == runtime_stem
 
 
 def test_prebuild_years_cover_runtime_default_year():
@@ -63,10 +62,9 @@ def test_prebuild_years_cover_runtime_default_year():
     assert DEFAULT_YEAR in PREBUILD_DATASET_YEARS
 
 
-@pytest.mark.parametrize("country", ["us", "uk"])
-def test_prebuild_passes_explicit_manifest_default(country, tmp_path, monkeypatch):
+def test_prebuild_passes_explicit_manifest_default(tmp_path, monkeypatch):
     monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
-    stem = _expected_stem(country)
+    stem = _expected_stem("us")
     calls = []
 
     def ensure_datasets(**kwargs):
@@ -75,13 +73,13 @@ def test_prebuild_passes_explicit_manifest_default(country, tmp_path, monkeypatc
             Path(kwargs["data_folder"], f"{stem}_year_{year}.h5").write_bytes(b"h5")
         return {}
 
-    _install_country_stub(monkeypatch, country, ensure_datasets)
+    _install_country_stub(monkeypatch, "us", ensure_datasets)
 
-    prebuild_country_datasets(country)
+    prebuild_country_datasets("us")
 
     assert calls == [
         {
-            "datasets": [get_release_manifest(country).default_dataset],
+            "datasets": [get_release_manifest("us").default_dataset],
             "years": [2025, 2026, 2027],
             "data_folder": str(tmp_path),
         }

--- a/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
@@ -29,8 +29,8 @@ class FakeImage:
         self.calls.append(("add_local_python_source", args, kwargs))
         return self
 
-    def run_function(self, function):
-        self.calls.append(("run_function", function.__name__))
+    def run_function(self, function, **kwargs):
+        self.calls.append(("run_function", function.__name__, kwargs))
         return self
 
 
@@ -97,3 +97,55 @@ def test_modal_image_uses_policyengine_bundle_install(monkeypatch):
             app.hf_secret,
             app.logfire_secret,
         ]
+
+
+# TEMPORARY: remove once single-year datasets are published (issue #596).
+def test_modal_image_prebuilds_datasets_between_env_and_local_source(monkeypatch):
+    install_fake_modal(monkeypatch)
+    monkeypatch.setenv("POLICYENGINE_VERSION", "4.19.1")
+    monkeypatch.setenv("POLICYENGINE_CORE_VERSION", "3.27.1")
+    monkeypatch.setenv("POLICYENGINE_US_VERSION", "1.700.0")
+    monkeypatch.setenv("POLICYENGINE_UK_VERSION", "2.90.0")
+    sys.modules.pop("src.modal.app", None)
+
+    app = importlib.import_module("src.modal.app")
+
+    calls = app.simulation_image.calls
+    prebuild_indices = [
+        index
+        for index, call in enumerate(calls)
+        if call[0] == "run_function" and call[1] == "prebuild_country_datasets"
+    ]
+    assert [calls[index][2]["args"] for index in prebuild_indices] == [
+        ("us",),
+        ("uk",),
+    ]
+    for index in prebuild_indices:
+        kwargs = calls[index][2]
+        assert kwargs["secrets"] == [app.data_secret, app.hf_secret]
+        assert kwargs["timeout"] == 4 * 60 * 60
+        assert kwargs["memory"] in (65536, 32768)
+
+    # The prebuild layers are multi-hour builds keyed only on upstream
+    # layers and their own definition. They must stay after the version env
+    # (so version bumps rebuild them) and before add_local_python_source
+    # (whose content-hash key would otherwise invalidate them on every
+    # source commit).
+    env_index = next(index for index, call in enumerate(calls) if call[0] == "env")
+    local_source_index = next(
+        index
+        for index, call in enumerate(calls)
+        if call[0] == "add_local_python_source"
+    )
+    snapshot_index = next(
+        index
+        for index, call in enumerate(calls)
+        if call[0] == "run_function" and call[1] == "snapshot_models"
+    )
+    assert (
+        env_index
+        < prebuild_indices[0]
+        < prebuild_indices[1]
+        < local_source_index
+        < snapshot_index
+    )

--- a/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
@@ -116,20 +116,17 @@ def test_modal_image_prebuilds_datasets_between_env_and_local_source(monkeypatch
         for index, call in enumerate(calls)
         if call[0] == "run_function" and call[1] == "prebuild_country_datasets"
     ]
-    assert [calls[index][2]["args"] for index in prebuild_indices] == [
-        ("us",),
-        ("uk",),
-    ]
-    for index in prebuild_indices:
-        kwargs = calls[index][2]
-        assert kwargs["secrets"] == [app.data_secret, app.hf_secret]
-        assert kwargs["timeout"] == 4 * 60 * 60
-        assert kwargs["memory"] in (65536, 32768)
+    # US only — UK is deliberately not prebuilt (keeps image build short).
+    assert [calls[index][2]["args"] for index in prebuild_indices] == [("us",)]
+    prebuild_kwargs = calls[prebuild_indices[0]][2]
+    assert prebuild_kwargs["secrets"] == [app.data_secret, app.hf_secret]
+    assert prebuild_kwargs["timeout"] == 4 * 60 * 60
+    assert prebuild_kwargs["memory"] == 65536
 
-    # The prebuild layers are multi-hour builds keyed only on upstream
-    # layers and their own definition. They must stay after the version env
-    # (so version bumps rebuild them) and before add_local_python_source
-    # (whose content-hash key would otherwise invalidate them on every
+    # The prebuild layer is a multi-hour build keyed only on upstream
+    # layers and its own definition. It must stay after the version env
+    # (so version bumps rebuild it) and before add_local_python_source
+    # (whose content-hash key would otherwise invalidate it on every
     # source commit).
     env_index = next(index for index, call in enumerate(calls) if call[0] == "env")
     local_source_index = next(
@@ -142,10 +139,4 @@ def test_modal_image_prebuilds_datasets_between_env_and_local_source(monkeypatch
         for index, call in enumerate(calls)
         if call[0] == "run_function" and call[1] == "snapshot_models"
     )
-    assert (
-        env_index
-        < prebuild_indices[0]
-        < prebuild_indices[1]
-        < local_source_index
-        < snapshot_index
-    )
+    assert env_index < prebuild_indices[0] < local_source_index < snapshot_index

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
@@ -534,17 +534,22 @@ def test_load_dataset_passes_bundle_default_name_to_country_loader_with_receipt(
 
 
 # TEMPORARY: remove once single-year datasets are published (issue #596).
-# Pins the guard that keeps revision-pinned requests away from the baked
-# default-revision single-year files in POLICYENGINE_DATA_FOLDER.
+# Pins the guard that keeps every non-default dataset request away from the
+# baked default-revision single-year files in POLICYENGINE_DATA_FOLDER.
+# ensure_datasets keys its cache on a revision-stripped filename stem, so
+# even an explicit dataset name or foreign URI can collide with the baked
+# default (e.g. hf://other/repo/populace_us_2024.h5).
 @pytest.mark.parametrize(
-    "revision_params",
+    "explicit_data_params",
     [
         {"data_version": "custom-v1"},
         {"data": "populace_us_2024@custom-v1"},
+        {"data": "populace_us_2024"},
+        {"data": "hf://other-org/other-repo/populace_us_2024.h5"},
     ],
 )
-def test_load_dataset_bypasses_baked_folder_for_revision_overrides(
-    revision_params,
+def test_load_dataset_bypasses_baked_folder_for_explicit_dataset_requests(
+    explicit_data_params,
     tmp_path,
     monkeypatch,
 ):
@@ -557,7 +562,7 @@ def test_load_dataset_bypasses_baked_folder_for_revision_overrides(
         return {"dataset": SimpleNamespace()}
 
     _load_dataset(
-        {"country": "us", "time_period": "2026", **revision_params},
+        {"country": "us", "time_period": "2026", **explicit_data_params},
         country_module=SimpleNamespace(ensure_datasets=ensure_datasets),
     )
 

--- a/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-api-simulation/tests/test_simulation_output_builder.py
@@ -533,6 +533,58 @@ def test_load_dataset_passes_bundle_default_name_to_country_loader_with_receipt(
     ]
 
 
+# TEMPORARY: remove once single-year datasets are published (issue #596).
+# Pins the guard that keeps revision-pinned requests away from the baked
+# default-revision single-year files in POLICYENGINE_DATA_FOLDER.
+@pytest.mark.parametrize(
+    "revision_params",
+    [
+        {"data_version": "custom-v1"},
+        {"data": "populace_us_2024@custom-v1"},
+    ],
+)
+def test_load_dataset_bypasses_baked_folder_for_revision_overrides(
+    revision_params,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+
+    ensure_calls = []
+
+    def ensure_datasets(**kwargs):
+        ensure_calls.append(kwargs)
+        return {"dataset": SimpleNamespace()}
+
+    _load_dataset(
+        {"country": "us", "time_period": "2026", **revision_params},
+        country_module=SimpleNamespace(ensure_datasets=ensure_datasets),
+    )
+
+    assert len(ensure_calls) == 1
+    assert ensure_calls[0]["data_folder"] == "/tmp/policyengine-data"
+
+
+def test_load_dataset_uses_baked_folder_for_default_requests(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("POLICYENGINE_DATA_FOLDER", str(tmp_path))
+
+    ensure_calls = []
+
+    def ensure_datasets(**kwargs):
+        ensure_calls.append(kwargs)
+        return {"dataset": SimpleNamespace()}
+
+    _load_dataset(
+        {"country": "us", "time_period": "2026"},
+        country_module=SimpleNamespace(ensure_datasets=ensure_datasets),
+    )
+
+    assert ensure_calls[0]["data_folder"] == str(tmp_path)
+
+
 def test_resolve_region_scopes_us_state_from_national_populace_dataset():
     bundle = get_country_release_bundle("us")
     scoping_strategy = object()


### PR DESCRIPTION
Fixes #596

## What

Temporary fix for slow cold-container simulation requests: the Modal image now prebuilds single-year datasets (`{stem}_year_{year}.h5`, years 2025–2027, **US national default only** — UK deliberately excluded to keep image builds short) into `POLICYENGINE_DATA_FOLDER` at image build time, so the runtime `ensure_datasets()` existence check hits immediately instead of rebuilding from the multi-year source with a full Microsimulation pass. UK requests keep building at request time, unchanged.

All changes are flagged `# TEMPORARY: remove once single-year datasets are published (see issue #596)`.

## How

- **`src/modal/_image_setup.py`**: new standalone `prebuild_country_datasets(country)` build function. Resolves the manifest default dataset, skips years already present, fails the image build loudly if expected files are missing afterwards. Country-parameterized so UK can be enabled later with one additional layer.
- **`src/modal/app.py`**: one `run_function` image layer (`args=("us",)`), run on Modal's builder. Placed after `.env(VERSION_ENV)` and before `.add_local_python_source(copy=True)` so the multi-hour layer only rebuilds on policyengine version bumps, not on every source commit. A test pins this ordering.
- **`simulation_runtime.py`**: `ensure_datasets` keys its single-year cache on a revision-stripped filename stem, so only pure default requests may read the baked folder — any request naming an explicit `data` dataset or pinning a `data_version` is routed to `/tmp/policyengine-data` instead (otherwise e.g. `hf://other/repo/populace_us_2024.h5` would silently read the baked default). Region requests resolve datasets without the `data` param and keep the cache. Broader question about which `data` values the API should accept at all: #598. Dataset load duration is now logged.
- **README**: operational notes (pre-warm deploy, `force_build` lever, removal condition).

## Tests

- `tests/test_image_setup_prebuild.py` (new): coupling pin that the prebuild stem equals the runtime default-lookup stem (turns silent cache-miss drift into a CI failure on version bumps); call-shape, skip-existing, and fail-loud cases.
- `tests/test_simulation_output_builder.py`: baked-folder guard cases (`data_version`, `data@rev`, plain `data` name, foreign URI with colliding stem), default-folder case.
- `tests/test_modal_bundle_image.py`: layer ordering + kwargs (secrets, timeout, memory) for the prebuild layer; asserts US is the only prebuilt country.

`uv run pytest tests/` in `projects/policyengine-api-simulation`: 312 passed. `ruff format`/`ruff check` clean on changed files (one pre-existing F401 in `main.py` left untouched).

Not run: Modal deploy / image build — the first deploy after merge pays a multi-hour image build (consider pre-warming with a scratch `MODAL_APP_NAME` deploy first; see README note). Integration tests require a deployed environment.

## Removal condition

Populace publishes prebuilt single-year artifacts to Hugging Face and the consumer side downloads instead of building. Then: delete `prebuild_country_datasets` + `PREBUILD_DATASET_YEARS`, remove the image layer, remove the revision-override guard, close #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
