### PR TITLE
Complete rename to policyengine-sim-api

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-# Contributing to policyengine-api-v2
+# Contributing to policyengine-sim-api
 
 See the shared PolicyEngine contribution guide for cross-repo conventions. This
-file covers policyengine-api-v2 specifics.
+file covers policyengine-sim-api specifics.
 
 ## Commands
 
@@ -45,15 +45,15 @@ pushes the current branch to `origin` with the correct tracking so
 `gh pr create` works. Then create and verify the PR explicitly:
 
 ```bash
-gh pr create --draft --repo PolicyEngine/policyengine-api-v2 --head "$(git branch --show-current)" --base main
-gh pr view <PR> --repo PolicyEngine/policyengine-api-v2 --json isDraft,headRepositoryOwner,headRepository
+gh pr create --draft --repo PolicyEngine/policyengine-sim-api --head "$(git branch --show-current)" --base main
+gh pr view <PR> --repo PolicyEngine/policyengine-sim-api --json isDraft,headRepositoryOwner,headRepository
 ```
 
 Before opening the PR, open or identify a GitHub issue for the work. The first
 line of the PR description must be `Fixes #ISSUE_NUMBER`.
 
 The PR is valid only if it is a draft and the head repository is
-`PolicyEngine/policyengine-api-v2`. If you cannot push to that repository, ask
+`PolicyEngine/policyengine-sim-api`. If you cannot push to that repository, ask
 for access instead of opening a fork PR.
 
 ## Repo-Specific Anti-Patterns

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,4 +8,4 @@ reviewing test files. Do not duplicate or override that testing guidance here.
 
 For pull requests, read `docs/engineering/skills/github-prs.md` before opening,
 replacing, or sharing a PR. This repository only accepts same-repository PRs
-from branches in `PolicyEngine/policyengine-api-v2`; never create fork PRs.
+from branches in `PolicyEngine/policyengine-sim-api`; never create fork PRs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Fixes #
 ## Same-Repository Draft PR Check
 
 - [ ] This PR is a draft.
-- [ ] This PR is from a branch in `PolicyEngine/policyengine-api-v2`, not a personal fork.
+- [ ] This PR is from a branch in `PolicyEngine/policyengine-sim-api`, not a personal fork.
 
 ## Summary
 

--- a/.github/workflows/check-policyengine-updates.yml
+++ b/.github/workflows/check-policyengine-updates.yml
@@ -22,9 +22,7 @@ jobs:
   update:
     name: Update policyengine.py bundle
     runs-on: ubuntu-latest
-    if: >-
-      github.repository == 'PolicyEngine/policyengine-api-v2' ||
-      github.repository == 'PolicyEngine/policyengine-sim-api'
+    if: github.repository == 'PolicyEngine/policyengine-sim-api'
 
     steps:
       - name: Generate GitHub App token

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,13 @@ When adding, moving, or reviewing tests, read
 
 ## GitHub PRs
 
-Never open `policyengine-api-v2` PRs from forks. CI and deployment checks are
+Never open `policyengine-sim-api` PRs from forks. CI and deployment checks are
 designed for same-repository branches.
 
 Before creating or sharing any PR, all developers and agents must:
 
 1. Confirm the canonical repository is reachable:
-   `gh repo view PolicyEngine/policyengine-api-v2 --json nameWithOwner`.
+   `gh repo view PolicyEngine/policyengine-sim-api --json nameWithOwner`.
 2. Open a GitHub issue for the work, or verify that an appropriate issue
    already exists.
 3. Put `Fixes #ISSUE_NUMBER` as the first line of the PR description, using the
@@ -39,13 +39,13 @@ Before creating or sharing any PR, all developers and agents must:
 4. Push the branch to the canonical repository, for example:
    `make push-pr-branch`.
 5. Create the PR as a draft from that same repository, for example:
-   `gh pr create --draft --repo PolicyEngine/policyengine-api-v2 --head "$(git branch --show-current)" --base main`.
+   `gh pr create --draft --repo PolicyEngine/policyengine-sim-api --head "$(git branch --show-current)" --base main`.
 6. Verify the PR is draft and the head repository is canonical before reporting
    it:
-   `gh pr view <PR> --repo PolicyEngine/policyengine-api-v2 --json isDraft,headRepositoryOwner,headRepository`.
+   `gh pr view <PR> --repo PolicyEngine/policyengine-sim-api --json isDraft,headRepositoryOwner,headRepository`.
 
 The PR is valid only if `isDraft` is `true` and the head repository is
-`PolicyEngine/policyengine-api-v2`. If you cannot push to the canonical
+`PolicyEngine/policyengine-sim-api`. If you cannot push to the canonical
 repository, stop and ask for access. Do not create a fork PR as a fallback. If
 you accidentally create one, immediately close it and replace it with a
 same-repository draft PR.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Simplified Makefile using docker-compose
-.PHONY: help dev up down build test deploy clean logs format check terraform-deploy push-pr-branch
+.PHONY: help dev up down build test clean logs format check push-pr-branch
 
 # Load environment variables if .env exists
 ifneq (,$(wildcard deployment/.env))
@@ -37,29 +37,6 @@ help:
 	@echo ""
 	@echo "Deployment is automated via GitHub Actions to Modal; there is no manual deploy target."
 
-# Initialize GCP (enables APIs, creates bucket, etc)
-init-gcp: check-deploy-env
-	@bash deployment/init-gcp.sh
-
-# Setup for first-time users
-setup:
-	@echo "Setting up PolicyEngine API for first time..."
-	@echo "Note: Using gcloud storage commands (compatible with Python 3.13+)"
-	@if [ ! -f deployment/.env ]; then \
-		cp deployment/.env.example deployment/.env; \
-		echo "✅ Created deployment/.env"; \
-		echo ""; \
-		echo "⚠️  IMPORTANT: Edit deployment/.env and set:"; \
-		echo "   - PROJECT_ID to your GCP project ID"; \
-		echo "   - GOOGLE_CLOUD_PROJECT to match PROJECT_ID"; \
-		echo ""; \
-		echo "Then run:"; \
-		echo "   make dev              # For local development"; \
-		echo "   make deploy           # To deploy to GCP"; \
-	else \
-		echo "✅ deployment/.env already exists"; \
-	fi
-
 # Development commands
 dev:
 	docker-compose -f deployment/docker-compose.yml up --build
@@ -84,9 +61,6 @@ endif
 # Build commands
 build:
 	docker-compose -f deployment/docker-compose.yml build --parallel
-
-build-prod:
-	docker-compose -f deployment/docker-compose.prod.yml build --parallel
 
 # Client generation
 generate-clients:
@@ -147,162 +121,6 @@ test-all: test test-integration
 # Complete test suite with services startup/shutdown
 test-complete: test test-integration-with-services
 	@echo "✅ All tests including integration passed!"
-
-# Deployment
-deploy: check-deploy-env build-prod push-images terraform-ensure-init terraform-deploy-all
-
-check-deploy-env:
-	@if [ ! -f "deployment/.env" ]; then \
-		echo "Error: deployment/.env not found. Run 'make setup' first"; \
-		exit 1; \
-	fi
-	@if [ -z "$(PROJECT_ID)" ]; then \
-		echo "Error: PROJECT_ID not set in deployment/.env"; \
-		exit 1; \
-	fi
-
-push-images:
-	@echo "Pushing images to GCP..."
-	docker-compose -f deployment/docker-compose.prod.yml push
-
-# Terraform commands
-terraform-backend:
-	@echo "Setting up Terraform backend..."
-	@if [ -z "$(PROJECT_ID)" ]; then \
-		echo "Error: PROJECT_ID not set. Please update deployment/.env"; \
-		exit 1; \
-	fi
-	@echo "Creating GCS bucket for Terraform state: $(PROJECT_ID)-state"
-	@gcloud storage buckets create gs://$(PROJECT_ID)-state \
-		--project=$(PROJECT_ID) \
-		--location=$(REGION) \
-		--uniform-bucket-level-access 2>/dev/null || echo "Bucket already exists"
-	@gcloud storage buckets update gs://$(PROJECT_ID)-state --versioning
-	@echo "Backend bucket ready"
-
-terraform-force-init:
-	@echo "Force reinitializing Terraform (cleaning existing state)..."
-	@rm -rf deployment/terraform/infra/.terraform deployment/terraform/project/.terraform
-	@$(MAKE) terraform-init
-
-terraform-init: terraform-backend
-	@echo "Initializing Terraform..."
-	@# Remove example backend files if they exist
-	@rm -f deployment/terraform/infra/backend.example.tf deployment/terraform/infra/backend.example.tfvars
-	@rm -f deployment/terraform/project/backend.example.tf deployment/terraform/project/backend.example_tf
-	@# Create or update backend.tf files
-	@echo "Configuring backend for $(PROJECT_ID)-state..."
-	@echo "terraform {" > deployment/terraform/infra/backend.tf.tmp
-	@echo "  backend \"gcs\" {" >> deployment/terraform/infra/backend.tf.tmp
-	@echo "    bucket = \"$(PROJECT_ID)-state\"" >> deployment/terraform/infra/backend.tf.tmp
-	@echo "    prefix = \"infra\"" >> deployment/terraform/infra/backend.tf.tmp
-	@echo "  }" >> deployment/terraform/infra/backend.tf.tmp
-	@echo "}" >> deployment/terraform/infra/backend.tf.tmp
-	@mv deployment/terraform/infra/backend.tf.tmp deployment/terraform/infra/backend.tf
-	@echo "terraform {" > deployment/terraform/project/backend.tf.tmp
-	@echo "  backend \"gcs\" {" >> deployment/terraform/project/backend.tf.tmp
-	@echo "    bucket = \"$(PROJECT_ID)-state\"" >> deployment/terraform/project/backend.tf.tmp
-	@echo "    prefix = \"project\"" >> deployment/terraform/project/backend.tf.tmp
-	@echo "  }" >> deployment/terraform/project/backend.tf.tmp
-	@echo "}" >> deployment/terraform/project/backend.tf.tmp
-	@mv deployment/terraform/project/backend.tf.tmp deployment/terraform/project/backend.tf
-	@echo "Initializing project module..."
-	-cd deployment/terraform/project && terraform init -reconfigure 2>/dev/null || true
-	@echo "Initializing infra module..."
-	cd deployment/terraform/infra && terraform init -reconfigure
-
-terraform-ensure-init:
-	@echo "Checking Terraform initialization..."
-	@# Always run init if backend.tf was recently modified or .terraform doesn't exist
-	@if [ ! -d "deployment/terraform/infra/.terraform" ] || \
-	   [ "deployment/terraform/infra/backend.tf" -nt "deployment/terraform/infra/.terraform" ] || \
-	   [ ! -f "deployment/terraform/infra/.terraform/terraform.tfstate" ]; then \
-		echo "Running terraform init..."; \
-		$(MAKE) terraform-init; \
-	else \
-		echo "Terraform already initialized"; \
-	fi
-
-terraform-plan: terraform-ensure-init
-	@echo "Planning Terraform changes..."
-	@if [ -z "$(TF_VAR_org_id)" ] || [ "$(TF_VAR_org_id)" = "your-org-id" ]; then \
-		echo "\n=== Skipping PROJECT module (using existing project) ==="; \
-	else \
-		echo "\n=== Planning PROJECT module ==="; \
-		cd deployment/terraform/project && terraform plan; \
-	fi
-	@echo "\n=== Planning INFRA module ==="
-	@# Auto-populate all required variables
-	@US_VERSION=$$(grep -A1 'name = "policyengine-us"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
-	UK_VERSION=$$(grep -A1 'name = "policyengine-uk"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
-	COMMIT_URL="https://github.com/PolicyEngine/policyengine-sim-api/commit/$$(git rev-parse HEAD)" && \
-	echo "project_id = \"$${TF_VAR_project_id}\"" > deployment/terraform/infra/auto.tfvars && \
-	echo "commit_url = \"$$COMMIT_URL\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "policyengine-us-package-version = \"$$US_VERSION\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "policyengine-uk-package-version = \"$$UK_VERSION\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "is_prod = $${TF_VAR_is_prod:-false}" >> deployment/terraform/infra/auto.tfvars && \
-	echo "full_container_tag = \"$${TF_VAR_full_container_tag:-latest}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "simulation_container_tag = \"$${TF_VAR_simulation_container_tag:-latest}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "tagger_container_tag = \"$${TF_VAR_tagger_container_tag:-latest}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "region = \"$${TF_VAR_region:-us-central1}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "stage = \"$${TF_VAR_stage:-dev}\"" >> deployment/terraform/infra/auto.tfvars && \
-	cd deployment/terraform/infra && terraform plan -var-file=auto.tfvars
-
-terraform-deploy-project: terraform-ensure-init
-	@echo "Deploying GCP project configuration..."
-	@echo "Note: This creates a NEW GCP project. Skip if using existing project."
-	@if [ -z "$(TF_VAR_org_id)" ] || [ "$(TF_VAR_org_id)" = "your-org-id" ]; then \
-		echo "⚠️  Skipping project creation - TF_VAR_org_id not set"; \
-		echo "   Using existing project: $(PROJECT_ID)"; \
-	else \
-		cd deployment/terraform/project && terraform apply -auto-approve; \
-	fi
-
-terraform-deploy-infra: terraform-ensure-init
-	@echo "Deploying infrastructure (Cloud Run, etc)..."
-	@# Auto-populate all required variables
-	@US_VERSION=$$(grep -A1 'name = "policyengine-us"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
-	UK_VERSION=$$(grep -A1 'name = "policyengine-uk"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
-	COMMIT_URL="https://github.com/PolicyEngine/policyengine-sim-api/commit/$$(git rev-parse HEAD)" && \
-	echo "project_id = \"$${TF_VAR_project_id}\"" > deployment/terraform/infra/auto.tfvars && \
-	echo "commit_url = \"$$COMMIT_URL\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "policyengine-us-package-version = \"$$US_VERSION\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "policyengine-uk-package-version = \"$$UK_VERSION\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "is_prod = $${TF_VAR_is_prod:-false}" >> deployment/terraform/infra/auto.tfvars && \
-	echo "full_container_tag = \"$${TF_VAR_full_container_tag:-latest}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "simulation_container_tag = \"$${TF_VAR_simulation_container_tag:-latest}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "tagger_container_tag = \"$${TF_VAR_tagger_container_tag:-latest}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "region = \"$${TF_VAR_region:-us-central1}\"" >> deployment/terraform/infra/auto.tfvars && \
-	echo "stage = \"$${TF_VAR_stage:-dev}\"" >> deployment/terraform/infra/auto.tfvars && \
-	cd deployment/terraform/infra && terraform apply -auto-approve -var-file=auto.tfvars
-
-terraform-deploy-all: terraform-ensure-init
-	@echo "Starting full deployment..."
-	@# Try project deployment but don't fail if skipped
-	@$(MAKE) terraform-deploy-project || true
-	@# Always deploy infrastructure
-	@$(MAKE) terraform-deploy-infra
-	@echo "✅ Deployment completed successfully!"
-
-terraform-deploy: terraform-deploy-all  # Alias for backward compatibility
-
-terraform-import:
-	@echo "Importing existing resources into terraform state..."
-	@cd deployment/terraform && ./import-existing.sh
-
-terraform-handle-workflows:
-	@echo "Checking and handling existing workflows..."
-	@cd deployment/terraform && ./handle-existing-workflows.sh $(PROJECT_ID) $(TF_VAR_region)
-
-terraform-destroy:
-	@echo "⚠️  WARNING: This will destroy all terraform-managed resources!"
-	@echo "Press Ctrl+C to cancel, or Enter to continue..."
-	@read confirm
-	@echo "Destroying infrastructure first..."
-	cd deployment/terraform/infra && terraform destroy -auto-approve
-	@echo "Destroying project configuration..."
-	cd deployment/terraform/project && terraform destroy -auto-approve
-	@echo "✅ All terraform resources destroyed"
 
 # Update dependencies
 update:
@@ -379,13 +197,6 @@ endif
 
 ps:
 	docker-compose -f deployment/docker-compose.yml ps
-
-# Production helpers
-prod-build:
-	docker-compose -f deployment/docker-compose.prod.yml build
-
-prod-push:
-	docker-compose -f deployment/docker-compose.prod.yml push
 
 # Quick command for the simulation executor
 dev-sim:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifneq (,$(wildcard deployment/.env))
 endif
 
 help:
-	@echo "PolicyEngine API v2 - Available commands:"
+	@echo "PolicyEngine Sim API - Available commands:"
 	@echo ""
 	@echo "Setup (first time):"
 	@echo "  make setup            - Create .env file from template"
@@ -237,7 +237,7 @@ terraform-plan: terraform-ensure-init
 	@# Auto-populate all required variables
 	@US_VERSION=$$(grep -A1 'name = "policyengine-us"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
 	UK_VERSION=$$(grep -A1 'name = "policyengine-uk"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
-	COMMIT_URL="https://github.com/PolicyEngine/policyengine-api-v2/commit/$$(git rev-parse HEAD)" && \
+	COMMIT_URL="https://github.com/PolicyEngine/policyengine-sim-api/commit/$$(git rev-parse HEAD)" && \
 	echo "project_id = \"$${TF_VAR_project_id}\"" > deployment/terraform/infra/auto.tfvars && \
 	echo "commit_url = \"$$COMMIT_URL\"" >> deployment/terraform/infra/auto.tfvars && \
 	echo "policyengine-us-package-version = \"$$US_VERSION\"" >> deployment/terraform/infra/auto.tfvars && \
@@ -265,7 +265,7 @@ terraform-deploy-infra: terraform-ensure-init
 	@# Auto-populate all required variables
 	@US_VERSION=$$(grep -A1 'name = "policyengine-us"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
 	UK_VERSION=$$(grep -A1 'name = "policyengine-uk"' projects/policyengine-simulation-executor/uv.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
-	COMMIT_URL="https://github.com/PolicyEngine/policyengine-api-v2/commit/$$(git rev-parse HEAD)" && \
+	COMMIT_URL="https://github.com/PolicyEngine/policyengine-sim-api/commit/$$(git rev-parse HEAD)" && \
 	echo "project_id = \"$${TF_VAR_project_id}\"" > deployment/terraform/infra/auto.tfvars && \
 	echo "commit_url = \"$$COMMIT_URL\"" >> deployment/terraform/infra/auto.tfvars && \
 	echo "policyengine-us-package-version = \"$$US_VERSION\"" >> deployment/terraform/infra/auto.tfvars && \
@@ -350,11 +350,11 @@ push-pr-branch:
 	fi; \
 	REMOTE_URL=$$(git remote get-url origin 2>/dev/null || true); \
 	case "$$REMOTE_URL" in \
-		*PolicyEngine/policyengine-api-v2* | *PolicyEngine/policyengine-sim-api* ) ;; \
+		*PolicyEngine/policyengine-sim-api* ) ;; \
 		* ) echo "Missing canonical origin remote PolicyEngine/policyengine-sim-api"; exit 1 ;; \
 	esac; \
 	git push -u origin HEAD:$$BRANCH; \
-	echo "Create the PR with: gh pr create --draft --repo PolicyEngine/policyengine-api-v2 --head $$BRANCH --base main"
+	echo "Create the PR with: gh pr create --draft --repo PolicyEngine/policyengine-sim-api --head $$BRANCH --base main"
 
 # Integration tests
 integ-test:

--- a/Makefile
+++ b/Makefile
@@ -10,32 +10,32 @@ endif
 help:
 	@echo "PolicyEngine Sim API - Available commands:"
 	@echo ""
-	@echo "Setup (first time):"
-	@echo "  make setup            - Create .env file from template"
-	@echo "  make init-gcp         - Initialize GCP project (APIs, registry, bucket)"
+	@echo "Development (local simulation-executor via docker-compose, port 8082):"
+	@echo "  make up [service=x]   - Start services in the background"
+	@echo "  make dev              - Start services in the foreground (build + reload)"
+	@echo "  make down             - Stop services"
+	@echo "  make logs [service=x] - Tail service logs"
+	@echo "  make ps               - Show running services"
 	@echo ""
-	@echo "Development:"
-	@echo "  make dev              - Start all services in development mode"
-	@echo "  make up [service=x]   - Start specific service or all services"
-	@echo "  make down             - Stop all services"
-	@echo "  make logs [service=x] - Show logs for service"
-	@echo "  make test             - Run tests for all services"
+	@echo "Testing:"
+	@echo "  make test             - Unit tests for all projects and libs"
+	@echo "  make test-service service=x - Unit tests for one compose service"
+	@echo "  make test-integration - Integration tests (services must be up)"
+	@echo "  make test-complete    - Unit + integration (manages services)"
 	@echo ""
-	@echo "Deployment:"
-	@echo "  make deploy           - Full deployment (builds, pushes, deploys project + infra)"
-	@echo "  make terraform-init   - Initialize terraform modules"
-	@echo "  make terraform-force-init - Force reinitialize (if stuck)"
-	@echo "  make terraform-plan   - Preview changes for both modules"
-	@echo "  make terraform-deploy-project - Deploy project configuration only"
-	@echo "  make terraform-deploy-infra   - Deploy infrastructure only"
-	@echo "  make terraform-destroy        - Destroy all terraform resources"
+	@echo "Clients:"
+	@echo "  make generate-clients - Regenerate the OpenAPI Python client"
+	@echo "  make publish-clients  - Publish the client to PyPI (needs PYPI_TOKEN)"
 	@echo ""
 	@echo "Maintenance:"
-	@echo "  make build            - Build all Docker images"
-	@echo "  make clean            - Clean up containers and volumes"
-	@echo "  make format           - Format Python code with ruff"
-	@echo "  make check            - Run code quality checks"
-	@echo "  make push-pr-branch   - Push current branch to origin for PR creation"
+	@echo "  make build            - Build Docker images"
+	@echo "  make format           - Format code with ruff"
+	@echo "  make check            - ruff check + pyright"
+	@echo "  make update           - uv lock --upgrade across packages"
+	@echo "  make clean            - Remove caches and stop containers"
+	@echo "  make push-pr-branch   - Push current branch to origin for a PR"
+	@echo ""
+	@echo "Deployment is automated via GitHub Actions to Modal; there is no manual deploy target."
 
 # Initialize GCP (enables APIs, creates bucket, etc)
 init-gcp: check-deploy-env
@@ -103,21 +103,19 @@ publish-clients: generate-clients
 
 # Testing
 test:
-	@echo "Running tests for all services..."
-	@for service in api-full simulation-executor api-tagger; do \
-		echo "Testing $$service..."; \
-		docker-compose -f deployment/docker-compose.yml run --rm $$service sh -c "cd /app/projects/policyengine-$$service && uv run --extra test pytest" || exit 1; \
+	@echo "Running unit tests for all projects and libs..."
+	@for proj in projects/policyengine-simulation-executor \
+		projects/policyengine-simulation-gateway \
+		libs/policyengine-simulation-contract \
+		libs/policyengine-simulation-observability; do \
+		echo "Testing $$proj..."; \
+		(cd "$$proj" && uv sync --extra test && uv run pytest tests/ -v) || exit 1; \
 	done
-	@echo "Testing simulation-gateway (no compose service)..."
-	@cd projects/policyengine-simulation-gateway && uv sync --extra test && uv run pytest
-	@for lib in policyengine-simulation-contract policyengine-simulation-observability; do \
-		echo "Testing $$lib..."; \
-		(cd libs/$$lib && uv sync --extra test && uv run pytest) || exit 1; \
-	done
+	@echo "✅ All unit tests passed"
 
 test-service:
 ifndef service
-	@echo "Please specify service: make test-service service=api-full"
+	@echo "Please specify service: make test-service service=simulation-executor"
 else
 	docker-compose -f deployment/docker-compose.yml run --rm $(service) sh -c "cd /app/projects/policyengine-$(service) && uv run --extra test pytest"
 endif
@@ -374,7 +372,7 @@ clean:
 # Local development helpers
 shell:
 ifndef service
-	@echo "Please specify service: make shell service=api-full"
+	@echo "Please specify service: make shell service=simulation-executor"
 else
 	docker-compose -f deployment/docker-compose.yml exec $(service) /bin/bash
 endif
@@ -389,12 +387,6 @@ prod-build:
 prod-push:
 	docker-compose -f deployment/docker-compose.prod.yml push
 
-# Quick commands for specific services
-dev-full:
-	docker-compose -f deployment/docker-compose.yml up api-full
-
+# Quick command for the simulation executor
 dev-sim:
 	docker-compose -f deployment/docker-compose.yml up simulation-executor
-
-dev-tagger:
-	docker-compose -f deployment/docker-compose.yml up api-tagger

--- a/README.md
+++ b/README.md
@@ -1,171 +1,112 @@
-# PolicyEngine Sim API
+# policyengine-sim-api
 
-Monorepo for PolicyEngine's API infrastructure, containing all services, libraries, and deployment configuration. 
-
-## Quick start
-
-### Prerequisites
-
-- Docker and Docker Compose
-- Python 3.13+
-- [uv](https://docs.astral.sh/uv/) package manager
-- gcloud CLI (for deployment)
-- Terraform 1.5+ (for deployment)
-
-### Local development
-
-Start all services:
-```bash
-make up        # Start services on ports 8081-8083
-make logs      # View logs
-make down      # Stop services
-```
-
-Run the test suite:
-```bash
-make test                          # Unit tests only
-make test-integration-with-services # Full integration tests (manages services automatically)
-make test-complete                 # Everything: unit + integration tests
-```
+Monorepo for PolicyEngine's simulation API — the services, shared libraries, and
+deployment configuration behind PolicyEngine's economic simulation service. The
+public API is served by a stable Modal gateway that routes requests to versioned
+simulation executor apps.
 
 ## Architecture
 
-The repository contains three main API services:
+Active services (`projects/`):
 
-- **api-full** (port 8081): Main PolicyEngine API with household calculations
-- **simulation-executor** (port 8082): Economic simulation engine  
-- **api-tagger** (port 8083): Cloud Run revision management
+- **policyengine-simulation-gateway** — the stable, public Modal gateway. Serves
+  the API contract and routes each request to a versioned executor app
+  (`policyengine-simulation-py{X}`) using routing state in a `modal.Dict`.
+- **policyengine-simulation-executor** — the simulation engine. Runs on Modal as
+  versioned apps, and also builds a Docker image used for local development and
+  integration tests (port 8082).
+- **policyengine-apis-integ** — integration tests that exercise the generated API
+  client against a running executor.
 
-Each service generates OpenAPI specs and Python client libraries for integration testing.
+Shared libraries (`libs/`):
 
-## Development workflow
+- **policyengine-fastapi** — shared FastAPI utilities and observability contracts.
+- **policyengine-simulation-contract** — the gateway↔executor request/response contract.
+- **policyengine-simulation-observability** — observability helpers for the services.
 
-### Making changes
+`projects/policyengine-api-full` and `projects/policyengine-api-tagger` are
+reserved placeholder stubs (no implementation yet).
 
-1. Edit code locally - services hot-reload automatically when running via `make up`
-2. Run tests: `make test-complete`
-3. Commit changes to a feature branch
-4. Open a PR - GitHub Actions will run tests automatically
+The generated Python client is published to PyPI as
+`policyengine_api_simulation_client` for external consumers.
 
-### Testing
+## Prerequisites
 
-Unit tests run in isolated containers:
+- Python 3.13+
+- [uv](https://docs.astral.sh/uv/)
+- Docker and Docker Compose (for the executor container and integration tests)
+
+## Local development
+
+The simulation executor runs locally via Docker Compose on port 8082:
+
 ```bash
-make test                    # All services
-make test-service service=api-full  # Single service
+make up        # start the simulation-executor (http://localhost:8082) in the background
+make logs      # tail logs
+make down      # stop
 ```
 
-Integration tests use generated client libraries:
+`make dev` runs it in the foreground with a live-reload build. The gateway is not
+run locally — it is a Modal-only service.
+
+## Testing
+
 ```bash
-make generate-clients        # Generate OpenAPI clients (done automatically by test commands)
-make test-integration        # Run integration tests (requires services running)
+make test                           # unit tests for all projects and libs (uv)
+make test-integration-with-services # start services + run integration tests
+make test-complete                  # unit + integration (manages services)
 ```
 
-### Project structure
+Each project's unit tests run in its own locked uv environment — the same lock
+the Modal image installs with `uv_sync(frozen=True)`. Integration tests generate
+the API client, start the executor via Docker Compose, wait for
+`http://localhost:8082/ping/alive`, then run `projects/policyengine-apis-integ`
+against it.
 
-```
-/
-├── projects/               # Service applications
-│   ├── policyengine-api-full/
-│   ├── policyengine-simulation-executor/
-│   ├── policyengine-api-tagger/
-│   └── policyengine-apis-integ/    # Integration tests
-├── libs/                   # Shared libraries
-│   └── policyengine-fastapi/       # Common FastAPI utilities
-├── deployment/             # Deployment configuration
-│   ├── docker-compose.yml          # Local development
-│   ├── docker-compose.prod.yml     # Production builds
-│   └── terraform/                  # Infrastructure as code
-├── scripts/                # Utility scripts
-└── .github/workflows/      # CI/CD pipelines
+Other useful targets:
+
+```bash
+make format           # format with ruff
+make check            # ruff check + pyright
+make generate-clients # regenerate the OpenAPI Python client
 ```
 
 ## Deployment
 
-### Setting up a new GCP project
+Deployment targets Modal and is automated through GitHub Actions — there is no
+manual deploy step. On merge to `main`, the Modal deploy workflow
+(`.github/workflows/modal-deploy.yml`):
 
-**Important**: Most development should be done locally. Cloud deployment is slow and harder to debug.
+1. Deploys to the beta (staging) Modal environment and runs integration tests.
+2. Deploys to the production Modal environment and runs integration tests.
+3. Publishes the API client to PyPI (`.github/workflows/publish-clients.yml`).
 
-1. Configure environment:
-```bash
-cp deployment/.env.example deployment/.env
-# Edit deployment/.env with your GCP project details
+The stable gateway app is `policyengine-simulation-gateway`; executors deploy as
+versioned `policyengine-simulation-py{version}` apps. For Modal image and deploy
+specifics (image dependency pinning, dataset prebuild, observability), see the
+service READMEs:
+
+- `projects/policyengine-simulation-gateway/README.md`
+- `projects/policyengine-simulation-executor/README.md`
+
+## Project structure
+
 ```
-
-2. Deploy infrastructure:
-```bash
-make deploy  # Builds images, pushes to registry, runs terraform
+projects/
+  policyengine-simulation-gateway/    # stable Modal gateway (public API)
+  policyengine-simulation-executor/   # simulation engine (versioned Modal apps)
+  policyengine-apis-integ/            # integration tests
+  policyengine-api-full/              # reserved stub
+  policyengine-api-tagger/            # reserved stub
+libs/
+  policyengine-fastapi/
+  policyengine-simulation-contract/
+  policyengine-simulation-observability/
+deployment/
+  docker-compose.yml                  # local simulation-executor
+scripts/                              # client generation + local integration helpers
+.github/workflows/                    # CI, Modal deploy, client publishing
 ```
-
-For existing GCP projects with resources:
-```bash
-make terraform-import  # Import existing resources
-./deployment/terraform/handle-existing-workflows.sh $PROJECT_ID --delete  # Handle workflows
-```
-
-See [deployment guide](deployment/DEPLOYMENT_GUIDE.md) for detailed instructions.
-
-### GitHub Actions deployment
-
-The repository includes automated deployment pipelines:
-
-1. **Pull requests**: Runs tests and builds
-2. **Merge to main**: 
-   - Deploys to beta environment
-   - Runs integration tests
-   - Deploys to production
-   - Publishes API client packages to PyPI
-
-Configure GitHub environments with these variables:
-- `PROJECT_ID`: GCP project ID
-- `REGION`: GCP region (usually us-central1)
-- `_GITHUB_IDENTITY_POOL_PROVIDER_NAME`: Workload identity provider
-
-### Important notes from experience
-
-- **Wait after bootstrap**: GCP permission propagation can take up to an hour
-- **Workflows can't be imported**: Use the provided script to handle existing workflows
-- **Always test locally first**: Cloud debugging is painful
-- **Check terraform state**: If deployments fail, check if resources already exist
-
-## Commands reference
-
-### Development
-- `make up` - Start services locally
-- `make down` - Stop services
-- `make logs` - View service logs
-- `make build` - Build Docker images
-
-### Testing
-- `make test` - Run unit tests
-- `make test-integration` - Run integration tests
-- `make test-complete` - Run all tests with service management
-- `make generate-clients` - Generate API client libraries
-
-### Deployment
-- `make deploy` - Full deployment to GCP
-- `make terraform-plan` - Preview infrastructure changes
-- `make terraform-import` - Import existing resources
-- `make terraform-destroy` - Remove all infrastructure
-- `make publish-clients` - Publish API clients to PyPI (requires PYPI_TOKEN)
-
-## Troubleshooting
-
-### Services won't start
-- Check Docker is running
-- Ensure ports 8081-8083 are free
-- Run `make build` to rebuild images
-
-### Integration tests fail
-- Regenerate clients: `make generate-clients`
-- Check services are healthy: `make logs`
-- Verify port configuration matches docker-compose.yml
-
-### Deployment issues
-- Check deployment/.env configuration
-- Verify GCP authentication: `gcloud auth list`
-- For "already exists" errors: `make terraform-import`
-- For workflow errors: `./deployment/terraform/handle-existing-workflows.sh`
 
 ## Contributing
 
@@ -173,11 +114,10 @@ See [AGENTS.md](AGENTS.md) and
 [docs/engineering/skills/github-prs.md](docs/engineering/skills/github-prs.md)
 for the canonical same-repository draft PR workflow.
 
-1. Create a feature branch
-2. Open a GitHub issue for non-trivial work
-3. Make changes and test locally
-4. Ensure `make test-complete` passes when feasible
-5. Open a same-repository draft PR with `Fixes #ISSUE_NUMBER` as the first line
-   of the description
-6. Include a clear summary and testing notes
-7. Wait for CI checks to pass
+1. Create a feature branch (never commit to `main`).
+2. Open a GitHub issue for non-trivial work; put `Fixes #ISSUE_NUMBER` as the
+   first line of the PR description.
+3. Make changes and run the relevant tests locally.
+4. Open a same-repository draft PR: `make push-pr-branch`, then
+   `gh pr create --draft`.
+5. Wait for CI checks to pass.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PolicyEngine API v2
+# PolicyEngine Sim API
 
 Monorepo for PolicyEngine's API infrastructure, containing all services, libraries, and deployment configuration. 
 

--- a/docs/engineering/skills/github-prs.md
+++ b/docs/engineering/skills/github-prs.md
@@ -5,13 +5,13 @@ repository.
 
 ## Same-Repository Draft PRs Only
 
-Open PRs from branches in `PolicyEngine/policyengine-api-v2`, not from personal
+Open PRs from branches in `PolicyEngine/policyengine-sim-api`, not from personal
 forks. CI and deployment checks are designed around same-repository branches.
 
 Before creating or sharing a PR:
 
 1. Confirm the canonical repository is reachable:
-   `gh repo view PolicyEngine/policyengine-api-v2 --json nameWithOwner`.
+   `gh repo view PolicyEngine/policyengine-sim-api --json nameWithOwner`.
 2. Open a GitHub issue for the work, or verify that an appropriate issue
    already exists.
 3. Put `Fixes #ISSUE_NUMBER` as the first line of the PR description, using the
@@ -21,14 +21,14 @@ Before creating or sharing a PR:
 5. Push the current branch to the canonical repository:
    `make push-pr-branch`.
 6. Create the PR as a draft from that same repository:
-   `gh pr create --draft --repo PolicyEngine/policyengine-api-v2 --head "$(git branch --show-current)" --base main`.
+   `gh pr create --draft --repo PolicyEngine/policyengine-sim-api --head "$(git branch --show-current)" --base main`.
 7. Verify the PR is draft and the head repository is canonical:
-   `gh pr view <PR> --repo PolicyEngine/policyengine-api-v2 --json isDraft,headRepositoryOwner,headRepository`.
+   `gh pr view <PR> --repo PolicyEngine/policyengine-sim-api --json isDraft,headRepositoryOwner,headRepository`.
 8. Leave the PR as draft unless a maintainer explicitly asks for it to be
    marked ready for review.
 
 The PR is valid only if `isDraft` is `true` and the head repository is
-`PolicyEngine/policyengine-api-v2`. If you cannot push to the canonical
+`PolicyEngine/policyengine-sim-api`. If you cannot push to the canonical
 repository, stop and ask for access. Do not create a fork PR as a fallback. If
 you accidentally create one, close it immediately and replace it with a
 same-repository draft PR.

--- a/libs/policyengine-fastapi/src/policyengine_fastapi/observability/__init__.py
+++ b/libs/policyengine-fastapi/src/policyengine_fastapi/observability/__init__.py
@@ -1,5 +1,5 @@
 """
-Shared observability contracts and utilities for API v2 services.
+Shared observability contracts and utilities for the PolicyEngine simulation API services.
 
 This stays in `policyengine-fastapi` for now because only one active service
 needs it and the main value today is shared contract stability, not a separate

--- a/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
@@ -1,4 +1,4 @@
-"""Tests for building PolicyEngine v4 outputs into API-v2 macro results."""
+"""Tests for building PolicyEngine v4 outputs into simulation API macro results."""
 
 from __future__ import annotations
 

--- a/scripts/test-integration-local.sh
+++ b/scripts/test-integration-local.sh
@@ -31,10 +31,8 @@ check_service() {
     return 1
 }
 
-# Check each service
-check_service "api-full" 8081
+# Check the local service
 check_service "simulation-executor" 8082
-check_service "api-tagger" 8083
 
 echo ""
 echo "Running integration tests (excluding GCP workflow tests)..."


### PR DESCRIPTION
Fixes #624

Follow-up to #623, now that the GitHub repo has been renamed to `policyengine-sim-api` (old `policyengine-api-v2` path redirects).

Removes the pre-rename dual-name compatibility and updates the remaining references + branding:

- `check-policyengine-updates.yml` guard → new name only
- `Makefile`: `push-pr-branch` remote check + `gh pr create` hint, terraform commit URLs, help text
- `README.md` title
- `AGENTS.md`, `.github/CONTRIBUTING.md`, `.github/copilot-instructions.md`, `.github/pull_request_template.md`, `docs/engineering/skills/github-prs.md`

The published client `policyengine_api_simulation_client` and all Modal app names are intentionally left unchanged.

## Testing
- `git grep policyengine-api-v2` and `git grep "PolicyEngine API v2"` both return nothing.
- `policyengine_api_simulation_client` still present/unchanged.
- Workflow YAML validated; guard evaluates to the single new name.
- `make -n push-pr-branch` parses; remote check now matches `PolicyEngine/policyengine-sim-api`.
- Confirmed post-rename the `Update policyengine package` workflow ran and opened `auto/update-policyengine-4.20.0` under the new repo name (dual guard from #623 worked across the boundary).