### PR TITLE
Open policyengine update PRs from policyengine-release dispatch

### DIFF
--- a/.github/scripts/update-policyengine-package.sh
+++ b/.github/scripts/update-policyengine-package.sh
@@ -9,7 +9,10 @@
 #
 # Optional environment:
 #   PROJECT_DIR      Project containing pyproject.toml and uv.lock.
-#   LATEST_OVERRIDE  policyengine version to use instead of querying PyPI.
+#   LATEST_OVERRIDE  policyengine version to use instead of querying PyPI (the
+#                    repository_dispatch trigger passes the just-released
+#                    version here).
+#   FORCE=1          Allow targeting a version not newer than the current pin.
 #   DRY_RUN=1        Report planned changes without editing files or opening a PR.
 
 set -euo pipefail
@@ -95,6 +98,11 @@ if [[ "$CURRENT" == "$LATEST" ]]; then
   exit 0
 fi
 
+if [[ "$(printf '%s\n%s\n' "$CURRENT" "$LATEST" | sort -V | tail -n1)" != "$LATEST" && "${FORCE:-0}" != "1" ]]; then
+  echo "Requested ${LATEST} is not newer than current ${CURRENT}. Skipping (set FORCE=1 to override)."
+  exit 0
+fi
+
 BRANCH="auto/update-policyengine-${LATEST}"
 echo "Update available: ${CURRENT} -> ${LATEST}"
 
@@ -150,10 +158,22 @@ if old_pin not in pyproject_text:
 pyproject.write_text(pyproject_text.replace(old_pin, new_pin), encoding="utf-8")
 PY
 
-(
-  cd "$PROJECT_PATH"
-  uv lock --upgrade-package "$PACKAGE"
-)
+# The PyPI Simple index (which uv resolves from) can lag the JSON API right
+# after a release, so retry the lock a few times.
+for attempt in 1 2 3; do
+  if (
+    cd "$PROJECT_PATH"
+    uv lock --upgrade-package "$PACKAGE"
+  ); then
+    break
+  fi
+  if [[ "$attempt" == "3" ]]; then
+    echo "ERROR: uv lock failed after ${attempt} attempts." >&2
+    exit 1
+  fi
+  echo "uv lock attempt ${attempt} failed; retrying in 30s..."
+  sleep 30
+done
 
 BUNDLE_OUTPUT=$(
   cd "$PROJECT_PATH"

--- a/.github/workflows/check-policyengine-updates.yml
+++ b/.github/workflows/check-policyengine-updates.yml
@@ -1,9 +1,18 @@
 name: Update policyengine package
 
 on:
-  schedule:
-    - cron: "*/30 * * * *"
+  repository_dispatch:
+    types: [policyengine-release]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "policyengine version to update to (defaults to latest on PyPI)"
+        required: false
+        type: string
+
+concurrency:
+  group: update-policyengine-${{ github.event.client_payload.version || inputs.version || github.event_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -42,4 +51,5 @@ jobs:
       - name: Check for update and open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          LATEST_OVERRIDE: ${{ github.event.client_payload.version || inputs.version }}
         run: bash .github/scripts/update-policyengine-package.sh


### PR DESCRIPTION
## Summary

Converts the simulation API's policyengine update automation from pull-based (30-minute PyPI polling cron) to push-based: policyengine.py's release pipeline now sends a `policyengine-release` repository dispatch after each PyPI release (companion PR in PolicyEngine/policyengine.py), and this workflow opens the bump PR immediately.

## Changes

- `check-policyengine-updates.yml`: replace `schedule` with `repository_dispatch` (`policyengine-release`); keep `workflow_dispatch` with an optional `version` input as the manual fallback; add a per-version concurrency group so duplicate dispatches serialize.
- `update-policyengine-package.sh`:
  - Feed the dispatched version in via `LATEST_OVERRIDE`.
  - Skip versions not strictly newer than the current pin (`FORCE=1` overrides), preventing downgrade PRs from stale dispatches.
  - Retry `uv lock` up to 3 times to absorb PyPI Simple-index propagation lag.

`update-dependencies.yml` (general dependency updates) is intentionally untouched.

## Behavior guarantees

- One single-version PR per release, on its own per-version branch — releases never stack as commits onto an existing PR.
- Older update PRs are never auto-closed or superseded.

## Rollout

The dispatch trigger is inert until the policyengine.py companion PR merges. In the interim, trigger manually with `gh workflow run` and the `version` input.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)