### PR TITLE
Return report-shaped US congressional district impacts

### DIFF
--- a/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
+++ b/projects/policyengine-apis-integ/tests/simulation/test_calculate.py
@@ -6,6 +6,7 @@ that economy-wide simulations complete successfully.
 """
 
 import time
+from collections.abc import Mapping
 from http import HTTPStatus
 
 import pytest
@@ -20,6 +21,18 @@ from policyengine_api_simulation_client.models import (
     JobSubmitResponse,
     SimulationRequest,
 )
+
+_REQUIRED_ECONOMY_RESULT_SECTIONS = {"budget", "poverty", "inequality"}
+_REQUIRED_DISTRICT_RESULT_KEYS = {
+    "district",
+    "average_household_income_change",
+    "relative_household_income_change",
+    "winner_percentage",
+    "loser_percentage",
+    "no_change_percentage",
+    "population",
+}
+_AT_LARGE_DISTRICT_IDS = {"AK-01", "DC-01", "DE-01", "ND-01", "SD-01", "VT-01", "WY-01"}
 
 
 def poll_for_completion(
@@ -90,6 +103,72 @@ def submit_simulation_request(
     return response.parsed
 
 
+def assert_economy_result_sections(economy_result: object) -> None:
+    assert isinstance(economy_result, Mapping), (
+        f"Expected economy result to be an object, got {type(economy_result)}"
+    )
+    missing = _REQUIRED_ECONOMY_RESULT_SECTIONS - set(economy_result)
+    assert not missing, (
+        f"Missing expected economy result sections {sorted(missing)} "
+        f"in result: {economy_result.keys()}"
+    )
+
+
+def assert_congressional_district_results(
+    economy_result: object,
+    *,
+    expected_district_prefix: str | None = None,
+    expected_district_ids: set[str] | None = None,
+) -> None:
+    assert isinstance(economy_result, Mapping), (
+        f"Expected economy result to be an object, got {type(economy_result)}"
+    )
+    assert "congressional_district_impact" in economy_result, (
+        f"Missing 'congressional_district_impact' in result: {economy_result.keys()}"
+    )
+
+    impact = economy_result["congressional_district_impact"]
+    assert isinstance(impact, Mapping), (
+        f"Expected congressional_district_impact to be an object, got {type(impact)}"
+    )
+    districts = impact.get("districts")
+    assert isinstance(districts, list), (
+        "Expected congressional_district_impact.districts to be a list, "
+        f"got {type(districts)}"
+    )
+    assert districts, "Expected congressional_district_impact.districts to be non-empty"
+
+    for district in districts:
+        assert isinstance(district, Mapping), (
+            "Expected each congressional district result to be an object, "
+            f"got {type(district)}"
+        )
+        missing = _REQUIRED_DISTRICT_RESULT_KEYS - set(district)
+        assert not missing, (
+            f"Missing expected district result keys {sorted(missing)} "
+            f"in district result: {district}"
+        )
+        assert isinstance(district["district"], str)
+
+    if expected_district_prefix is not None:
+        district_ids = [district["district"] for district in districts]
+        assert all(
+            district_id.startswith(expected_district_prefix)
+            for district_id in district_ids
+        ), (
+            f"Expected all district IDs to start with {expected_district_prefix!r}, "
+            f"got {district_ids}"
+        )
+
+    if expected_district_ids is not None:
+        district_ids = {district["district"] for district in districts}
+        missing = expected_district_ids - district_ids
+        assert not missing, (
+            f"Missing expected district IDs {sorted(missing)} "
+            f"from result IDs: {sorted(district_ids)}"
+        )
+
+
 @pytest.mark.beta_only
 def test_calculate_default_model(
     client: Client | AuthenticatedClient,
@@ -125,16 +204,11 @@ def test_calculate_default_model(
     assert result.status == "complete"
     assert result.result is not None
 
-    # Verify key economic impact sections are present
     economy_result = result.result
-    assert "budget" in economy_result, (
-        f"Missing 'budget' in result: {economy_result.keys()}"
-    )
-    assert "poverty" in economy_result, (
-        f"Missing 'poverty' in result: {economy_result.keys()}"
-    )
-    assert "inequality" in economy_result, (
-        f"Missing 'inequality' in result: {economy_result.keys()}"
+    assert_economy_result_sections(economy_result)
+    assert_congressional_district_results(
+        economy_result,
+        expected_district_ids=_AT_LARGE_DISTRICT_IDS,
     )
 
 
@@ -178,16 +252,11 @@ def test_calculate_us_state_region_model(
     assert result.status == "complete"
     assert result.result is not None
 
-    # Verify key economic impact sections are present
     economy_result = result.result
-    assert "budget" in economy_result, (
-        f"Missing 'budget' in result: {economy_result.keys()}"
-    )
-    assert "poverty" in economy_result, (
-        f"Missing 'poverty' in result: {economy_result.keys()}"
-    )
-    assert "inequality" in economy_result, (
-        f"Missing 'inequality' in result: {economy_result.keys()}"
+    assert_economy_result_sections(economy_result)
+    assert_congressional_district_results(
+        economy_result,
+        expected_district_prefix="UT-",
     )
 
 
@@ -234,9 +303,11 @@ def test_calculate_specific_model(
     assert result.result is not None
 
     economy_result = result.result
-    assert "budget" in economy_result
-    assert "poverty" in economy_result
-    assert "inequality" in economy_result
+    assert_economy_result_sections(economy_result)
+    assert_congressional_district_results(
+        economy_result,
+        expected_district_prefix="UT-",
+    )
 
 
 @pytest.mark.beta_only
@@ -278,6 +349,4 @@ def test_calculate_uk_model(
     assert result.result is not None
 
     economy_result = result.result
-    assert "budget" in economy_result
-    assert "poverty" in economy_result
-    assert "inequality" in economy_result
+    assert_economy_result_sections(economy_result)

--- a/projects/policyengine-simulation-executor/fixtures/test_simulation_api_contracts.py
+++ b/projects/policyengine-simulation-executor/fixtures/test_simulation_api_contracts.py
@@ -126,6 +126,18 @@ CURRENT_SINGLE_YEAR_MACRO_RESULT = {
     },
     "constituency_impact": None,
     "local_authority_impact": None,
-    "congressional_district_impact": [{"district_geoid": 101}],
+    "congressional_district_impact": {
+        "districts": [
+            {
+                "district": "AL-01",
+                "average_household_income_change": 10.0,
+                "relative_household_income_change": 0.01,
+                "winner_percentage": 0.6,
+                "loser_percentage": 0.3,
+                "no_change_percentage": 0.1,
+                "population": 1000.0,
+            }
+        ]
+    },
     "cliff_impact": None,
 }

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_macro_output.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_macro_output.py
@@ -124,6 +124,20 @@ class GeographicImpactOutput(MacroRootModel[list[dict[str, Any]]]):
     pass
 
 
+class CongressionalDistrictImpactRecord(MacroOutputModel):
+    district: str
+    average_household_income_change: float
+    relative_household_income_change: float
+    winner_percentage: float
+    loser_percentage: float
+    no_change_percentage: float
+    population: float
+
+
+class CongressionalDistrictImpactOutput(MacroOutputModel):
+    districts: list[CongressionalDistrictImpactRecord]
+
+
 class SingleYearMacroOutput(MacroOutputModel):
     model_version: str
     data_version: str
@@ -140,5 +154,5 @@ class SingleYearMacroOutput(MacroOutputModel):
     labor_supply_response: LaborSupplyResponseOutput | None
     constituency_impact: GeographicImpactOutput | None
     local_authority_impact: GeographicImpactOutput | None
-    congressional_district_impact: GeographicImpactOutput | None
+    congressional_district_impact: CongressionalDistrictImpactOutput | None
     cliff_impact: CliffImpactOutput | None = None

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_output_builder.py
@@ -19,6 +19,7 @@ from policyengine_simulation_executor.release_bundle import get_country_release_
 from policyengine_simulation_executor.simulation_macro_output import (
     BudgetaryImpact,
     CliffImpactOutput,
+    CongressionalDistrictImpactOutput,
     DecileOutput,
     DetailedBudgetOutput,
     GeographicImpactOutput,
@@ -42,6 +43,7 @@ class SimulationOutputBuilder:
     baseline: Any
     reform: Any
     resolved_data_version: str | None = None
+    resolved_region_code: str | None = None
     _analysis: Any = field(default=None, init=False)
 
     def __post_init__(self) -> None:
@@ -208,10 +210,13 @@ class SimulationOutputBuilder:
 
     def _build_congressional_district_impact(
         self,
-    ) -> GeographicImpactOutput | None:
+    ) -> CongressionalDistrictImpactOutput | None:
         with segment(SegmentName.OUTPUT_CONGRESSIONAL_DISTRICT):
             return simulation_output_geographic.build_congressional_district_impact(
-                self.country, self.baseline, self.reform
+                self.country,
+                self.baseline,
+                self.reform,
+                region_code=self.resolved_region_code,
             )
 
     def _build_uk_constituency_impact(self) -> GeographicImpactOutput | None:

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_output_geographic.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_output_geographic.py
@@ -6,13 +6,72 @@ from collections.abc import Mapping
 from typing import Any
 
 from policyengine_simulation_executor.simulation_macro_output import (
+    CongressionalDistrictImpactOutput,
+    CongressionalDistrictImpactRecord,
     GeographicImpactOutput,
 )
 from policyengine_simulation_executor.simulation_output_common import (
+    _number,
     _output_model_dump,
     _output_module_function,
     _try_compute_output,
 )
+
+_STATE_ABBREVIATION_BY_FIPS = {
+    1: "AL",
+    2: "AK",
+    4: "AZ",
+    5: "AR",
+    6: "CA",
+    8: "CO",
+    9: "CT",
+    10: "DE",
+    11: "DC",
+    12: "FL",
+    13: "GA",
+    15: "HI",
+    16: "ID",
+    17: "IL",
+    18: "IN",
+    19: "IA",
+    20: "KS",
+    21: "KY",
+    22: "LA",
+    23: "ME",
+    24: "MD",
+    25: "MA",
+    26: "MI",
+    27: "MN",
+    28: "MS",
+    29: "MO",
+    30: "MT",
+    31: "NE",
+    32: "NV",
+    33: "NH",
+    34: "NJ",
+    35: "NM",
+    36: "NY",
+    37: "NC",
+    38: "ND",
+    39: "OH",
+    40: "OK",
+    41: "OR",
+    42: "PA",
+    44: "RI",
+    45: "SC",
+    46: "SD",
+    47: "TN",
+    48: "TX",
+    49: "UT",
+    50: "VT",
+    51: "VA",
+    53: "WA",
+    54: "WV",
+    55: "WI",
+    56: "WY",
+}
+
+_AT_LARGE_DISTRICTS = {"AK", "DE", "DC", "ND", "SD", "VT", "WY"}
 
 
 def build_geographic_impact_output(value: Any) -> GeographicImpactOutput | None:
@@ -30,25 +89,104 @@ def build_geographic_impact_output(value: Any) -> GeographicImpactOutput | None:
     return None
 
 
+def build_congressional_district_impact_output(
+    value: Any,
+) -> CongressionalDistrictImpactOutput | None:
+    if isinstance(value, CongressionalDistrictImpactOutput):
+        return value
+    records = _output_model_dump(value)
+    if not isinstance(records, list):
+        records = value if isinstance(value, list) else None
+    if not isinstance(records, list):
+        return None
+
+    return CongressionalDistrictImpactOutput(
+        districts=[
+            _build_congressional_district_record(record)
+            for record in records
+            if isinstance(record, Mapping)
+        ]
+    )
+
+
+def _build_congressional_district_record(
+    record: Mapping[str, Any],
+) -> CongressionalDistrictImpactRecord:
+    return CongressionalDistrictImpactRecord(
+        district=_public_congressional_district_code(record),
+        average_household_income_change=_number(
+            record.get("average_household_income_change")
+        ),
+        relative_household_income_change=_number(
+            record.get("relative_household_income_change")
+        ),
+        winner_percentage=_number(record.get("winner_percentage")),
+        loser_percentage=_number(record.get("loser_percentage")),
+        no_change_percentage=_number(record.get("no_change_percentage")),
+        population=_number(record.get("population")),
+    )
+
+
+def _public_congressional_district_code(record: Mapping[str, Any]) -> str:
+    state_fips = _integer_record_value(record, "state_fips")
+    district_number = _integer_record_value(record, "district_number")
+    geoid = _integer_record_value(record, "district_geoid")
+    if geoid is not None:
+        if state_fips is None:
+            state_fips = geoid // 100
+        if district_number is None:
+            district_number = geoid % 100
+    if state_fips is None:
+        raise ValueError("Congressional district output is missing state FIPS")
+
+    state_abbreviation = _STATE_ABBREVIATION_BY_FIPS.get(state_fips)
+    if state_abbreviation is None:
+        raise ValueError(f"Unknown state FIPS code: {state_fips}")
+    if district_number is None:
+        raise ValueError("Congressional district output is missing district number")
+
+    public_district_number = (
+        1 if state_abbreviation in _AT_LARGE_DISTRICTS else district_number
+    )
+    return f"{state_abbreviation}-{public_district_number:02d}"
+
+
+def _integer_record_value(record: Mapping[str, Any], key: str) -> int | None:
+    value = record.get(key)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _should_build_us_congressional_district_impact(region_code: str | None) -> bool:
+    if region_code is None:
+        return True
+    normalized_region_code = region_code.lower()
+    return normalized_region_code == "us" or normalized_region_code.startswith("state/")
+
+
 def build_congressional_district_impact(
-    country: str, baseline, reform
-) -> GeographicImpactOutput | None:
+    country: str, baseline, reform, *, region_code: str | None = None
+) -> CongressionalDistrictImpactOutput | None:
     if country != "us":
+        return None
+    if not _should_build_us_congressional_district_impact(region_code):
         return None
 
     from policyengine.outputs.congressional_district_impact import (
         compute_us_congressional_district_impacts,
     )
 
-    impact = _try_compute_output(
-        "congressional district impacts",
-        compute_us_congressional_district_impacts,
-        baseline,
-        reform,
-    )
-    return build_geographic_impact_output(
-        getattr(impact, "district_results", None) if impact is not None else None
-    )
+    def compute_and_format() -> CongressionalDistrictImpactOutput | None:
+        impact = compute_us_congressional_district_impacts(baseline, reform)
+        return build_congressional_district_impact_output(
+            getattr(impact, "district_results", None)
+        )
+
+    return _try_compute_output("congressional district impacts", compute_and_format)
 
 
 def build_uk_constituency_impact(

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_output_geographic.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_output_geographic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from functools import lru_cache
 from typing import Any
 
 from policyengine_simulation_executor.simulation_macro_output import (
@@ -17,61 +18,18 @@ from policyengine_simulation_executor.simulation_output_common import (
     _try_compute_output,
 )
 
-_STATE_ABBREVIATION_BY_FIPS = {
-    1: "AL",
-    2: "AK",
-    4: "AZ",
-    5: "AR",
-    6: "CA",
-    8: "CO",
-    9: "CT",
-    10: "DE",
-    11: "DC",
-    12: "FL",
-    13: "GA",
-    15: "HI",
-    16: "ID",
-    17: "IL",
-    18: "IN",
-    19: "IA",
-    20: "KS",
-    21: "KY",
-    22: "LA",
-    23: "ME",
-    24: "MD",
-    25: "MA",
-    26: "MI",
-    27: "MN",
-    28: "MS",
-    29: "MO",
-    30: "MT",
-    31: "NE",
-    32: "NV",
-    33: "NH",
-    34: "NJ",
-    35: "NM",
-    36: "NY",
-    37: "NC",
-    38: "ND",
-    39: "OH",
-    40: "OK",
-    41: "OR",
-    42: "PA",
-    44: "RI",
-    45: "SC",
-    46: "SD",
-    47: "TN",
-    48: "TX",
-    49: "UT",
-    50: "VT",
-    51: "VA",
-    53: "WA",
-    54: "WV",
-    55: "WI",
-    56: "WY",
-}
 
-_AT_LARGE_DISTRICTS = {"AK", "DE", "DC", "ND", "SD", "VT", "WY"}
+@lru_cache(maxsize=1)
+def _policyengine_us_district_metadata() -> tuple[dict[int, str], frozenset[str]]:
+    from policyengine.countries.us.data import AT_LARGE_STATES, US_STATE_FIPS
+
+    return (
+        {
+            int(fips): state_abbreviation
+            for state_abbreviation, fips in US_STATE_FIPS.items()
+        },
+        frozenset(AT_LARGE_STATES),
+    )
 
 
 def build_geographic_impact_output(value: Any) -> GeographicImpactOutput | None:
@@ -139,14 +97,15 @@ def _public_congressional_district_code(record: Mapping[str, Any]) -> str:
     if state_fips is None:
         raise ValueError("Congressional district output is missing state FIPS")
 
-    state_abbreviation = _STATE_ABBREVIATION_BY_FIPS.get(state_fips)
+    state_abbreviation_by_fips, at_large_states = _policyengine_us_district_metadata()
+    state_abbreviation = state_abbreviation_by_fips.get(state_fips)
     if state_abbreviation is None:
         raise ValueError(f"Unknown state FIPS code: {state_fips}")
     if district_number is None:
         raise ValueError("Congressional district output is missing district number")
 
     public_district_number = (
-        1 if state_abbreviation in _AT_LARGE_DISTRICTS else district_number
+        1 if state_abbreviation in at_large_states else district_number
     )
     return f"{state_abbreviation}-{public_district_number:02d}"
 

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_runtime.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_runtime.py
@@ -497,6 +497,7 @@ def _run_simulation_impl_core(params: dict) -> dict:
         baseline=baseline,
         reform=reform,
         resolved_data_version=_requested_data_version(simulation_params),
+        resolved_region_code=region_resolution.code,
     )
     output = builder.serialize()
     logger.info("Comparison complete")

--- a/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
@@ -34,9 +34,13 @@ from policyengine_simulation_observability.observability import SegmentName
 from policyengine_simulation_executor.simulation_runtime import RegionResolution
 from policyengine_simulation_executor.simulation_runtime import _load_dataset
 from policyengine_simulation_executor.simulation_runtime import _normalise_policy
-from policyengine_simulation_executor.simulation_runtime import _resolve_dataset_reference
+from policyengine_simulation_executor.simulation_runtime import (
+    _resolve_dataset_reference,
+)
 from policyengine_simulation_executor.simulation_runtime import _resolve_region
-from policyengine_simulation_executor.simulation_runtime import _run_simulation_impl_core
+from policyengine_simulation_executor.simulation_runtime import (
+    _run_simulation_impl_core,
+)
 from policyengine_simulation_executor.simulation_runtime import run_simulation_impl
 from policyengine_simulation_executor.simulation_macro_output import (
     AgePovertyOutput,
@@ -45,7 +49,7 @@ from policyengine_simulation_executor.simulation_macro_output import (
     BudgetaryOutput,
     DecileOutput,
     DetailedBudgetOutput,
-    GeographicImpactOutput,
+    CongressionalDistrictImpactOutput,
     GenderPovertyOutput,
     InequalityOutput,
     IntraDecileOutput,
@@ -54,6 +58,10 @@ from policyengine_simulation_executor.simulation_macro_output import (
     PovertyModuleOutputs,
     PovertyOutput,
     SingleYearMacroOutput,
+)
+from policyengine_simulation_executor.simulation_output_geographic import (
+    build_congressional_district_impact,
+    build_congressional_district_impact_output,
 )
 from policyengine_simulation_executor.simulation_output_builder import (
     SimulationOutputBuilder,
@@ -131,6 +139,7 @@ def _simulation_output_builder(
     reform,
     analysis=None,
     include_cliffs: bool | None = None,
+    resolved_region_code: str | None = "us",
 ) -> SimulationOutputBuilder:
     analysis = analysis or fake_analysis()
 
@@ -160,6 +169,23 @@ def _simulation_output_builder(
         dataset=SimpleNamespace(metadata={}),
         baseline=baseline,
         reform=reform,
+        resolved_region_code=resolved_region_code,
+    )
+
+
+def _congressional_district_output() -> CongressionalDistrictImpactOutput:
+    return CongressionalDistrictImpactOutput(
+        districts=[
+            {
+                "district": "AL-01",
+                "average_household_income_change": 10.0,
+                "relative_household_income_change": 0.01,
+                "winner_percentage": 0.6,
+                "loser_percentage": 0.3,
+                "no_change_percentage": 0.1,
+                "population": 1000.0,
+            }
+        ]
     )
 
 
@@ -203,9 +229,7 @@ def _stub_policyengine_output_calls(monkeypatch, baseline, reform) -> None:
         SimulationOutputBuilder,
         "_build_congressional_district_impact",
         lambda self: (
-            self._build_geographic_impact_output([{"district_geoid": 101}])
-            if self.country == "us"
-            else None
+            _congressional_district_output() if self.country == "us" else None
         ),
     )
     monkeypatch.setattr(
@@ -246,9 +270,11 @@ def test_builder_returns_schema_modules_before_legacy_dict_dump(monkeypatch):
     assert isinstance(output.decile, DecileOutput)
     assert isinstance(output.intra_decile, IntraDecileOutput)
     assert isinstance(output.poverty, PovertyOutput)
-    assert isinstance(output.congressional_district_impact, GeographicImpactOutput)
+    assert isinstance(
+        output.congressional_district_impact, CongressionalDistrictImpactOutput
+    )
     assert output.wealth_decile is None
-    assert output.congressional_district_impact.root == [{"district_geoid": 101}]
+    assert output.congressional_district_impact.districts[0].district == "AL-01"
 
 
 def test_builder_returns_existing_single_year_macro_shape(monkeypatch):
@@ -256,6 +282,117 @@ def test_builder_returns_existing_single_year_macro_shape(monkeypatch):
 
     assert set(output) == CURRENT_SINGLE_YEAR_MACRO_KEYS
     assert output == CURRENT_SINGLE_YEAR_MACRO_RESULT
+
+
+def test_congressional_district_output_formats_policyengine_results():
+    output = build_congressional_district_impact_output(
+        [
+            {
+                "district_geoid": 101,
+                "state_fips": 1,
+                "district_number": 1,
+                "average_household_income_change": 10,
+                "relative_household_income_change": "0.01",
+                "winner_percentage": 0.6,
+                "loser_percentage": 0.3,
+                "no_change_percentage": 0.1,
+                "population": 1000,
+            },
+            {
+                "district_geoid": 200,
+                "average_household_income_change": 20,
+                "relative_household_income_change": 0.02,
+                "winner_percentage": 0.7,
+                "loser_percentage": 0.2,
+                "no_change_percentage": 0.1,
+                "population": 2000,
+            },
+            {
+                "state_fips": 6,
+                "district_number": 12,
+                "average_household_income_change": 30,
+                "relative_household_income_change": 0.03,
+                "winner_percentage": 0.8,
+                "loser_percentage": 0.1,
+                "no_change_percentage": 0.1,
+                "population": 3000,
+            },
+        ]
+    )
+
+    assert output is not None
+    assert output.model_dump(mode="json") == {
+        "districts": [
+            {
+                "district": "AL-01",
+                "average_household_income_change": 10.0,
+                "relative_household_income_change": 0.01,
+                "winner_percentage": 0.6,
+                "loser_percentage": 0.3,
+                "no_change_percentage": 0.1,
+                "population": 1000.0,
+            },
+            {
+                "district": "AK-01",
+                "average_household_income_change": 20.0,
+                "relative_household_income_change": 0.02,
+                "winner_percentage": 0.7,
+                "loser_percentage": 0.2,
+                "no_change_percentage": 0.1,
+                "population": 2000.0,
+            },
+            {
+                "district": "CA-12",
+                "average_household_income_change": 30.0,
+                "relative_household_income_change": 0.03,
+                "winner_percentage": 0.8,
+                "loser_percentage": 0.1,
+                "no_change_percentage": 0.1,
+                "population": 3000.0,
+            },
+        ]
+    }
+
+
+def test_congressional_district_output_skips_narrow_regions():
+    assert (
+        build_congressional_district_impact(
+            "us",
+            object(),
+            object(),
+            region_code="congressional_district/AL-01",
+        )
+        is None
+    )
+    assert build_congressional_district_impact("uk", object(), object()) is None
+
+
+def test_builder_passes_resolved_region_to_congressional_district_output(monkeypatch):
+    baseline, reform = _macro_baseline_reform()
+    calls = []
+
+    def fake_build_congressional_district_impact(
+        country, baseline_arg, reform_arg, *, region_code=None
+    ):
+        calls.append((country, baseline_arg, reform_arg, region_code))
+        return CongressionalDistrictImpactOutput(districts=[])
+
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_output_geographic.build_congressional_district_impact",
+        fake_build_congressional_district_impact,
+    )
+
+    builder = _simulation_output_builder(
+        "us",
+        baseline,
+        reform,
+        resolved_region_code="state/ut",
+    )
+
+    assert builder._build_congressional_district_impact() == (
+        CongressionalDistrictImpactOutput(districts=[])
+    )
+    assert calls == [("us", baseline, reform, "state/ut")]
 
 
 def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
@@ -477,7 +614,9 @@ def test_builder_records_output_timings_without_real_calculation(monkeypatch):
     )
     monkeypatch.setattr(
         "policyengine_simulation_executor.simulation_output_geographic.build_congressional_district_impact",
-        record("congressional_district", GeographicImpactOutput([])),
+        record(
+            "congressional_district", CongressionalDistrictImpactOutput(districts=[])
+        ),
     )
     monkeypatch.setattr(
         "policyengine_simulation_executor.simulation_output_geographic.build_uk_constituency_impact",
@@ -765,6 +904,7 @@ def test_run_simulation_impl_core_builds_and_serializes_macro_output(monkeypatch
             "baseline": baseline_simulation,
             "reform": reform_simulation,
             "resolved_data_version": None,
+            "resolved_region_code": "us",
         }
     ]
 

--- a/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
@@ -285,6 +285,8 @@ def test_builder_returns_existing_single_year_macro_shape(monkeypatch):
 
 
 def test_congressional_district_output_formats_policyengine_results():
+    from policyengine.countries.us.data import US_STATE_FIPS
+
     output = build_congressional_district_impact_output(
         [
             {
@@ -316,6 +318,15 @@ def test_congressional_district_output_formats_policyengine_results():
                 "loser_percentage": 0.1,
                 "no_change_percentage": 0.1,
                 "population": 3000,
+            },
+            {
+                "district_geoid": US_STATE_FIPS["DC"] * 100,
+                "average_household_income_change": 40,
+                "relative_household_income_change": 0.04,
+                "winner_percentage": 0.9,
+                "loser_percentage": 0.05,
+                "no_change_percentage": 0.05,
+                "population": 4000,
             },
         ]
     )
@@ -349,6 +360,15 @@ def test_congressional_district_output_formats_policyengine_results():
                 "loser_percentage": 0.1,
                 "no_change_percentage": 0.1,
                 "population": 3000.0,
+            },
+            {
+                "district": "DC-01",
+                "average_household_income_change": 40.0,
+                "relative_household_income_change": 0.04,
+                "winner_percentage": 0.9,
+                "loser_percentage": 0.05,
+                "no_change_percentage": 0.05,
+                "population": 4000.0,
             },
         ]
     }


### PR DESCRIPTION
Fixes #615.

Summary:
- Converts .py US congressional district results into the report/API v1 shape: `{ districts: [...] }`.
- Maps FIPS/GEOID values to canonical district IDs like `AL-01` and normalizes at-large districts to `-01`.
- Gates CD output to US national and state-level report scopes by threading the resolved region code into output building.

Verification:
- `uv run ruff check` on changed simulation executor files
- `uv run pytest tests/test_simulation_output_builder.py -q`