### PR TITLE
Lengthen simulation integration timeout

### DIFF
--- a/projects/policyengine-apis-integ/tests/simulation/conftest.py
+++ b/projects/policyengine-apis-integ/tests/simulation/conftest.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
     base_url: str = "http://localhost:8082"
     access_token: str | None = None
     gateway_auth_required: bool = False
-    timeout_in_millis: int = 900_000  # 15 minutes for full simulations
+    timeout_in_millis: int = 1_500_000  # 25 minutes for full simulations
     poll_interval_seconds: float = 5.0
     us_model_version: str = "1.690.7"
     uk_model_version: str = "2.88.14"


### PR DESCRIPTION
Fixes #612

## Summary
Increase the generated-client simulation integration timeout from 15 minutes to 25 minutes.

## Root Cause
The default US national simulation can complete successfully in Modal after the previous 900 second polling limit. The failed beta deploy run timed out just before the Modal worker completed, so CI reported a timeout even though the simulation job succeeded.

## Validation
- `uv run pytest tests/simulation/test_calculate.py --collect-only -q`

I did not rerun the live Modal integration suite because the affected path is a long-running staging test.