### PR TITLE
Revert policyengine 4.21.1 bump (Build M default US runs ~26 min)

### DIFF
--- a/projects/policyengine-simulation-executor/pyproject.toml
+++ b/projects/policyengine-simulation-executor/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "policyengine-fastapi",
     "policyengine-simulation-observability",
     "policyengine-simulation-contract",
-    "policyengine==4.21.1",
+    "policyengine==4.20.3",
     "policyengine-core==3.28.0",
     "policyengine-uk==2.89.2",
     "policyengine-us==1.764.6",

--- a/projects/policyengine-simulation-executor/uv.lock
+++ b/projects/policyengine-simulation-executor/uv.lock
@@ -1718,7 +1718,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.21.1"
+version = "4.20.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -1732,9 +1732,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/94/1e00a7674cdd4a293635d757327f3ed6a07def330ed2cb744b3e4ff41fb6/policyengine-4.21.1.tar.gz", hash = "sha256:0f075703558bc4b7e44690f7d138704333e6a95cd6177ea331beafc4a9a55647", size = 730103, upload-time = "2026-07-17T15:21:15.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/fd/5271ee51d1f1a2c2c84841bd3fae37118258febdb59c156b5c268adf96de/policyengine-4.20.3.tar.gz", hash = "sha256:1d4741fd631ca160cf29da4ae31480842d973b130e341adadb798c115a92cd00", size = 724947, upload-time = "2026-07-09T20:16:52.094Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/22/31cd14b578029cd6519ade991e0eaa598d6c6caa4a662d275348917a4514/policyengine-4.21.1-py3-none-any.whl", hash = "sha256:a944eca4585764fa9e2b8bb67c6238ac64c4895d935fe33788f158f3f5bb0709", size = 222674, upload-time = "2026-07-17T15:21:13.954Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ce/1a2f5d6fe059d5521368585fc0b1ccb1428735a85065716bc3219509879f/policyengine-4.20.3-py3-none-any.whl", hash = "sha256:dc46f803c42550e9c9b99aed7e64c728c30b90ca4826ee18160a4f4feccbffd9", size = 221895, upload-time = "2026-07-09T20:16:50.52Z" },
 ]
 
 [[package]]
@@ -1903,7 +1903,7 @@ requires-dist = [
     { name = "openapi-python-client", marker = "extra == 'build'", specifier = ">=0.21.6" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.51b0,<0.52" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.51b0,<0.52" },
-    { name = "policyengine", specifier = "==4.21.1" },
+    { name = "policyengine", specifier = "==4.20.3" },
     { name = "policyengine-core", specifier = "==3.28.0" },
     { name = "policyengine-fastapi", editable = "../../libs/policyengine-fastapi" },
     { name = "policyengine-observability", extras = ["fastapi"], specifier = ">=1.3.0,<2" },


### PR DESCRIPTION
Fixes #630

Reverts #629 (merge commit 26ac790), returning the simulation executor to `policyengine==4.20.3` (certified US dataset Build I). No other pins move: `policyengine-core==3.28.0`, `policyengine-us==1.764.6`, and `policyengine-uk==2.89.2` were already unchanged by #629, so this revert touches exactly the `policyengine` wheel and its lock entries.

## Why

The #629 deploy failed promotion: `test_calculate_default_model` timed out at 25 minutes. Modal telemetry for the exact job (`fc-01KXZW39ZSVSD188K44XFDE1S5`) shows it completed successfully in 26m07s on a warm worker with prebaked datasets — `economic_impact_analysis` alone took 1,563s vs 913s for the identical request on the 4.20.3/Build I worker (+71%). Full evidence and the re-application conditions are in #630.

Prod is still on 4.20.3; this revert makes main deployable again while the Build M runtime regression is investigated upstream.

## Checks

Dependency-pin revert only; no source changes. PR CI (unit tests, Ruff, Docker build, local integration) plus the PR image smoke exercise the reverted pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)