### PR TITLE
chore(deps): update policyengine to 4.18.9

### DIFF
--- a/projects/policyengine-api-simulation/pyproject.toml
+++ b/projects/policyengine-api-simulation/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings (>=2.7.1,<3.0.0)",
     "opentelemetry-instrumentation-fastapi (>=0.51b0,<0.52)",
     "policyengine-fastapi",
-    "policyengine==4.18.8",
+    "policyengine==4.18.9",
     "policyengine-core==3.28.0",
     "policyengine-uk==2.89.2",
     "policyengine-us==1.752.2",

--- a/projects/policyengine-api-simulation/uv.lock
+++ b/projects/policyengine-api-simulation/uv.lock
@@ -1635,7 +1635,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1675,7 +1675,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.18.8"
+version = "4.18.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -1689,9 +1689,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/50/bd4427530435a73cf1f09f8e1912115e11b8dcbc5b9c386ee16a62eec75d/policyengine-4.18.8.tar.gz", hash = "sha256:684b89d4bb88c77cebc4b3b44389ac48be8336305c4c0c8baa179ef557149a67", size = 696784, upload-time = "2026-07-01T23:11:19.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/f0/452c855cdb162e19dfdeb2f04939b763ab98e4cf07ce2caf7a4c619ba34f/policyengine-4.18.9.tar.gz", hash = "sha256:4f7a58d9e88256076b474debda02c61019011215196c7f8b8265560486aa4ec7", size = 699680, upload-time = "2026-07-02T23:34:11.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cb/58327139aaf54ef7d8f893d1ef8671c5a6924bd4228d063baa2f0660920a/policyengine-4.18.8-py3-none-any.whl", hash = "sha256:d55e7b06ec403dc0a13f6dc604b0e0469c58206e66d2be5e23601d8cdd180d5c", size = 208899, upload-time = "2026-07-01T23:11:17.789Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/15/908db27608da1981b4b45992eb58ee616eeefd70abe5dfd62a0511edec6d/policyengine-4.18.9-py3-none-any.whl", hash = "sha256:fda8d3069151fcfe3e5bb2ac6fc2402b1d0de9600f296086c9a254406bb16f05", size = 210079, upload-time = "2026-07-02T23:34:10.119Z" },
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ requires-dist = [
     { name = "openapi-python-client", marker = "extra == 'build'", specifier = ">=0.21.6" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.51b0,<0.52" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.51b0,<0.52" },
-    { name = "policyengine", specifier = "==4.18.8" },
+    { name = "policyengine", specifier = "==4.18.9" },
     { name = "policyengine-core", specifier = "==3.28.0" },
     { name = "policyengine-fastapi", editable = "../../libs/policyengine-fastapi" },
     { name = "policyengine-uk", specifier = "==2.89.2" },


### PR DESCRIPTION
Fixes #600

## What

Bumps the simulation worker's `policyengine` pin from `4.18.8` to **`4.18.9`** and relocks `uv.lock`.

## Why

policyengine 4.18.9 ships the dataset-autosave-corruption fix ([policyengine.py #450](https://github.com/PolicyEngine/policyengine.py/pull/450), issue [#449](https://github.com/PolicyEngine/policyengine.py/issues/449)). In 4.18.8, constructing a region-scoped dataset copy auto-saved over the shared single-year file baked into the Modal image, corrupting it inside reused containers — crashing subsequent state runs (`No households found matching state_fips=N`) and silently computing national results on one state's data. 4.18.9 removes the construction-time autosave and builds scoped copies with `filepath=None`.

## Changes

- `projects/policyengine-api-simulation/pyproject.toml`: `policyengine==4.18.8` → `4.18.9` (one line).
- `projects/policyengine-api-simulation/uv.lock`: relocked (`policyengine v4.18.8 -> v4.18.9`; no other packages changed).

No worker code change is required — the corruption occurred entirely inside policyengine.py's `run()`.

## Verification

- `uv lock` resolved cleanly with companion pins (`policyengine-core`, `policyengine-us`, `policyengine-uk`) unchanged.
- Confirmed the published 4.18.9 wheel contains the fix: `model_post_init` no longer calls `self.save()`, and the US/UK region-scoped copies use `filepath=None`.
- `ruff format --check` clean (no Python changed). No changelog mechanism in this repo.

Not run locally: Modal deploy — the merge triggers the deploy pipeline, which rebuilds the image on the new policyengine version (the single-year prebuild layers rerun on the version bump, ~1 min). CI on this PR is the source of truth.