### PR TITLE
Install importlib-metadata explicitly in Modal images

### DIFF
--- a/projects/policyengine-api-simulation/src/modal/app.py
+++ b/projects/policyengine-api-simulation/src/modal/app.py
@@ -144,6 +144,10 @@ def build_base_simulation_image() -> modal.Image:
             "fastapi>=0.115.0",
             "tables>=3.10.2",
             "logfire>=3.0.0",
+            # logfire imports importlib_metadata unconditionally but does
+            # not declare it as a dependency on Python 3.13, so install it
+            # explicitly or workers crash on ``import logfire``.
+            "importlib-metadata>=8",
             "policyengine-observability[fastapi]>=1.3.0,<2",
         )
         .run_commands(

--- a/projects/policyengine-api-simulation/src/modal/gateway/app.py
+++ b/projects/policyengine-api-simulation/src/modal/gateway/app.py
@@ -29,6 +29,10 @@ gateway_image = (
         # the auth module at runtime here.
         "cryptography>=41.0.0",
         "logfire>=3.0.0",
+        # logfire imports importlib_metadata unconditionally but does not
+        # declare it as a dependency on Python 3.13, so install it
+        # explicitly or the container crashes at startup.
+        "importlib-metadata>=8",
         "policyengine-observability[fastapi]>=1.3.0,<2",
     )
     .add_local_python_source(

--- a/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
+++ b/projects/policyengine-api-simulation/tests/test_modal_bundle_image.py
@@ -95,6 +95,10 @@ def test_modal_image_uses_policyengine_bundle_install(monkeypatch):
     packages = pip_install_calls[0][1]
     assert "policyengine-observability[fastapi]>=1.3.0,<2" in packages
     assert "logfire>=3.0.0" in packages
+    # logfire needs importlib_metadata at import time on Python 3.13 but
+    # does not declare it; without the explicit install every worker
+    # crashes on ``import logfire``.
+    assert "importlib-metadata>=8" in packages
 
     runtime_secret_sets = {
         name: kwargs["secrets"] for name, kwargs in app.app.function_calls
@@ -164,6 +168,9 @@ def test_gateway_image_installs_dual_observability(monkeypatch):
     packages = pip_install_calls[0][1]
     assert "policyengine-observability[fastapi]>=1.3.0,<2" in packages
     assert "logfire>=3.0.0" in packages
+    # Same importlib_metadata gap as the simulation image: without this the
+    # gateway ASGI factory dies in configure_logfire and every request 303s.
+    assert "importlib-metadata>=8" in packages
 
     function_kwargs = {name: kwargs for name, kwargs in app.app.function_calls}
     assert function_kwargs["web_app"]["secrets"] == [


### PR DESCRIPTION
Fixes #602

## Problem

The #594 merge deploy failed all beta integration tests and skipped production. Every gateway endpoint (including `/ping`) hung past Modal's HTTP window and returned 303 redirects: the gateway ASGI factory crashes at startup on `import logfire` with `ModuleNotFoundError: No module named 'importlib_metadata'`.

The Modal images install `logfire>=3.0.0` unpinned. #594's change to the `pip_install` layer invalidated the cached image layer, and the fresh rebuild resolved logfire 4.37.0, which imports `importlib_metadata` unconditionally on Python 3.13 without declaring it as a dependency (it previously arrived transitively via opentelemetry). The `uv.lock` environment (logfire 4.6.0 + importlib-metadata 8.5.0) is unaffected, which is why unit tests passed while the deployed image crashed.

## Fix

Install `importlib-metadata>=8` explicitly in both the gateway image and the shared base simulation image, and assert its presence in the image tests. This is robust across logfire versions rather than pinning around the upstream packaging bug.

Note: this changes the base image's `pip_install` layer again, which invalidates the dataset prebuild layer. The layers are being prewarmed off the deploy path per the README (`modal run src/modal/prewarm_app.py`) so the post-merge deploy fast-forwards.

## Tests

- `uv run pytest tests/` in `projects/policyengine-api-simulation`: 325 passed
- `make format`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)