### PR TITLE
Accept both repo names in rename-sensitive guards

### DIFF
--- a/.github/workflows/check-policyengine-updates.yml
+++ b/.github/workflows/check-policyengine-updates.yml
@@ -22,7 +22,9 @@ jobs:
   update:
     name: Update policyengine.py bundle
     runs-on: ubuntu-latest
-    if: github.repository == 'PolicyEngine/policyengine-api-v2'
+    if: >-
+      github.repository == 'PolicyEngine/policyengine-api-v2' ||
+      github.repository == 'PolicyEngine/policyengine-sim-api'
 
     steps:
       - name: Generate GitHub App token

--- a/Makefile
+++ b/Makefile
@@ -350,8 +350,8 @@ push-pr-branch:
 	fi; \
 	REMOTE_URL=$$(git remote get-url origin 2>/dev/null || true); \
 	case "$$REMOTE_URL" in \
-		*PolicyEngine/policyengine-api-v2* ) ;; \
-		* ) echo "Missing canonical origin remote PolicyEngine/policyengine-api-v2"; exit 1 ;; \
+		*PolicyEngine/policyengine-api-v2* | *PolicyEngine/policyengine-sim-api* ) ;; \
+		* ) echo "Missing canonical origin remote PolicyEngine/policyengine-sim-api"; exit 1 ;; \
 	esac; \
 	git push -u origin HEAD:$$BRANCH; \
 	echo "Create the PR with: gh pr create --draft --repo PolicyEngine/policyengine-api-v2 --head $$BRANCH --base main"


### PR DESCRIPTION
Fixes #622

Pre-rename compatibility step for renaming this repository to `policyengine-sim-api`.

Two guards hardcode `PolicyEngine/policyengine-api-v2` and have no single value that is correct both before and after a GitHub repo rename. This PR makes both accept either name so the rename can happen with zero gap:

- `.github/workflows/check-policyengine-updates.yml` — job `if:` guard now matches the old or new `owner/name`, so the scheduled update-policyengine workflow keeps running across the rename.
- `Makefile` `push-pr-branch` — the origin-remote check accepts either repo path.

A follow-up PR (after the GitHub rename is live) removes the old name and updates the remaining docs/branding references.

## Testing
- Validated the workflow YAML parses and the `if:` guard evaluates to the two-name OR expression.
- No Python surface changed (only a GitHub Actions workflow and the Makefile), so the unit/integration suites are not applicable to this diff.