### PR TITLE
Run national macro simulations segmented across region groups by default

### DIFF
--- a/libs/policyengine-simulation-contract/src/policyengine_simulation_contract/gateway_models.py
+++ b/libs/policyengine-simulation-contract/src/policyengine_simulation_contract/gateway_models.py
@@ -98,6 +98,10 @@ class GatewayRequestBase(BaseModel):
     include_cliffs: Optional[bool] = None
     model_version: Optional[str] = None
     data_version: Optional[str] = None
+    # National macro requests run segmented across region groups by default;
+    # False forces a monolithic single-process run. Ignored for requests that
+    # are not eligible for segmentation (regional, household-scope, UK).
+    segmented: Optional[bool] = None
 
     model_config = ConfigDict(
         extra="forbid",

--- a/libs/policyengine-simulation-contract/tests/test_gateway_models.py
+++ b/libs/policyengine-simulation-contract/tests/test_gateway_models.py
@@ -225,6 +225,22 @@ class TestSimulationRequest:
                 country="us", region="state/hi", region_group=["state/ia"]
             )
 
+    def test_simulation_request_segmented_defaults_to_none(self):
+        """Absent segmented means the default (segmented where eligible)."""
+        request = SimulationRequest(country="us", scope="macro")
+        assert request.segmented is None
+
+    def test_simulation_request_accepts_segmented_opt_out(self):
+        """segmented=False (force monolithic) round-trips."""
+        request = SimulationRequest(country="us", scope="macro", segmented=False)
+        assert request.segmented is False
+        assert request.model_dump(exclude_none=True)["segmented"] is False
+
+    def test_simulation_request_accepts_segmented_true(self):
+        """An explicit segmented=True is accepted (same as the default)."""
+        request = SimulationRequest(country="us", scope="macro", segmented=True)
+        assert request.segmented is True
+
     def test_simulation_request_rejects_unknown_fields(self):
         """Unknown fields should fail fast with ``extra="forbid"``."""
         with pytest.raises(ValidationError):

--- a/libs/policyengine-simulation-observability/src/policyengine_simulation_observability/observability.py
+++ b/libs/policyengine-simulation-observability/src/policyengine_simulation_observability/observability.py
@@ -87,6 +87,9 @@ class SegmentName(StrEnum):
     # backoff_sleep_ms_total) instead, because one segment per probe grows
     # the operation's segment tree without bound over a long batch.
 
+    SEGMENTED_NATIONAL_CHILD_SPAWN = "segmented_national_child_spawn"
+    SEGMENTED_NATIONAL_REDUCE = "segmented_national_reduce"
+
     MODAL_JOB_METADATA_READ = "modal_job_metadata_read"
 
     SIMULATION_OUTPUT_BUILD = "simulation_output_build"

--- a/projects/policyengine-simulation-executor/src/modal/app.py
+++ b/projects/policyengine-simulation-executor/src/modal/app.py
@@ -280,8 +280,55 @@ def run_simulation(params: dict) -> dict:
 
                 # Plain national macro requests fan out across region groups
                 # by default (segmented: false opts out). APP_NAME is this
-                # deployed app, so children spawn into the same worker pool.
+                # deployed app; children spawn into its dedicated
+                # run_simulation_segment pool.
                 return dispatch_run_simulation(params, app_name=APP_NAME)
+    finally:
+        flush_logfire(logfire_enabled)
+
+
+@app.function(
+    image=simulation_image,
+    cpu=8.0,
+    memory=32768,
+    timeout=3600,
+    retries=0,
+    max_containers=300,
+    secrets=[gcp_secret, data_secret, hf_secret, logfire_secret],
+)
+def run_simulation_segment(params: dict) -> dict:
+    """One region-group child of a segmented national run.
+
+    The same worker as ``run_simulation`` but a separate Modal function so
+    segment children draw from their own container pool: a blocking
+    segmented parent must never share a bounded pool with the children it
+    waits on. Calls the monolithic impl directly — children are
+    ``region_group`` requests and never re-segment.
+    """
+    static_attributes = _configure_modal_observability(
+        service_role="simulation_worker",
+        modal_function_name="run_simulation_segment",
+    )
+    redacted_params = {
+        **redact_params_for_logging(params),
+        **static_attributes,
+        **legacy_logfire_attributes(),
+    }
+    logfire_enabled = False
+    try:
+        with operation(
+            "run_simulation_segment", flavor="modal_function", **redacted_params
+        ):
+            logfire_enabled = configure_logfire("policyengine-simulation")
+            _set_modal_call_attributes()
+            with logfire_span(
+                logfire_enabled, "run_simulation_segment", **redacted_params
+            ):
+                from policyengine_simulation_executor.simulation_runtime import (
+                    run_simulation_impl,
+                )
+
+                return run_simulation_impl(params)
     finally:
         flush_logfire(logfire_enabled)
 

--- a/projects/policyengine-simulation-executor/src/modal/app.py
+++ b/projects/policyengine-simulation-executor/src/modal/app.py
@@ -274,11 +274,14 @@ def run_simulation(params: dict) -> dict:
             logfire_enabled = configure_logfire("policyengine-simulation")
             _set_modal_call_attributes()
             with logfire_span(logfire_enabled, "run_simulation", **redacted_params):
-                from policyengine_simulation_executor.simulation_runtime import (
-                    run_simulation_impl,
+                from src.modal.segmented_national import (
+                    dispatch_run_simulation,
                 )
 
-                return run_simulation_impl(params)
+                # Plain national macro requests fan out across region groups
+                # by default (segmented: false opts out). APP_NAME is this
+                # deployed app, so children spawn into the same worker pool.
+                return dispatch_run_simulation(params, app_name=APP_NAME)
     finally:
         flush_logfire(logfire_enabled)
 

--- a/projects/policyengine-simulation-executor/src/modal/budget_window_context.py
+++ b/projects/policyengine-simulation-executor/src/modal/budget_window_context.py
@@ -92,6 +92,10 @@ def build_child_simulation_request(
         if key not in BATCH_ONLY_FIELDS
     }
     payload["time_period"] = simulation_year
+    # Budget-window children stay monolithic for now: a national child would
+    # otherwise fan out again (years x 21 containers). Enabling nested
+    # segmentation is a deliberate follow-up, not a side effect.
+    payload["segmented"] = False
 
     telemetry = context.raw_params.get("_telemetry")
     if isinstance(telemetry, dict):

--- a/projects/policyengine-simulation-executor/src/modal/budget_window_context.py
+++ b/projects/policyengine-simulation-executor/src/modal/budget_window_context.py
@@ -9,6 +9,7 @@ from policyengine_simulation_contract.gateway_models import (
     BudgetWindowBatchRequest,
     PolicyEngineBundle,
 )
+from src.modal.fanout import build_child_payload
 
 BATCH_ONLY_FIELDS = {
     "version",
@@ -86,20 +87,17 @@ def build_child_simulation_request(
     *,
     simulation_year: str,
 ) -> ChildSimulationRequest:
-    payload = {
-        key: value
-        for key, value in context.raw_params.items()
-        if key not in BATCH_ONLY_FIELDS
-    }
-    payload["time_period"] = simulation_year
-    # Budget-window children stay monolithic for now: a national child would
-    # otherwise fan out again (years x 21 containers). Enabling nested
-    # segmentation is a deliberate follow-up, not a side effect.
-    payload["segmented"] = False
-
-    telemetry = context.raw_params.get("_telemetry")
-    if isinstance(telemetry, dict):
-        payload["_telemetry"] = telemetry
+    payload = build_child_payload(
+        context.raw_params,
+        strip_fields=BATCH_ONLY_FIELDS,
+        overrides={
+            "time_period": simulation_year,
+            # Budget-window children stay monolithic for now: a national
+            # child would otherwise fan out again (years x 21 containers).
+            # Enabling nested segmentation is a deliberate follow-up.
+            "segmented": False,
+        },
+    )
 
     return ChildSimulationRequest(
         simulation_year=simulation_year,

--- a/projects/policyengine-simulation-executor/src/modal/fanout.py
+++ b/projects/policyengine-simulation-executor/src/modal/fanout.py
@@ -1,0 +1,34 @@
+"""Shared helpers for parent jobs that fan out child simulation requests.
+
+Both fan-out orchestrators (budget-window batches and segmented national
+runs) build child payloads the same way: copy the parent's raw params minus
+parent-scoped fields, overwrite the fan-out axis, and re-attach
+``_telemetry`` so child spans join the parent's trace. Keeping the rule in
+one place stops the builders drifting (e.g. an internal key stripped in one
+orchestrator but forwarded by the other).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def build_child_payload(
+    raw_params: dict[str, Any],
+    *,
+    strip_fields: Iterable[str],
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    strip = set(strip_fields) | {"_telemetry"}
+    payload = {key: value for key, value in raw_params.items() if key not in strip}
+    payload.update(overrides)
+    telemetry = raw_params.get("_telemetry")
+    if isinstance(telemetry, dict):
+        payload["_telemetry"] = telemetry
+    return payload
+
+
+def next_backoff(current: float, *, factor: float, maximum: float) -> float:
+    """The next sleep in an exponential backoff walk."""
+    return min(current * factor, maximum)

--- a/projects/policyengine-simulation-executor/src/modal/segmented_national.py
+++ b/projects/policyengine-simulation-executor/src/modal/segmented_national.py
@@ -213,3 +213,19 @@ def run_segmented_national_impl(
         params, app_name=app_name, modal_module=modal_module
     )
     return runner.run()
+
+
+def dispatch_run_simulation(
+    params: dict[str, Any], *, app_name: str
+) -> dict[str, Any]:
+    """The run_simulation entrypoint's routing: segmented national fan-out
+    for eligible requests, the monolithic path for everything else."""
+    if should_run_segmented_national(params):
+        return run_segmented_national_impl(params, app_name=app_name)
+
+    from policyengine_simulation_executor.simulation_runtime import (
+        run_simulation_impl,
+    )
+
+    set_attribute("national_execution", "monolithic")
+    return run_simulation_impl(params)

--- a/projects/policyengine-simulation-executor/src/modal/segmented_national.py
+++ b/projects/policyengine-simulation-executor/src/modal/segmented_national.py
@@ -177,9 +177,9 @@ class SegmentedNationalRunner:
         (Households whose state has NO registered region remain invisible
         here; the partition test pins the registry at pin-bump time.)
         """
-        model = country_module.model
-        model.get_region(self.groups[0][0])  # force lazy registry load
-        registry = getattr(model, "region_registry", None)
+        # region_registry is populated eagerly in the model version's
+        # __init__; None only occurs for stub models (unit tests).
+        registry = getattr(country_module.model, "region_registry", None)
         if registry is None:
             return
         state_codes = {
@@ -230,6 +230,9 @@ class SegmentedNationalRunner:
                 try:
                     results[index] = call.get(timeout=0)
                 except TimeoutError:
+                    # A not-ready probe is a SUCCESSFUL RPC: reset the error
+                    # tally so only consecutive failures fail the job.
+                    poll_errors.pop(index, None)
                     continue
                 except Exception as exc:
                     # One transient poll-RPC blip must not kill the job; a

--- a/projects/policyengine-simulation-executor/src/modal/segmented_national.py
+++ b/projects/policyengine-simulation-executor/src/modal/segmented_national.py
@@ -1,0 +1,215 @@
+"""Fan out a plain national macro request across region groups.
+
+A US national macro request runs segmented BY DEFAULT: one ``region_group``
+child per partition group (spawned back into this app's own ``run_simulation``
+worker), then the children's computed microdata reduces into the national
+output via the existing builder (``segmented_national_reduce``). The request
+and response shapes are identical to the monolithic path — the gateway and
+its clients see nothing but a faster job. ``segmented: false`` opts out.
+
+Mirrors ``BudgetWindowBatchRunner``'s spawn/poll mechanics, minus the state
+store: the plain job-poll path needs no partial status, so a parent failure
+simply propagates to the gateway as a failed job, exactly like a monolithic
+failure today.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import modal
+from policyengine_observability import segment, set_attribute
+
+from policyengine_simulation_executor.national_partition import (
+    national_region_groups,
+)
+from policyengine_simulation_executor.segmented_national_reduce import (
+    build_national_output,
+)
+from policyengine_simulation_observability.errors import log_and_redact_exception
+from policyengine_simulation_observability.observability import SegmentName
+
+POLL_INTERVAL_INITIAL_SECONDS = 0.5
+POLL_INTERVAL_MAX_SECONDS = 15.0
+POLL_INTERVAL_BACKOFF_FACTOR = 2.0
+
+# Never forwarded to children: the opt-out knob (children are region_group
+# requests and thus ineligible regardless) and parent-scoped metadata.
+SEGMENTED_STRIP_FIELDS = frozenset({"segmented", "_metadata", "_telemetry"})
+
+
+def should_run_segmented_national(params: dict[str, Any]) -> bool:
+    """True when a request should fan out across the national partition.
+
+    Eligible: US, macro scope, no region/region_group, not opted out via
+    ``segmented: false``. ``include_cliffs`` falls back to monolithic —
+    cliff-variable reconstruction through the reduce is not yet validated.
+    """
+    country = str(params.get("country") or "us").lower()
+    if country != "us":
+        return False
+    if str(params.get("scope") or "").lower() != "macro":
+        return False
+    if params.get("region") or params.get("region_group"):
+        return False
+    if params.get("segmented") is False:
+        return False
+    if params.get("include_cliffs"):
+        return False
+    return national_region_groups(country) is not None
+
+
+def build_group_child_payload(
+    params: dict[str, Any], group: list[str]
+) -> dict[str, Any]:
+    """One child's request: the parent's params scoped to a region group.
+
+    Mirrors ``build_child_simulation_request`` (budget-window): copy the
+    parent params minus the strip set, overwrite the fan-out axis, re-attach
+    telemetry so child spans join the parent's trace.
+    """
+    payload = {
+        key: value
+        for key, value in params.items()
+        if key not in SEGMENTED_STRIP_FIELDS
+    }
+    payload["region_group"] = list(group)
+    payload["_emit_microdata"] = True
+    telemetry = params.get("_telemetry")
+    if isinstance(telemetry, dict):
+        payload["_telemetry"] = telemetry
+    return payload
+
+
+class SegmentedNationalRunner:
+    """Runs one segmented national request to completion."""
+
+    def __init__(
+        self,
+        params: dict[str, Any],
+        *,
+        app_name: str,
+        modal_module=None,
+        poll_interval_seconds: float = POLL_INTERVAL_INITIAL_SECONDS,
+        poll_interval_max_seconds: float = POLL_INTERVAL_MAX_SECONDS,
+        poll_interval_backoff_factor: float = POLL_INTERVAL_BACKOFF_FACTOR,
+    ):
+        self.params = params
+        self.app_name = app_name
+        self.modal = modal if modal_module is None else modal_module
+        self.poll_interval_initial_seconds = poll_interval_seconds
+        self.poll_interval_max_seconds = poll_interval_max_seconds
+        self.poll_interval_backoff_factor = poll_interval_backoff_factor
+        self.country = str(params.get("country") or "us").lower()
+        groups = national_region_groups(self.country)
+        if not groups:
+            raise ValueError(
+                f"No national partition for country {self.country!r}"
+            )
+        self.groups = groups
+        # Lazy handle, no RPC until first spawn (budget-window precedent).
+        self.child_func = self.modal.Function.from_name(
+            app_name, "run_simulation"
+        )
+        set_attribute("national_execution", "segmented")
+        set_attribute("segmented_group_count", len(self.groups))
+        self._poll_count = 0
+
+    def run(self) -> dict[str, Any]:
+        handles = self._spawn_all_children()
+        child_results = self._collect(handles)
+        return self._reduce(child_results)
+
+    def _spawn_all_children(self) -> list[tuple[list[str], Any]]:
+        handles = []
+        for group in self.groups:
+            payload = build_group_child_payload(self.params, group)
+            with segment(
+                SegmentName.SEGMENTED_NATIONAL_CHILD_SPAWN,
+                region_group="+".join(group),
+            ):
+                call = self.child_func.spawn(payload)
+            handles.append((group, call))
+        return handles
+
+    def _collect(self, handles: list[tuple[list[str], Any]]) -> list[dict]:
+        results: list[dict | None] = [None] * len(handles)
+        pending = set(range(len(handles)))
+        current_sleep = self.poll_interval_initial_seconds
+
+        while pending:
+            progress_made = False
+            for index in sorted(pending):
+                group, call = handles[index]
+                self._poll_count += 1
+                try:
+                    results[index] = call.get(timeout=0)
+                except TimeoutError:
+                    continue
+                except Exception as exc:
+                    redacted = log_and_redact_exception(
+                        exc,
+                        scope="segmented_national_child",
+                        context={"region_group": "+".join(group)},
+                    )
+                    self._cancel_all(handles)
+                    raise RuntimeError(
+                        "Segmented national child failed for group "
+                        f"{'+'.join(group)}: {redacted}"
+                    ) from None
+                pending.discard(index)
+                progress_made = True
+            # Bounded aggregate instead of one segment per probe (see the
+            # SegmentName NOTE about long poll loops).
+            set_attribute("segmented_poll_count", self._poll_count)
+            if pending and not progress_made:
+                time.sleep(current_sleep)
+                current_sleep = min(
+                    current_sleep * self.poll_interval_backoff_factor,
+                    self.poll_interval_max_seconds,
+                )
+            elif progress_made:
+                current_sleep = self.poll_interval_initial_seconds
+        return results  # type: ignore[return-value]
+
+    def _cancel_all(self, handles: list[tuple[list[str], Any]]) -> None:
+        """Best-effort cancel so a failed batch doesn't strand 19 workers."""
+        for _, call in handles:
+            try:
+                call.cancel()
+            except Exception:
+                pass
+
+    def _reduce(self, child_results: list[dict]) -> dict[str, Any]:
+        from policyengine_simulation_executor.simulation_runtime import (
+            _country_module,
+            _parse_year,
+            _requested_data_version,
+        )
+
+        simulation_params = {
+            key: value
+            for key, value in self.params.items()
+            if key not in SEGMENTED_STRIP_FIELDS
+        }
+        with segment(SegmentName.SEGMENTED_NATIONAL_REDUCE):
+            return build_national_output(
+                child_results,
+                country=self.country,
+                simulation_params=simulation_params,
+                country_module=_country_module(self.country),
+                year=_parse_year(simulation_params),
+                resolved_data_version=_requested_data_version(
+                    simulation_params
+                ),
+            )
+
+
+def run_segmented_national_impl(
+    params: dict[str, Any], *, app_name: str, modal_module=None
+) -> dict[str, Any]:
+    runner = SegmentedNationalRunner(
+        params, app_name=app_name, modal_module=modal_module
+    )
+    return runner.run()

--- a/projects/policyengine-simulation-executor/src/modal/segmented_national.py
+++ b/projects/policyengine-simulation-executor/src/modal/segmented_national.py
@@ -1,20 +1,26 @@
 """Fan out a plain national macro request across region groups.
 
 A US national macro request runs segmented BY DEFAULT: one ``region_group``
-child per partition group (spawned back into this app's own ``run_simulation``
-worker), then the children's computed microdata reduces into the national
-output via the existing builder (``segmented_national_reduce``). The request
-and response shapes are identical to the monolithic path — the gateway and
-its clients see nothing but a faster job. ``segmented: false`` opts out.
+child per partition group (spawned into the dedicated
+``run_simulation_segment`` worker pool), then the children's computed
+microdata reduces into the national output via the existing builder
+(``segmented_national_reduce``). The request and response shapes are
+identical to the monolithic path — the gateway and its clients see nothing
+but a faster job. ``segmented: false`` opts out.
 
-Mirrors ``BudgetWindowBatchRunner``'s spawn/poll mechanics, minus the state
-store: the plain job-poll path needs no partial status, so a parent failure
-simply propagates to the gateway as a failed job, exactly like a monolithic
-failure today.
+Children get their own container pool because a blocking parent must never
+share a bounded pool with the work it waits on: parents live in
+``run_simulation`` (gateway-facing), children in ``run_simulation_segment``.
+
+There is no batch state store: the plain job-poll path needs no partial
+status, so a parent failure propagates to the gateway as a failed job. A
+parent killed outright (its own timeout/OOM) cannot cancel children — the
+in-band failure paths do.
 """
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any
 
@@ -29,55 +35,94 @@ from policyengine_simulation_executor.segmented_national_reduce import (
 )
 from policyengine_simulation_observability.errors import log_and_redact_exception
 from policyengine_simulation_observability.observability import SegmentName
+from policyengine_simulation_observability.telemetry import split_internal_payload
+from src.modal.fanout import build_child_payload, next_backoff
+
+logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_INITIAL_SECONDS = 0.5
 POLL_INTERVAL_MAX_SECONDS = 15.0
 POLL_INTERVAL_BACKOFF_FACTOR = 2.0
 
-# Never forwarded to children: the opt-out knob (children are region_group
-# requests and thus ineligible regardless) and parent-scoped metadata.
-SEGMENTED_STRIP_FIELDS = frozenset({"segmented", "_metadata", "_telemetry"})
+# The dedicated children pool (see module docstring).
+SEGMENT_FUNCTION_NAME = "run_simulation_segment"
+
+# Parent-scoped keys never forwarded to children. (The shared payload
+# builder owns _telemetry: stripped, then re-attached when present.)
+# `region` is stripped because v1-style national parents carry
+# region:"us", and a child must scope by its region_group alone.
+CHILD_STRIP_FIELDS = frozenset({"segmented", "_metadata", "region"})
+
+# Reforms under this prefix activate labor-supply behavioral responses.
+# policyengine decides LSR activity from simulation.policy — which the
+# reduce's stand-in simulations do not carry — so an LSR reform through the
+# reduce would silently report labor_supply_response as all zeros. Worse,
+# the naive fix (attaching the policy to the stand-ins) mislabels the LSR
+# decile splits: the transported household_income_decile column is computed
+# per region group, not nationally. Until the reduce recomputes national
+# deciles and is validated for LSR, these reforms run monolithic.
+LSR_PARAMETER_PREFIX = "gov.simulation.labor_supply_responses"
 
 
-def should_run_segmented_national(params: dict[str, Any]) -> bool:
-    """True when a request should fan out across the national partition.
+def _activates_labor_supply_response(params: dict[str, Any]) -> bool:
+    for policy_key in ("reform", "baseline"):
+        policy = params.get(policy_key)
+        if isinstance(policy, dict) and any(
+            str(name).startswith(LSR_PARAMETER_PREFIX) for name in policy
+        ):
+            return True
+    return False
 
-    Eligible: US, macro scope, no region/region_group, not opted out via
-    ``segmented: false``. ``include_cliffs`` falls back to monolithic —
-    cliff-variable reconstruction through the reduce is not yet validated.
+
+def is_plain_national_macro(params: dict[str, Any]) -> bool:
+    """The request SHAPE of a plain US national macro run (ignores the
+    eligibility knobs — see ``should_run_segmented_national``).
+
+    National is spelled two ways in the wild: region omitted (the sim API's
+    own convention) and ``region: "us"`` (what API v1 sends on every
+    national run). Both must match, mirroring the worker's normalisation
+    (``_normalise_region_code``: None/empty/"us" -> country).
     """
     country = str(params.get("country") or "us").lower()
     if country != "us":
         return False
     if str(params.get("scope") or "").lower() != "macro":
         return False
-    if params.get("region") or params.get("region_group"):
+    if params.get("region_group"):
+        return False
+    region = str(params.get("region") or "").strip().lower()
+    return region in ("", country)
+
+
+def should_run_segmented_national(params: dict[str, Any]) -> bool:
+    """True when a request should fan out across the national partition.
+
+    Eligible: a plain US national macro shape, not opted out via
+    ``segmented: false``. Falls back to monolithic for ``include_cliffs``
+    (cliff-variable reconstruction through the reduce is not yet validated)
+    and for labor-supply-response reforms (see ``LSR_PARAMETER_PREFIX``).
+    """
+    if not is_plain_national_macro(params):
         return False
     if params.get("segmented") is False:
         return False
     if params.get("include_cliffs"):
         return False
+    if _activates_labor_supply_response(params):
+        return False
+    country = str(params.get("country") or "us").lower()
     return national_region_groups(country) is not None
 
 
 def build_group_child_payload(
     params: dict[str, Any], group: list[str]
 ) -> dict[str, Any]:
-    """One child's request: the parent's params scoped to a region group.
-
-    Mirrors ``build_child_simulation_request`` (budget-window): copy the
-    parent params minus the strip set, overwrite the fan-out axis, re-attach
-    telemetry so child spans join the parent's trace.
-    """
-    payload = {
-        key: value for key, value in params.items() if key not in SEGMENTED_STRIP_FIELDS
-    }
-    payload["region_group"] = list(group)
-    payload["_emit_microdata"] = True
-    telemetry = params.get("_telemetry")
-    if isinstance(telemetry, dict):
-        payload["_telemetry"] = telemetry
-    return payload
+    """One child's request: the parent's params scoped to a region group."""
+    return build_child_payload(
+        params,
+        strip_fields=CHILD_STRIP_FIELDS,
+        overrides={"region_group": list(group), "_emit_microdata": True},
+    )
 
 
 class SegmentedNationalRunner:
@@ -91,57 +136,114 @@ class SegmentedNationalRunner:
         modal_module=None,
         poll_interval_seconds: float = POLL_INTERVAL_INITIAL_SECONDS,
         poll_interval_max_seconds: float = POLL_INTERVAL_MAX_SECONDS,
-        poll_interval_backoff_factor: float = POLL_INTERVAL_BACKOFF_FACTOR,
     ):
         self.params = params
         self.app_name = app_name
         self.modal = modal if modal_module is None else modal_module
         self.poll_interval_initial_seconds = poll_interval_seconds
         self.poll_interval_max_seconds = poll_interval_max_seconds
-        self.poll_interval_backoff_factor = poll_interval_backoff_factor
         self.country = str(params.get("country") or "us").lower()
         groups = national_region_groups(self.country)
         if not groups:
             raise ValueError(f"No national partition for country {self.country!r}")
         self.groups = groups
         # Lazy handle, no RPC until first spawn (budget-window precedent).
-        self.child_func = self.modal.Function.from_name(app_name, "run_simulation")
+        self.child_func = self.modal.Function.from_name(app_name, SEGMENT_FUNCTION_NAME)
         set_attribute("national_execution", "segmented")
         set_attribute("segmented_group_count", len(self.groups))
-        self._poll_count = 0
+        set_attribute("country", self.country)
+        set_attribute("region", self.country)
+        if params.get("time_period"):
+            set_attribute("simulation_year", str(params["time_period"]))
 
     def run(self) -> dict[str, Any]:
+        country_module = self._country_module()
+        self._extend_last_group_with_uncovered_states(country_module)
         handles = self._spawn_all_children()
         child_results = self._collect(handles)
-        return self._reduce(child_results)
+        return self._reduce(child_results, country_module=country_module)
+
+    def _country_module(self):
+        from policyengine_simulation_executor.simulation_runtime import (
+            _country_module,
+        )
+
+        return _country_module(self.country)
+
+    def _extend_last_group_with_uncovered_states(self, country_module) -> None:
+        """Registry state regions missing from the static partition ride in
+        the last group, loudly, so a new state-level region added to the
+        model cannot silently drop its households from national results.
+        (Households whose state has NO registered region remain invisible
+        here; the partition test pins the registry at pin-bump time.)
+        """
+        model = country_module.model
+        model.get_region(self.groups[0][0])  # force lazy registry load
+        registry = getattr(model, "region_registry", None)
+        if registry is None:
+            return
+        state_codes = {
+            region.code for region in registry.regions if region.region_type == "state"
+        }
+        covered = {code for group in self.groups for code in group}
+        uncovered = sorted(state_codes - covered)
+        if uncovered:
+            logger.warning(
+                "National partition is missing registry state regions %s; "
+                "assigning them to the last group for this run. Rebalance "
+                "US_NATIONAL_REGION_GROUPS with a measured partition.",
+                uncovered,
+            )
+            set_attribute("partition_uncovered_regions", ",".join(uncovered))
+            self.groups[-1] = list(self.groups[-1]) + uncovered
 
     def _spawn_all_children(self) -> list[tuple[list[str], Any]]:
-        handles = []
-        for group in self.groups:
-            payload = build_group_child_payload(self.params, group)
-            with segment(
-                SegmentName.SEGMENTED_NATIONAL_CHILD_SPAWN,
-                region_group="+".join(group),
-            ):
-                call = self.child_func.spawn(payload)
-            handles.append((group, call))
+        handles: list[tuple[list[str], Any]] = []
+        try:
+            for group in self.groups:
+                payload = build_group_child_payload(self.params, group)
+                with segment(
+                    SegmentName.SEGMENTED_NATIONAL_CHILD_SPAWN,
+                    region_group="+".join(group),
+                ):
+                    call = self.child_func.spawn(payload)
+                handles.append((group, call))
+        except Exception:
+            # Children spawned before the failure must not run for a job
+            # that is already dead.
+            self._cancel_all(handles)
+            raise
         return handles
 
     def _collect(self, handles: list[tuple[list[str], Any]]) -> list[dict]:
         results: list[dict | None] = [None] * len(handles)
         pending = set(range(len(handles)))
+        poll_errors: dict[int, int] = {}
         current_sleep = self.poll_interval_initial_seconds
+        poll_count = 0
 
         while pending:
             progress_made = False
             for index in sorted(pending):
                 group, call = handles[index]
-                self._poll_count += 1
+                poll_count += 1
                 try:
                     results[index] = call.get(timeout=0)
                 except TimeoutError:
                     continue
                 except Exception as exc:
+                    # One transient poll-RPC blip must not kill the job; a
+                    # real child failure re-raises on the next probe too.
+                    attempts = poll_errors.get(index, 0) + 1
+                    poll_errors[index] = attempts
+                    if attempts < 2:
+                        logger.warning(
+                            "Poll error for group %s (attempt %d), retrying: %s",
+                            "+".join(group),
+                            attempts,
+                            type(exc).__name__,
+                        )
+                        continue
                     redacted = log_and_redact_exception(
                         exc,
                         scope="segmented_national_child",
@@ -153,58 +255,58 @@ class SegmentedNationalRunner:
                         f"{'+'.join(group)}: {redacted}"
                     ) from None
                 pending.discard(index)
+                poll_errors.pop(index, None)
                 progress_made = True
             # Bounded aggregate instead of one segment per probe (see the
             # SegmentName NOTE about long poll loops).
-            set_attribute("segmented_poll_count", self._poll_count)
+            set_attribute("segmented_poll_count", poll_count)
             if pending and not progress_made:
                 time.sleep(current_sleep)
-                current_sleep = min(
-                    current_sleep * self.poll_interval_backoff_factor,
-                    self.poll_interval_max_seconds,
+                current_sleep = next_backoff(
+                    current_sleep,
+                    factor=POLL_INTERVAL_BACKOFF_FACTOR,
+                    maximum=self.poll_interval_max_seconds,
                 )
             elif progress_made:
                 current_sleep = self.poll_interval_initial_seconds
         return results  # type: ignore[return-value]
 
     def _cancel_all(self, handles: list[tuple[list[str], Any]]) -> None:
-        """Best-effort cancel so a failed batch doesn't strand 19 workers."""
+        """Best-effort cancel so a failed batch doesn't strand workers."""
         for _, call in handles:
             try:
                 call.cancel()
             except Exception:
                 pass
 
-    def _reduce(self, child_results: list[dict]) -> dict[str, Any]:
+    def _reduce(self, child_results: list[dict], *, country_module) -> dict[str, Any]:
         from policyengine_simulation_executor.simulation_runtime import (
-            _country_module,
             _parse_year,
             _requested_data_version,
         )
 
-        simulation_params = {
-            key: value
-            for key, value in self.params.items()
-            if key not in SEGMENTED_STRIP_FIELDS
-        }
+        # The canonical internal-key stripper, plus the opt-out knob.
+        simulation_params, _, _ = split_internal_payload(self.params)
+        simulation_params.pop("segmented", None)
         with segment(SegmentName.SEGMENTED_NATIONAL_REDUCE):
-            return build_national_output(
+            output = build_national_output(
                 child_results,
                 country=self.country,
                 simulation_params=simulation_params,
-                country_module=_country_module(self.country),
+                country_module=country_module,
                 year=_parse_year(simulation_params),
                 resolved_data_version=_requested_data_version(simulation_params),
             )
+        for key in ("model_version", "data_version"):
+            if output.get(key):
+                set_attribute(key, str(output[key]))
+        return output
 
 
 def run_segmented_national_impl(
-    params: dict[str, Any], *, app_name: str, modal_module=None
+    params: dict[str, Any], *, app_name: str
 ) -> dict[str, Any]:
-    runner = SegmentedNationalRunner(
-        params, app_name=app_name, modal_module=modal_module
-    )
-    return runner.run()
+    return SegmentedNationalRunner(params, app_name=app_name).run()
 
 
 def dispatch_run_simulation(params: dict[str, Any], *, app_name: str) -> dict[str, Any]:
@@ -217,5 +319,8 @@ def dispatch_run_simulation(params: dict[str, Any], *, app_name: str) -> dict[st
         run_simulation_impl,
     )
 
-    set_attribute("national_execution", "monolithic")
+    # Only label runs that are actually national-shaped: children, regional,
+    # and UK requests must not pollute the segmented-vs-monolithic metric.
+    if is_plain_national_macro(params):
+        set_attribute("national_execution", "monolithic")
     return run_simulation_impl(params)

--- a/projects/policyengine-simulation-executor/src/modal/segmented_national.py
+++ b/projects/policyengine-simulation-executor/src/modal/segmented_national.py
@@ -70,9 +70,7 @@ def build_group_child_payload(
     telemetry so child spans join the parent's trace.
     """
     payload = {
-        key: value
-        for key, value in params.items()
-        if key not in SEGMENTED_STRIP_FIELDS
+        key: value for key, value in params.items() if key not in SEGMENTED_STRIP_FIELDS
     }
     payload["region_group"] = list(group)
     payload["_emit_microdata"] = True
@@ -104,14 +102,10 @@ class SegmentedNationalRunner:
         self.country = str(params.get("country") or "us").lower()
         groups = national_region_groups(self.country)
         if not groups:
-            raise ValueError(
-                f"No national partition for country {self.country!r}"
-            )
+            raise ValueError(f"No national partition for country {self.country!r}")
         self.groups = groups
         # Lazy handle, no RPC until first spawn (budget-window precedent).
-        self.child_func = self.modal.Function.from_name(
-            app_name, "run_simulation"
-        )
+        self.child_func = self.modal.Function.from_name(app_name, "run_simulation")
         set_attribute("national_execution", "segmented")
         set_attribute("segmented_group_count", len(self.groups))
         self._poll_count = 0
@@ -200,9 +194,7 @@ class SegmentedNationalRunner:
                 simulation_params=simulation_params,
                 country_module=_country_module(self.country),
                 year=_parse_year(simulation_params),
-                resolved_data_version=_requested_data_version(
-                    simulation_params
-                ),
+                resolved_data_version=_requested_data_version(simulation_params),
             )
 
 
@@ -215,9 +207,7 @@ def run_segmented_national_impl(
     return runner.run()
 
 
-def dispatch_run_simulation(
-    params: dict[str, Any], *, app_name: str
-) -> dict[str, Any]:
+def dispatch_run_simulation(params: dict[str, Any], *, app_name: str) -> dict[str, Any]:
     """The run_simulation entrypoint's routing: segmented national fan-out
     for eligible requests, the monolithic path for everything else."""
     if should_run_segmented_national(params):

--- a/projects/policyengine-simulation-executor/src/modal/smoke_app.py
+++ b/projects/policyengine-simulation-executor/src/modal/smoke_app.py
@@ -44,12 +44,19 @@ def smoke_import_executor() -> dict:
     # baked env layer).
     importlib.import_module("src.modal.app")
 
-    # The lazy request-time imports of the two worker functions.
+    # The lazy request-time imports of the worker functions. run_simulation
+    # imports the segmented-national dispatch (and its pandas/microdf/
+    # policyengine.core chain) on EVERY request, so a break there crashes
+    # all requests at import time — exactly the #602 failure class this
+    # smoke exists to catch.
     from policyengine_simulation_executor.simulation_runtime import (  # noqa: F401
         run_simulation_impl,
     )
     from src.modal.budget_window_batch import (  # noqa: F401
         run_budget_window_batch_impl,
+    )
+    from src.modal.segmented_national import (  # noqa: F401
+        dispatch_run_simulation,
     )
 
     import policyengine_simulation_contract

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/compat_models.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/compat_models.py
@@ -21,10 +21,15 @@ class SimulationOptions(BaseModel):
     reform: Optional[dict[str, Any]] = None
     baseline: Optional[dict[str, Any]] = None
     region: Optional[str] = None
+    region_group: Optional[list[str]] = None
     title: Optional[str] = None
     include_cliffs: Optional[bool] = None
     model_version: Optional[str] = None
     data_version: Optional[str] = None
+    # Accepted for parity with the gateway contract. The synchronous
+    # surface always runs monolithically, so segmented=false is trivially
+    # honored and segmented=true has no effect here.
+    segmented: Optional[bool] = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/national_partition.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/national_partition.py
@@ -1,0 +1,48 @@
+"""Static region-group partition for segmented national runs.
+
+A plain US national macro request runs as one simulation per group below
+(each a ``region_group`` request over whole states), and a coordinator
+reduces the groups' microdata back into the national output. Partitioning
+by whole states with row-filter scoping preserves national weights, so the
+reduce is exact — see the segmented-national plan.
+
+Provenance: household-balanced 20-way partition computed from the actual
+dataset household counts (LPT greedy over per-state rows; no state needed
+splitting into districts). Groups hold 2,440-3,042 of the 57,240 sample
+households each. Rebalance only with a measured partition; group count and
+membership changes alter per-child runtimes, not correctness.
+"""
+
+US_NATIONAL_REGION_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("state/hi", "state/ia", "state/wi"),
+    ("state/ak", "state/ga", "state/la"),
+    ("state/al", "state/co", "state/ri"),
+    ("state/mn", "state/mo", "state/nh"),
+    ("state/az", "state/de", "state/me"),
+    ("state/ny", "state/wv"),
+    ("state/in", "state/ky", "state/md"),
+    ("state/mt", "state/sc", "state/wa"),
+    ("state/id", "state/or", "state/tn"),
+    ("state/ar", "state/nc", "state/nd"),
+    ("state/dc", "state/ks", "state/mi"),
+    ("state/ct", "state/oh", "state/vt"),
+    ("state/nv", "state/va", "state/wy"),
+    ("state/pa", "state/ut"),
+    ("state/sd", "state/tx"),
+    ("state/ca",),
+    ("state/il", "state/ms"),
+    ("state/fl", "state/nm"),
+    ("state/ne", "state/nj"),
+    ("state/ma", "state/ok"),
+)
+
+
+def national_region_groups(country: str) -> list[list[str]] | None:
+    """The region-group partition for a country's segmented national run.
+
+    Returns None when the country has no partition (only the US has one),
+    in which case national requests run monolithically.
+    """
+    if country.lower() == "us":
+        return [list(group) for group in US_NATIONAL_REGION_GROUPS]
+    return None

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/segmented_national_reduce.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/segmented_national_reduce.py
@@ -1,0 +1,155 @@
+"""Reduce region-group children into the national macro output.
+
+The segmented national path runs one ``region_group`` child per partition
+group (each with ``_emit_microdata``), then this module concatenates the
+children's computed ``output_dataset`` microdata into full national entity
+tables and runs the EXISTING ``SimulationOutputBuilder`` over stand-in
+simulations. The model never re-runs: the reducers only read
+``output_dataset.data``, which is per-household independent, so the reduce
+reproduces the monolithic national output bit-for-bit (validated on staging:
+group == sum of members at 2e-16; rebuilt output == direct output with zero
+differing leaves once dtypes are preserved).
+
+Two hazards this module exists to handle:
+
+* ``Simulation.ensure()`` consults the in-process cache and disk, NOT the
+  instance's ``output_dataset`` field — a bare assignment gets ignored and
+  the model re-runs. ``PrecomputedSimulation`` overrides ``ensure`` to a
+  no-op (a subclass, not a monkeypatch: warm worker processes must never be
+  globally patched).
+* The transported arrays must be cast back to their source dtypes
+  (``rebuild_entity_frame``), or float32 widens to float64 and weighted
+  aggregates drift ~1e-7 relative.
+"""
+
+from typing import Any
+
+import pandas as pd
+from microdf import MicroDataFrame
+
+from policyengine.core import Simulation
+
+from policyengine_simulation_executor.simulation_microdata import (
+    rebuild_entity_frame,
+)
+from policyengine_simulation_executor.simulation_output_builder import (
+    SimulationOutputBuilder,
+)
+
+
+class PrecomputedSimulation(Simulation):
+    """A Simulation whose ``output_dataset`` is injected, never computed."""
+
+    def ensure(self) -> None:
+        """No-op: the output data is already attached (see module docstring)."""
+        return
+
+
+def concatenate_microdata(
+    child_outputs: list[dict],
+) -> dict[str, dict[str, pd.DataFrame]]:
+    """Concatenate the children's microdata into national entity tables.
+
+    Returns ``{side: {entity: DataFrame}}`` for ``baseline``/``reform``,
+    concatenated in child order with source dtypes restored.
+    """
+    if not child_outputs:
+        raise ValueError("No child outputs to reduce")
+    payloads = []
+    for index, child in enumerate(child_outputs):
+        payload = child.get("_microdata")
+        if not payload:
+            raise ValueError(f"Child {index} returned no _microdata payload")
+        payloads.append(payload)
+
+    entities = payloads[0]["entities"]
+    sides: dict[str, dict[str, pd.DataFrame]] = {}
+    for side in ("baseline", "reform"):
+        frames: dict[str, pd.DataFrame] = {}
+        for entity in entities:
+            parts = [
+                rebuild_entity_frame(
+                    payload[side][entity],
+                    (payload.get("dtypes") or {}).get(side, {}).get(entity),
+                )
+                for payload in payloads
+            ]
+            frames[entity] = pd.concat(parts, ignore_index=True)
+        sides[side] = frames
+    return sides
+
+
+def _us_dataset_from_frames(frames: dict[str, pd.DataFrame], *, year: int):
+    """Wrap concatenated entity tables as an in-memory US dataset.
+
+    Weights need no special handling: they ride as ``<entity>_weight``
+    columns and ``MicroDataFrame(df, weights=...)`` re-derives them.
+    """
+    from policyengine.tax_benefit_models.us.datasets import (
+        PolicyEngineUSDataset,
+        USYearData,
+    )
+
+    fields = {}
+    for entity, df in frames.items():
+        weight_column = f"{entity}_weight"
+        fields[entity] = (
+            MicroDataFrame(df, weights=weight_column)
+            if weight_column in df.columns
+            else MicroDataFrame(df)
+        )
+    return PolicyEngineUSDataset(
+        data=USYearData(**fields),
+        year=year,
+        filepath=None,
+        name="segmented-national",
+        description="Concatenated region-group output microdata",
+    )
+
+
+def build_national_output(
+    child_outputs: list[dict],
+    *,
+    country: str,
+    simulation_params: dict[str, Any],
+    country_module,
+    year: int,
+    resolved_data_version: str | None = None,
+) -> dict[str, Any]:
+    """The reduce: children's microdata -> full national macro output dict.
+
+    Runs the existing ``SimulationOutputBuilder`` over stand-in simulations
+    with ``resolved_region_code=country`` so the national congressional
+    district table populates. No model recompute occurs.
+    """
+    if country.lower() != "us":
+        raise ValueError(
+            f"No segmented-national reduce for country {country!r} (US only)"
+        )
+
+    sides = concatenate_microdata(child_outputs)
+    datasets = {
+        side: _us_dataset_from_frames(frames, year=year)
+        for side, frames in sides.items()
+    }
+
+    def stand_in(dataset) -> PrecomputedSimulation:
+        simulation = PrecomputedSimulation(
+            dataset=dataset,
+            tax_benefit_model_version=country_module.model,
+            policy=None,
+        )
+        simulation.output_dataset = dataset
+        return simulation
+
+    builder = SimulationOutputBuilder(
+        country=country,
+        simulation_params=simulation_params,
+        country_module=country_module,
+        dataset=datasets["baseline"],
+        baseline=stand_in(datasets["baseline"]),
+        reform=stand_in(datasets["reform"]),
+        resolved_data_version=resolved_data_version,
+        resolved_region_code=country,
+    )
+    return builder.serialize()

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/segmented_national_reduce.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/segmented_national_reduce.py
@@ -22,6 +22,7 @@ Two hazards this module exists to handle:
   aggregates drift ~1e-7 relative.
 """
 
+import logging
 from typing import Any
 
 import pandas as pd
@@ -35,6 +36,8 @@ from policyengine_simulation_executor.simulation_microdata import (
 from policyengine_simulation_executor.simulation_output_builder import (
     SimulationOutputBuilder,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PrecomputedSimulation(Simulation):
@@ -62,7 +65,7 @@ def concatenate_microdata(
             raise ValueError(f"Child {index} returned no _microdata payload")
         payloads.append(payload)
 
-    entities = payloads[0]["entities"]
+    entities = list(payloads[0]["baseline"])
     sides: dict[str, dict[str, pd.DataFrame]] = {}
     for side in ("baseline", "reform"):
         frames: dict[str, pd.DataFrame] = {}
@@ -152,4 +155,17 @@ def build_national_output(
         resolved_data_version=resolved_data_version,
         resolved_region_code=country,
     )
-    return builder.serialize()
+    output = builder.serialize()
+    # The rebuilt in-memory dataset carries no artifact metadata, so the
+    # builder's version fallbacks can misreport provenance; the children
+    # loaded the real artifact, so their reported versions are authoritative.
+    for key in ("model_version", "data_version"):
+        values = sorted({str(child[key]) for child in child_outputs if child.get(key)})
+        if not values:
+            continue
+        if len(values) > 1:
+            logger.warning(
+                "Segmented national children disagree on %s: %s", key, values
+            )
+        output[key] = values[0]
+    return output

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_microdata.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_microdata.py
@@ -5,6 +5,12 @@ the output builder has already computed — so a coordinator can concatenate the
 across groups and rebuild the national output with the *existing* builder,
 without re-running the model. Only the additive fields (budget, geographic) plus
 these per-household/person tables are needed to reconstruct every national field.
+
+The payload carries each column's source dtype: the model's arrays are float32,
+and a plain ``to_dict("list")`` round-trip widens them to float64, which shifts
+weighted aggregates by ~1e-7 relative (e.g. $0.49 on a $509M budget). Rebuilding
+with ``rebuild_entity_frame`` restores the source dtypes so the reduce is
+bit-exact against a direct run.
 """
 
 from typing import Any
@@ -14,7 +20,7 @@ import pandas as pd
 
 def extract_output_microdata(baseline, reform) -> dict[str, Any]:
     """Columnar dump of each simulation's computed ``output_dataset.data`` per
-    entity, for baseline and reform.
+    entity, for baseline and reform, plus per-column source dtypes.
 
     The entity tables come from the model's own ``YearData.entity_data``
     property, so there is no hardcoded per-country entity list to drift.
@@ -24,16 +30,38 @@ def extract_output_microdata(baseline, reform) -> dict[str, Any]:
     stays valid on the reassembled national data.
     """
 
-    def dump(simulation) -> dict[str, dict[str, list]]:
-        entity_data = simulation.output_dataset.data.entity_data
-        return {
-            entity: pd.DataFrame(frame).to_dict("list")
-            for entity, frame in entity_data.items()
-        }
+    def dump(simulation) -> tuple[dict[str, dict[str, list]], dict[str, dict[str, str]]]:
+        columns: dict[str, dict[str, list]] = {}
+        dtypes: dict[str, dict[str, str]] = {}
+        for entity, frame in simulation.output_dataset.data.entity_data.items():
+            df = pd.DataFrame(frame)
+            columns[entity] = df.to_dict("list")
+            dtypes[entity] = {col: str(dtype) for col, dtype in df.dtypes.items()}
+        return columns, dtypes
 
-    baseline_dump = dump(baseline)
+    baseline_columns, baseline_dtypes = dump(baseline)
+    reform_columns, reform_dtypes = dump(reform)
     return {
-        "entities": list(baseline_dump),
-        "baseline": baseline_dump,
-        "reform": dump(reform),
+        "entities": list(baseline_columns),
+        "baseline": baseline_columns,
+        "reform": reform_columns,
+        "dtypes": {"baseline": baseline_dtypes, "reform": reform_dtypes},
     }
+
+
+def rebuild_entity_frame(
+    columns: dict[str, list], dtypes: dict[str, str] | None
+) -> pd.DataFrame:
+    """Rebuild one transported entity table, casting each column back to its
+    source dtype (float32 stays float32 — see module docstring). Tolerant of
+    missing or uncastable dtype entries: those columns keep pandas' inferred
+    dtype rather than failing the reduce.
+    """
+    df = pd.DataFrame(columns)
+    for col, dtype in (dtypes or {}).items():
+        if col in df.columns and str(df[col].dtype) != dtype:
+            try:
+                df[col] = df[col].astype(dtype)
+            except (ValueError, TypeError):
+                pass
+    return df

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_microdata.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_microdata.py
@@ -13,9 +13,12 @@ with ``rebuild_entity_frame`` restores the source dtypes so the reduce is
 bit-exact against a direct run.
 """
 
+import logging
 from typing import Any
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def extract_output_microdata(baseline, reform) -> dict[str, Any]:
@@ -44,7 +47,6 @@ def extract_output_microdata(baseline, reform) -> dict[str, Any]:
     baseline_columns, baseline_dtypes = dump(baseline)
     reform_columns, reform_dtypes = dump(reform)
     return {
-        "entities": list(baseline_columns),
         "baseline": baseline_columns,
         "reform": reform_columns,
         "dtypes": {"baseline": baseline_dtypes, "reform": reform_dtypes},
@@ -55,15 +57,31 @@ def rebuild_entity_frame(
     columns: dict[str, list], dtypes: dict[str, str] | None
 ) -> pd.DataFrame:
     """Rebuild one transported entity table, casting each column back to its
-    source dtype (float32 stays float32 — see module docstring). Tolerant of
-    missing or uncastable dtype entries: those columns keep pandas' inferred
-    dtype rather than failing the reduce.
+    source dtype (float32 stays float32 — see module docstring). A missing
+    or uncastable dtype falls back to pandas' inferred dtype rather than
+    failing the reduce, but LOUDLY: that fallback breaks the bit-exactness
+    guarantee (float64 widening, ~1e-7 aggregate drift).
     """
     df = pd.DataFrame(columns)
-    for col, dtype in (dtypes or {}).items():
+    if dtypes is None:
+        logger.warning(
+            "Transported microdata carries no dtypes; rebuilding with "
+            "inferred dtypes — the reduce is no longer bit-exact against a "
+            "monolithic run (version-skewed child?)"
+        )
+        return df
+    for col, dtype in dtypes.items():
         if col in df.columns and str(df[col].dtype) != dtype:
             try:
                 df[col] = df[col].astype(dtype)
-            except (ValueError, TypeError):
-                pass
+            except (ValueError, TypeError) as exc:
+                logger.warning(
+                    "Could not restore dtype %s for transported column %r "
+                    "(%s); keeping inferred dtype %s — bit-exactness is not "
+                    "guaranteed for aggregates over this column",
+                    dtype,
+                    col,
+                    type(exc).__name__,
+                    df[col].dtype,
+                )
     return df

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_microdata.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_microdata.py
@@ -30,7 +30,9 @@ def extract_output_microdata(baseline, reform) -> dict[str, Any]:
     stays valid on the reassembled national data.
     """
 
-    def dump(simulation) -> tuple[dict[str, dict[str, list]], dict[str, dict[str, str]]]:
+    def dump(
+        simulation,
+    ) -> tuple[dict[str, dict[str, list]], dict[str, dict[str, str]]]:
         columns: dict[str, dict[str, list]] = {}
         dtypes: dict[str, dict[str, str]] = {}
         for entity, frame in simulation.output_dataset.data.entity_data.items():

--- a/projects/policyengine-simulation-executor/tests/test_budget_window_context.py
+++ b/projects/policyengine-simulation-executor/tests/test_budget_window_context.py
@@ -73,3 +73,17 @@ def test_build_child_simulation_request_removes_batch_only_fields():
     assert "max_parallel" not in child_request.payload
     assert "target" not in child_request.payload
     assert "_metadata" not in child_request.payload
+
+
+def test_build_child_simulation_request_pins_children_monolithic():
+    """A national budget-window child must not fan out again (years x 21
+    containers); enabling nested segmentation is a deliberate follow-up."""
+    _, payload = _build_parent_payload()
+    context = build_batch_context(payload, batch_job_id="parent-123")
+
+    child_request = build_child_simulation_request(
+        context,
+        simulation_year="2028",
+    )
+
+    assert child_request.payload["segmented"] is False

--- a/projects/policyengine-simulation-executor/tests/test_national_partition.py
+++ b/projects/policyengine-simulation-executor/tests/test_national_partition.py
@@ -39,6 +39,28 @@ class TestPartitionInvariants:
         assert all(len(group) >= 1 for group in US_NATIONAL_REGION_GROUPS)
 
 
+class TestPartitionMatchesModelRegistry:
+    def test__partition_covers_exactly_the_registry_state_regions(self):
+        """A policyengine pin bump that adds/renames a state-level region
+        must fail here, forcing a measured partition rebalance. (At runtime
+        the runner also assigns uncovered registry states to the last group
+        as a stopgap — this test is what makes the drift loud in CI.)"""
+        from policyengine_simulation_executor.simulation_runtime import (
+            _country_module,
+        )
+
+        registry = _country_module("us").model.region_registry
+        registry_states = {
+            region.code
+            for region in registry.regions
+            if region.region_type == "state"
+        }
+        partition_codes = {
+            code for group in US_NATIONAL_REGION_GROUPS for code in group
+        }
+        assert partition_codes == registry_states
+
+
 class TestNationalRegionGroups:
     def test__us_returns_mutable_copies(self):
         groups = national_region_groups("us")

--- a/projects/policyengine-simulation-executor/tests/test_national_partition.py
+++ b/projects/policyengine-simulation-executor/tests/test_national_partition.py
@@ -1,0 +1,54 @@
+"""Unit tests for the segmented-national partition (C2)."""
+
+import re
+
+from policyengine_simulation_executor.national_partition import (
+    US_NATIONAL_REGION_GROUPS,
+    national_region_groups,
+)
+
+# 50 states + DC as they appear in region codes.
+ALL_STATE_CODES = {
+    f"state/{s}"
+    for s in (
+        "al ak az ar ca co ct de dc fl ga hi id il in ia ks ky la me md ma "
+        "mi mn ms mo mt ne nv nh nj nm ny nc nd oh ok or pa ri sc sd tn tx "
+        "ut vt va wa wv wi wy"
+    ).split()
+}
+
+
+class TestPartitionInvariants:
+    def test__exactly_twenty_groups(self):
+        assert len(US_NATIONAL_REGION_GROUPS) == 20
+
+    def test__every_state_appears_exactly_once(self):
+        codes = [c for group in US_NATIONAL_REGION_GROUPS for c in group]
+        assert len(codes) == 51
+        assert set(codes) == ALL_STATE_CODES
+
+    def test__codes_are_wellformed_state_codes(self):
+        for group in US_NATIONAL_REGION_GROUPS:
+            # Guards the ("state/xx",) single-member tuple trap: a bare
+            # ("state/xx") is a string and would iterate as characters.
+            assert isinstance(group, tuple)
+            for code in group:
+                assert re.fullmatch(r"state/[a-z]{2}", code)
+
+    def test__groups_are_nonempty(self):
+        assert all(len(group) >= 1 for group in US_NATIONAL_REGION_GROUPS)
+
+
+class TestNationalRegionGroups:
+    def test__us_returns_mutable_copies(self):
+        groups = national_region_groups("us")
+        assert groups is not None
+        assert len(groups) == 20
+        groups[0].append("state/zz")  # mutating the copy...
+        assert "state/zz" not in US_NATIONAL_REGION_GROUPS[0]  # ...not the source
+
+    def test__case_insensitive_country(self):
+        assert national_region_groups("US") is not None
+
+    def test__uk_has_no_partition(self):
+        assert national_region_groups("uk") is None

--- a/projects/policyengine-simulation-executor/tests/test_segmented_national.py
+++ b/projects/policyengine-simulation-executor/tests/test_segmented_national.py
@@ -1,4 +1,4 @@
-"""Unit tests for the segmented-national fan-out runner (C5)."""
+"""Unit tests for the segmented-national fan-out runner (C5/C6 + review fixes)."""
 
 from types import SimpleNamespace
 
@@ -6,9 +6,49 @@ import pytest
 
 from src.modal import segmented_national as sn
 from policyengine_simulation_executor import simulation_runtime as sr
+from policyengine_simulation_executor.national_partition import (
+    US_NATIONAL_REGION_GROUPS,
+)
 
 
 NATIONAL = {"country": "us", "scope": "macro", "time_period": "2026"}
+
+
+def _bare_country_module():
+    """A country module whose model has no loadable region registry."""
+    return SimpleNamespace(
+        model=SimpleNamespace(get_region=lambda code: None, region_registry=None)
+    )
+
+
+class TestIsPlainNationalMacro:
+    def test__plain_national_shape(self):
+        assert sn.is_plain_national_macro(dict(NATIONAL)) is True
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"region": "state/ut"},
+            {"region_group": ["state/hi"]},
+            {"country": "uk"},
+            {"scope": "household"},
+            {"scope": None},
+        ],
+    )
+    def test__non_national_shapes(self, overrides):
+        assert sn.is_plain_national_macro({**NATIONAL, **overrides}) is False
+
+    def test__knobs_do_not_change_the_shape(self):
+        assert (
+            sn.is_plain_national_macro({**NATIONAL, "segmented": False}) is True
+        )
+
+    @pytest.mark.parametrize("region", ["us", "US", " us "])
+    def test__v1_style_region_us_is_national(self, region):
+        # API v1 sends region:"us" on every national macro run; both
+        # national spellings must match (simulation_runtime normalises
+        # None/empty/"us" to the country).
+        assert sn.is_plain_national_macro({**NATIONAL, "region": region}) is True
 
 
 class TestShouldRunSegmentedNational:
@@ -37,6 +77,38 @@ class TestShouldRunSegmentedNational:
             is True
         )
 
+    def test__v1_style_region_us_is_eligible(self):
+        assert (
+            sn.should_run_segmented_national({**NATIONAL, "region": "us"})
+            is True
+        )
+
+    @pytest.mark.parametrize("policy_key", ["reform", "baseline"])
+    def test__labor_supply_response_reforms_fall_back_monolithic(
+        self, policy_key
+    ):
+        # The reduce's stand-ins carry no policy, so LSR would silently
+        # zero out (see LSR_PARAMETER_PREFIX) — these must run monolithic.
+        params = {
+            **NATIONAL,
+            policy_key: {
+                "gov.simulation.labor_supply_responses.elasticities."
+                "income.all": {"2026-01-01.2100-12-31": -0.05}
+            },
+        }
+        assert sn.should_run_segmented_national(params) is False
+
+    def test__non_lsr_reform_stays_eligible(self):
+        params = {
+            **NATIONAL,
+            "reform": {
+                "gov.irs.credits.ctc.refundable.fully_refundable": {
+                    "2023-01-01.2100-12-31": True
+                }
+            },
+        }
+        assert sn.should_run_segmented_national(params) is True
+
 
 class TestBuildGroupChildPayload:
     def test__scopes_to_group_and_requests_microdata(self):
@@ -62,17 +134,30 @@ class TestBuildGroupChildPayload:
         )
         assert "_metadata" not in payload
 
+    def test__strips_v1_style_region_us_from_children(self):
+        # A child must scope by its region_group alone, never a stale
+        # parent region.
+        payload = sn.build_group_child_payload(
+            {**NATIONAL, "region": "us"}, ["state/ca"]
+        )
+        assert "region" not in payload
+        assert payload["region_group"] == ["state/ca"]
+
 
 class FakeCall:
     """A FunctionCall whose result resolves after N polls (or raises)."""
 
-    def __init__(self, result, polls_until_ready=0, error=None):
+    def __init__(self, result, polls_until_ready=0, error=None, errors_once=0):
         self.result = result
         self.polls_until_ready = polls_until_ready
         self.error = error
+        self.errors_once = errors_once
         self.cancelled = False
 
     def get(self, timeout):
+        if self.errors_once > 0:
+            self.errors_once -= 1
+            raise ConnectionError("transient control-plane blip")
         if self.error is not None:
             raise self.error
         if self.polls_until_ready > 0:
@@ -85,8 +170,9 @@ class FakeCall:
 
 
 class FakeModal:
-    def __init__(self, calls):
+    def __init__(self, calls, fail_spawn_at=None):
         self._calls = list(calls)
+        self.fail_spawn_at = fail_spawn_at
         self.spawned_payloads = []
         self.from_name_args = None
         fake = self
@@ -100,6 +186,11 @@ class FakeModal:
         self.Function = _Function
 
     def _spawn(self, payload):
+        if (
+            self.fail_spawn_at is not None
+            and len(self.spawned_payloads) == self.fail_spawn_at
+        ):
+            raise ConnectionError("spawn RPC failed")
         self.spawned_payloads.append(payload)
         return self._calls[len(self.spawned_payloads) - 1]
 
@@ -118,45 +209,120 @@ def _twenty_calls(**kwargs):
     return [FakeCall({"child": i}, **kwargs) for i in range(20)]
 
 
+@pytest.fixture
+def bare_country(monkeypatch):
+    monkeypatch.setattr(sr, "_country_module", lambda c: _bare_country_module())
+
+
 class TestSegmentedNationalRunner:
-    def test__spawns_one_child_per_partition_group(self, monkeypatch):
+    def test__spawns_one_child_per_group_into_the_segment_pool(
+        self, monkeypatch, bare_country
+    ):
         fake = FakeModal(_twenty_calls())
         runner = _runner(fake)
-        monkeypatch.setattr(runner, "_reduce", lambda results: {"ok": results})
+        monkeypatch.setattr(
+            runner, "_reduce", lambda results, country_module: {"ok": results}
+        )
 
         result = runner.run()
 
+        # Children draw from the dedicated segment pool, never the
+        # gateway-facing run_simulation pool the parent occupies.
         assert fake.from_name_args == (
             "policyengine-simulation-py-test",
-            "run_simulation",
+            sn.SEGMENT_FUNCTION_NAME,
         )
         assert len(fake.spawned_payloads) == 20
         groups = [p["region_group"] for p in fake.spawned_payloads]
         assert groups == [list(g) for g in runner.groups]
         assert all(p["_emit_microdata"] is True for p in fake.spawned_payloads)
-        # Results arrive in group order regardless of completion order.
         assert result == {"ok": [{"child": i} for i in range(20)]}
 
     def test__collects_out_of_order_completions_in_group_order(
-        self, monkeypatch
+        self, monkeypatch, bare_country
     ):
         calls = [
             FakeCall({"child": i}, polls_until_ready=(19 - i) % 3)
             for i in range(20)
         ]
         runner = _runner(FakeModal(calls))
-        monkeypatch.setattr(runner, "_reduce", lambda results: results)
+        monkeypatch.setattr(
+            runner, "_reduce", lambda results, country_module: results
+        )
         assert runner.run() == [{"child": i} for i in range(20)]
 
-    def test__child_failure_fails_fast_and_cancels_the_rest(self, monkeypatch):
+    def test__child_failure_fails_fast_and_cancels_the_rest(
+        self, monkeypatch, bare_country
+    ):
         calls = _twenty_calls(polls_until_ready=5)
         calls[7] = FakeCall(None, error=ValueError("boom"))
         runner = _runner(FakeModal(calls))
-        monkeypatch.setattr(runner, "_reduce", lambda results: results)
+        monkeypatch.setattr(
+            runner, "_reduce", lambda results, country_module: results
+        )
 
         with pytest.raises(RuntimeError, match="Segmented national child failed"):
             runner.run()
         assert all(c.cancelled for c in calls if c.error is None)
+
+    def test__one_transient_poll_error_is_tolerated(
+        self, monkeypatch, bare_country
+    ):
+        # A single control-plane blip on one handle must not kill the job.
+        calls = _twenty_calls()
+        calls[3] = FakeCall({"child": 3}, errors_once=1)
+        runner = _runner(FakeModal(calls))
+        monkeypatch.setattr(
+            runner, "_reduce", lambda results, country_module: results
+        )
+        assert runner.run() == [{"child": i} for i in range(20)]
+
+    def test__spawn_failure_cancels_already_spawned_children(
+        self, monkeypatch, bare_country
+    ):
+        calls = _twenty_calls(polls_until_ready=100)
+        fake = FakeModal(calls, fail_spawn_at=15)
+        runner = _runner(fake)
+        monkeypatch.setattr(
+            runner, "_reduce", lambda results, country_module: results
+        )
+
+        with pytest.raises(ConnectionError):
+            runner.run()
+        assert all(c.cancelled for c in calls[:15])
+
+    def test__uncovered_registry_states_ride_in_the_last_group(
+        self, monkeypatch, bare_country
+    ):
+        partition_codes = [
+            code for group in US_NATIONAL_REGION_GROUPS for code in group
+        ]
+        registry = SimpleNamespace(
+            regions=[
+                SimpleNamespace(code=code, region_type="state")
+                for code in partition_codes + ["state/pr"]
+            ]
+        )
+        country_module = SimpleNamespace(
+            model=SimpleNamespace(
+                get_region=lambda code: None, region_registry=registry
+            )
+        )
+        monkeypatch.setattr(sr, "_country_module", lambda c: country_module)
+
+        fake = FakeModal([FakeCall({"child": i}) for i in range(20)])
+        runner = _runner(fake)
+        monkeypatch.setattr(
+            runner, "_reduce", lambda results, country_module: results
+        )
+        runner.run()
+
+        assert runner.groups[-1][-1] == "state/pr"
+        assert fake.spawned_payloads[-1]["region_group"][-1] == "state/pr"
+        # Only the last group changes.
+        assert [p["region_group"] for p in fake.spawned_payloads[:-1]] == [
+            list(g) for g in US_NATIONAL_REGION_GROUPS[:-1]
+        ]
 
     def test__reduce_receives_clean_params_and_all_children(self, monkeypatch):
         captured = {}
@@ -169,7 +335,9 @@ class TestSegmentedNationalRunner:
         monkeypatch.setattr(
             sn, "build_national_output", fake_build_national_output
         )
-        monkeypatch.setattr(sr, "_country_module", lambda c: "fake-country-module")
+        monkeypatch.setattr(
+            sr, "_country_module", lambda c: _bare_country_module()
+        )
 
         params = {**NATIONAL, "segmented": True, "_telemetry": {"run_id": "r"}}
         runner = _runner(FakeModal(_twenty_calls()), params=params)
@@ -178,7 +346,6 @@ class TestSegmentedNationalRunner:
         assert len(captured["children"]) == 20
         assert captured["country"] == "us"
         assert captured["year"] == 2026
-        assert captured["country_module"] == "fake-country-module"
         assert "segmented" not in captured["simulation_params"]
         assert "_telemetry" not in captured["simulation_params"]
 

--- a/projects/policyengine-simulation-executor/tests/test_segmented_national.py
+++ b/projects/policyengine-simulation-executor/tests/test_segmented_national.py
@@ -185,3 +185,45 @@ class TestSegmentedNationalRunner:
     def test__uk_has_no_partition_to_run(self):
         with pytest.raises(ValueError, match="No national partition"):
             _runner(FakeModal([]), params={"country": "uk", "scope": "macro"})
+
+
+class TestDispatchRunSimulation:
+    def test__eligible_national_takes_the_segmented_path(self, monkeypatch):
+        calls = {}
+
+        def fake_segmented(params, *, app_name):
+            calls["segmented"] = (params, app_name)
+            return {"segmented": True}
+
+        monkeypatch.setattr(sn, "run_segmented_national_impl", fake_segmented)
+        monkeypatch.setattr(
+            sr,
+            "run_simulation_impl",
+            lambda params: pytest.fail("monolithic path must not run"),
+        )
+        result = sn.dispatch_run_simulation(dict(NATIONAL), app_name="app-x")
+        assert result == {"segmented": True}
+        assert calls["segmented"][1] == "app-x"
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {**NATIONAL, "segmented": False},
+            {**NATIONAL, "region": "state/ut"},
+            {"country": "uk", "scope": "macro"},
+        ],
+    )
+    def test__everything_else_takes_the_monolithic_path(
+        self, monkeypatch, params
+    ):
+        monkeypatch.setattr(
+            sn,
+            "run_segmented_national_impl",
+            lambda *a, **k: pytest.fail("segmented path must not run"),
+        )
+        monkeypatch.setattr(
+            sr, "run_simulation_impl", lambda params: {"monolithic": True}
+        )
+        assert sn.dispatch_run_simulation(params, app_name="app-x") == {
+            "monolithic": True
+        }

--- a/projects/policyengine-simulation-executor/tests/test_segmented_national.py
+++ b/projects/policyengine-simulation-executor/tests/test_segmented_national.py
@@ -1,0 +1,187 @@
+"""Unit tests for the segmented-national fan-out runner (C5)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.modal import segmented_national as sn
+from policyengine_simulation_executor import simulation_runtime as sr
+
+
+NATIONAL = {"country": "us", "scope": "macro", "time_period": "2026"}
+
+
+class TestShouldRunSegmentedNational:
+    def test__plain_us_national_macro_is_eligible(self):
+        assert sn.should_run_segmented_national(dict(NATIONAL)) is True
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"region": "state/ut"},
+            {"region_group": ["state/hi", "state/ia"]},
+            {"segmented": False},
+            {"country": "uk"},
+            {"scope": "household"},
+            {"scope": None},
+            {"include_cliffs": True},
+        ],
+    )
+    def test__ineligible_variants(self, overrides):
+        params = {**NATIONAL, **overrides}
+        assert sn.should_run_segmented_national(params) is False
+
+    def test__explicit_segmented_true_is_eligible(self):
+        assert (
+            sn.should_run_segmented_national({**NATIONAL, "segmented": True})
+            is True
+        )
+
+
+class TestBuildGroupChildPayload:
+    def test__scopes_to_group_and_requests_microdata(self):
+        params = {**NATIONAL, "reform": {"x": 1}, "segmented": True}
+        payload = sn.build_group_child_payload(params, ["state/hi", "state/ia"])
+        assert payload["region_group"] == ["state/hi", "state/ia"]
+        assert payload["_emit_microdata"] is True
+        assert payload["reform"] == {"x": 1}
+        assert "segmented" not in payload
+        assert "_metadata" not in payload
+
+    def test__reattaches_telemetry_only_when_present(self):
+        with_telemetry = sn.build_group_child_payload(
+            {**NATIONAL, "_telemetry": {"run_id": "r1"}}, ["state/ca"]
+        )
+        assert with_telemetry["_telemetry"] == {"run_id": "r1"}
+        without = sn.build_group_child_payload(dict(NATIONAL), ["state/ca"])
+        assert "_telemetry" not in without
+
+    def test__never_forwards_parent_metadata(self):
+        payload = sn.build_group_child_payload(
+            {**NATIONAL, "_metadata": {"resolved_app_name": "x"}}, ["state/ca"]
+        )
+        assert "_metadata" not in payload
+
+
+class FakeCall:
+    """A FunctionCall whose result resolves after N polls (or raises)."""
+
+    def __init__(self, result, polls_until_ready=0, error=None):
+        self.result = result
+        self.polls_until_ready = polls_until_ready
+        self.error = error
+        self.cancelled = False
+
+    def get(self, timeout):
+        if self.error is not None:
+            raise self.error
+        if self.polls_until_ready > 0:
+            self.polls_until_ready -= 1
+            raise TimeoutError
+        return self.result
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class FakeModal:
+    def __init__(self, calls):
+        self._calls = list(calls)
+        self.spawned_payloads = []
+        self.from_name_args = None
+        fake = self
+
+        class _Function:
+            @staticmethod
+            def from_name(app_name, function_name):
+                fake.from_name_args = (app_name, function_name)
+                return SimpleNamespace(spawn=fake._spawn)
+
+        self.Function = _Function
+
+    def _spawn(self, payload):
+        self.spawned_payloads.append(payload)
+        return self._calls[len(self.spawned_payloads) - 1]
+
+
+def _runner(fake_modal, params=None):
+    return sn.SegmentedNationalRunner(
+        params or dict(NATIONAL),
+        app_name="policyengine-simulation-py-test",
+        modal_module=fake_modal,
+        poll_interval_seconds=0.001,
+        poll_interval_max_seconds=0.002,
+    )
+
+
+def _twenty_calls(**kwargs):
+    return [FakeCall({"child": i}, **kwargs) for i in range(20)]
+
+
+class TestSegmentedNationalRunner:
+    def test__spawns_one_child_per_partition_group(self, monkeypatch):
+        fake = FakeModal(_twenty_calls())
+        runner = _runner(fake)
+        monkeypatch.setattr(runner, "_reduce", lambda results: {"ok": results})
+
+        result = runner.run()
+
+        assert fake.from_name_args == (
+            "policyengine-simulation-py-test",
+            "run_simulation",
+        )
+        assert len(fake.spawned_payloads) == 20
+        groups = [p["region_group"] for p in fake.spawned_payloads]
+        assert groups == [list(g) for g in runner.groups]
+        assert all(p["_emit_microdata"] is True for p in fake.spawned_payloads)
+        # Results arrive in group order regardless of completion order.
+        assert result == {"ok": [{"child": i} for i in range(20)]}
+
+    def test__collects_out_of_order_completions_in_group_order(
+        self, monkeypatch
+    ):
+        calls = [
+            FakeCall({"child": i}, polls_until_ready=(19 - i) % 3)
+            for i in range(20)
+        ]
+        runner = _runner(FakeModal(calls))
+        monkeypatch.setattr(runner, "_reduce", lambda results: results)
+        assert runner.run() == [{"child": i} for i in range(20)]
+
+    def test__child_failure_fails_fast_and_cancels_the_rest(self, monkeypatch):
+        calls = _twenty_calls(polls_until_ready=5)
+        calls[7] = FakeCall(None, error=ValueError("boom"))
+        runner = _runner(FakeModal(calls))
+        monkeypatch.setattr(runner, "_reduce", lambda results: results)
+
+        with pytest.raises(RuntimeError, match="Segmented national child failed"):
+            runner.run()
+        assert all(c.cancelled for c in calls if c.error is None)
+
+    def test__reduce_receives_clean_params_and_all_children(self, monkeypatch):
+        captured = {}
+
+        def fake_build_national_output(child_results, **kwargs):
+            captured["children"] = child_results
+            captured.update(kwargs)
+            return {"budget": {}}
+
+        monkeypatch.setattr(
+            sn, "build_national_output", fake_build_national_output
+        )
+        monkeypatch.setattr(sr, "_country_module", lambda c: "fake-country-module")
+
+        params = {**NATIONAL, "segmented": True, "_telemetry": {"run_id": "r"}}
+        runner = _runner(FakeModal(_twenty_calls()), params=params)
+        assert runner.run() == {"budget": {}}
+
+        assert len(captured["children"]) == 20
+        assert captured["country"] == "us"
+        assert captured["year"] == 2026
+        assert captured["country_module"] == "fake-country-module"
+        assert "segmented" not in captured["simulation_params"]
+        assert "_telemetry" not in captured["simulation_params"]
+
+    def test__uk_has_no_partition_to_run(self):
+        with pytest.raises(ValueError, match="No national partition"):
+            _runner(FakeModal([]), params={"country": "uk", "scope": "macro"})

--- a/projects/policyengine-simulation-executor/tests/test_segmented_national_reduce.py
+++ b/projects/policyengine-simulation-executor/tests/test_segmented_national_reduce.py
@@ -20,7 +20,7 @@ from policyengine_simulation_executor.segmented_national_reduce import (
 )
 
 
-def _child(household_ids, incomes):
+def _child(household_ids, incomes, **extra):
     """A minimal child output dict with a _microdata payload."""
     frame = {
         "household_id": list(household_ids),
@@ -34,8 +34,8 @@ def _child(household_ids, incomes):
     }
     return {
         "budget": {"budgetary_impact": -1.0},
+        **extra,
         "_microdata": {
-            "entities": ["household"],
             "baseline": {"household": frame},
             "reform": {"household": frame},
             "dtypes": {
@@ -158,3 +158,45 @@ class TestBuildNationalOutputWiring:
                 country_module=SimpleNamespace(model=object()),
                 year=2026,
             )
+
+    def test__propagates_child_versions_over_builder_fallbacks(
+        self, monkeypatch
+    ):
+        # The rebuilt dataset has no artifact metadata, so the builder's
+        # version fallbacks misreport provenance; the children loaded the
+        # real artifact and their reported versions win.
+        class FakeBuilder:
+            def __init__(self, **kwargs):
+                pass
+
+            def serialize(self):
+                return {
+                    "model_version": "bundle-fallback",
+                    "data_version": "bundle-fallback",
+                }
+
+        monkeypatch.setattr(reduce_mod, "SimulationOutputBuilder", FakeBuilder)
+        monkeypatch.setattr(
+            reduce_mod,
+            "PrecomputedSimulation",
+            lambda **kwargs: SimpleNamespace(output_dataset=None, **kwargs),
+        )
+        monkeypatch.setattr(
+            reduce_mod,
+            "_us_dataset_from_frames",
+            lambda frames, *, year: SimpleNamespace(frames=frames, year=year),
+        )
+
+        children = [
+            _child([1], [10], model_version="1.764.6", data_version="buildm-x"),
+            _child([2], [20], model_version="1.764.6", data_version="buildm-x"),
+        ]
+        result = build_national_output(
+            children,
+            country="us",
+            simulation_params={"country": "us", "scope": "macro"},
+            country_module=SimpleNamespace(model=object()),
+            year=2026,
+        )
+        assert result["model_version"] == "1.764.6"
+        assert result["data_version"] == "buildm-x"

--- a/projects/policyengine-simulation-executor/tests/test_segmented_national_reduce.py
+++ b/projects/policyengine-simulation-executor/tests/test_segmented_national_reduce.py
@@ -1,0 +1,160 @@
+"""Unit tests for the segmented-national reduce (C4).
+
+Full-fidelity reduce-vs-direct parity runs on staging (C7); these tests pin
+the pure mechanics: concatenation order, dtype restoration, the no-recompute
+guarantee of PrecomputedSimulation, and the builder wiring.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from policyengine_simulation_executor import segmented_national_reduce as reduce_mod
+from policyengine_simulation_executor.segmented_national_reduce import (
+    PrecomputedSimulation,
+    _us_dataset_from_frames,
+    build_national_output,
+    concatenate_microdata,
+)
+
+
+def _child(household_ids, incomes):
+    """A minimal child output dict with a _microdata payload."""
+    frame = {
+        "household_id": list(household_ids),
+        "household_net_income": [float(x) for x in incomes],
+        "household_weight": [1.0] * len(household_ids),
+    }
+    dtypes = {
+        "household_id": "int64",
+        "household_net_income": "float32",
+        "household_weight": "float32",
+    }
+    return {
+        "budget": {"budgetary_impact": -1.0},
+        "_microdata": {
+            "entities": ["household"],
+            "baseline": {"household": frame},
+            "reform": {"household": frame},
+            "dtypes": {
+                "baseline": {"household": dtypes},
+                "reform": {"household": dtypes},
+            },
+        },
+    }
+
+
+class TestConcatenateMicrodata:
+    def test__concatenates_in_child_order(self):
+        sides = concatenate_microdata([_child([1, 2], [10, 20]), _child([3], [30])])
+        household = sides["baseline"]["household"]
+        assert list(household["household_id"]) == [1, 2, 3]
+        assert list(household["household_net_income"]) == [10.0, 20.0, 30.0]
+
+    def test__restores_source_dtypes(self):
+        sides = concatenate_microdata([_child([1], [10]), _child([2], [20])])
+        assert str(sides["reform"]["household"]["household_net_income"].dtype) == (
+            "float32"
+        )
+
+    def test__rejects_child_without_microdata(self):
+        with pytest.raises(ValueError, match="no _microdata"):
+            concatenate_microdata([_child([1], [10]), {"budget": {}}])
+
+    def test__rejects_empty_input(self):
+        with pytest.raises(ValueError, match="No child outputs"):
+            concatenate_microdata([])
+
+
+class TestPrecomputedSimulation:
+    def test__ensure_never_computes(self, monkeypatch):
+        def boom(self):
+            raise AssertionError("RECOMPUTE ATTEMPTED")
+
+        monkeypatch.setattr(PrecomputedSimulation, "run", boom)
+        simulation = PrecomputedSimulation()
+        assert simulation.ensure() is None
+
+
+class TestUSDatasetFromFrames:
+    def test__wraps_entities_with_weight_columns(self):
+        frames = {
+            entity: pd.DataFrame(
+                {
+                    f"{entity}_id": [1, 2],
+                    f"{entity}_weight": np.array([2.0, 3.0], dtype=np.float32),
+                }
+            )
+            for entity in (
+                "person",
+                "marital_unit",
+                "family",
+                "spm_unit",
+                "tax_unit",
+                "household",
+            )
+        }
+        dataset = _us_dataset_from_frames(frames, year=2026)
+        assert dataset.year == 2026
+        assert dataset.filepath is None
+        assert float(dataset.data.household.weights.sum()) == 5.0
+
+
+class TestBuildNationalOutputWiring:
+    def test__runs_existing_builder_over_stand_ins(self, monkeypatch):
+        captured = {}
+
+        class FakeBuilder:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def serialize(self):
+                return {"budget": {"budgetary_impact": -42.0}}
+
+        class FakeStandIn:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.output_dataset = None
+
+        monkeypatch.setattr(reduce_mod, "SimulationOutputBuilder", FakeBuilder)
+        monkeypatch.setattr(reduce_mod, "PrecomputedSimulation", FakeStandIn)
+        monkeypatch.setattr(
+            reduce_mod,
+            "_us_dataset_from_frames",
+            lambda frames, *, year: SimpleNamespace(frames=frames, year=year),
+        )
+
+        country_module = SimpleNamespace(model=object())
+        result = build_national_output(
+            [_child([1], [10]), _child([2], [20])],
+            country="us",
+            simulation_params={"country": "us", "scope": "macro"},
+            country_module=country_module,
+            year=2026,
+        )
+
+        assert result == {"budget": {"budgetary_impact": -42.0}}
+        assert captured["resolved_region_code"] == "us"
+        assert captured["country"] == "us"
+        # Both stand-ins carry the injected output_dataset.
+        assert captured["baseline"].output_dataset is captured["baseline"].kwargs[
+            "dataset"
+        ]
+        assert captured["reform"].output_dataset is captured["reform"].kwargs[
+            "dataset"
+        ]
+        assert captured["baseline"].kwargs["tax_benefit_model_version"] is (
+            country_module.model
+        )
+
+    def test__rejects_non_us(self):
+        with pytest.raises(ValueError, match="US only"):
+            build_national_output(
+                [_child([1], [10])],
+                country="uk",
+                simulation_params={},
+                country_module=SimpleNamespace(model=object()),
+                year=2026,
+            )

--- a/projects/policyengine-simulation-executor/tests/test_simulation_microdata.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_microdata.py
@@ -30,9 +30,12 @@ def _fake_sim(net_income):
 
 
 class TestExtractOutputMicrodata:
-    def test__entities_derive_from_the_models_entity_data(self):
+    def test__entity_tables_derive_from_the_models_entity_data(self):
         out = extract_output_microdata(_fake_sim(100.0), _fake_sim(120.0))
-        assert out["entities"] == ["person", "household"]
+        # The payload's entity list IS the baseline dict's keys — no
+        # separate "entities" field to drift out of sync.
+        assert list(out["baseline"]) == ["person", "household"]
+        assert list(out["reform"]) == ["person", "household"]
 
     def test__dumps_baseline_and_reform_per_entity(self):
         out = extract_output_microdata(_fake_sim(100.0), _fake_sim(120.0))

--- a/projects/policyengine-simulation-executor/tests/test_simulation_microdata.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_microdata.py
@@ -1,11 +1,13 @@
-"""Unit tests for the map-reduce microdata payload (B4)."""
+"""Unit tests for the map-reduce microdata payload (B4 + C3 dtype transport)."""
 
 from types import SimpleNamespace
 
+import numpy as np
 import pandas as pd
 
 from policyengine_simulation_executor.simulation_microdata import (
     extract_output_microdata,
+    rebuild_entity_frame,
 )
 
 
@@ -17,7 +19,10 @@ def _fake_sim(net_income):
                 {"person_id": [1, 2], "household_id": [1, 1], "age": [30, 40]}
             ),
             "household": pd.DataFrame(
-                {"household_id": [1], "household_net_income": [net_income]}
+                {
+                    "household_id": [1],
+                    "household_net_income": np.array([net_income], dtype=np.float32),
+                }
             ),
         }
     )
@@ -40,7 +45,30 @@ class TestExtractOutputMicrodata:
         assert out["baseline"]["person"]["household_id"] == [1, 1]
         assert out["baseline"]["person"]["person_id"] == [1, 2]
 
-    def test__roundtrips_back_to_dataframe(self):
+    def test__carries_source_dtypes_per_side_and_entity(self):
+        out = extract_output_microdata(_fake_sim(100.0), _fake_sim(120.0))
+        for side in ("baseline", "reform"):
+            assert (
+                out["dtypes"][side]["household"]["household_net_income"] == "float32"
+            )
+            assert "person_id" in out["dtypes"][side]["person"]
+
+
+class TestRebuildEntityFrame:
+    def test__float32_column_survives_the_round_trip(self):
+        # The B5 regression: a plain to_dict("list") -> DataFrame round trip
+        # widens float32 to float64 and shifts weighted aggregates ~1e-7.
         out = extract_output_microdata(_fake_sim(42.0), _fake_sim(42.0))
-        df = pd.DataFrame(out["baseline"]["household"])
-        assert list(df["household_net_income"]) == [42.0]
+        df = rebuild_entity_frame(
+            out["baseline"]["household"], out["dtypes"]["baseline"]["household"]
+        )
+        assert str(df["household_net_income"].dtype) == "float32"
+        assert list(df["household_net_income"]) == [np.float32(42.0)]
+
+    def test__missing_dtypes_fall_back_to_inference(self):
+        df = rebuild_entity_frame({"x": [1, 2]}, None)
+        assert list(df["x"]) == [1, 2]
+
+    def test__uncastable_dtype_is_tolerated(self):
+        df = rebuild_entity_frame({"x": ["a", "b"]}, {"x": "float32"})
+        assert list(df["x"]) == ["a", "b"]

--- a/projects/policyengine-simulation-gateway/tests/golden/openapi.json
+++ b/projects/policyengine-simulation-gateway/tests/golden/openapi.json
@@ -540,6 +540,17 @@
             ],
             "title": "Data Version"
           },
+          "segmented": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Segmented"
+          },
           "start_year": {
             "type": "string",
             "title": "Start Year"
@@ -1197,6 +1208,17 @@
               }
             ],
             "title": "Data Version"
+          },
+          "segmented": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Segmented"
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
Fixes #636

## What

Plain US national macro requests now fan out across a static 20-group partition of whole states (one `region_group` child per group, spawned back into the same worker app), and the children's computed microdata reduces into the identical national `SingleYearMacroOutput` via the existing `SimulationOutputBuilder` — no model recompute, no new endpoints, no gateway changes. `segmented: false` (new optional contract field) forces the old monolithic path.

Measured on the isolated staging benchmark app (Build M): **~4 min cold** for a segmented national vs 20-25 min monolithic, with the reduced budget equal to the sum of the 20 children to float epsilon (worst 2.1e-16), a full 436-district table including the seven at-large districts the deploy-time integration test asserts, and the `state/ut` monolithic regression unchanged.

## Why

Build M monolithic nationals straddle the deploy pipeline's 25-minute national integration budget: the 4.21.1 deploy (#629) timed out on `test_calculate_default_model`, and the #635 deploy passed it with minutes to spare. This makes every deploy a coin flip and every national request a 20+ minute wait. Segmentation is the mitigation the region-group mechanism (#635) was built for.

## How

- `segmented` optional bool on `GatewayRequestBase` (opt-out knob; gateway passes it through verbatim; OpenAPI golden regenerated — additive-only diff).
- `national_partition.py`: checked-in household-balanced 20-group partition (all 51 states exactly once; 2,440-3,042 sample households per group).
- `simulation_microdata.py`: the payload now carries per-column source dtypes; `rebuild_entity_frame` casts back so the reduce is bit-exact (float32 otherwise widens to float64, ~1e-7 drift).
- `segmented_national_reduce.py`: concatenates children's microdata into national entity tables and runs the existing builder over `PrecomputedSimulation` stand-ins (`ensure()` no-op subclass — the base implementation consults cache/disk, not the injected `output_dataset`, and would silently re-run the model).
- `src/modal/segmented_national.py`: eligibility gate + fan-out runner mirroring `BudgetWindowBatchRunner` (spawn all, poll with backoff, fail fast with best-effort cancel); no state store — parent failure surfaces exactly like a monolithic failure.
- `run_simulation` routes through `dispatch_run_simulation`; budget-window children are pinned `segmented=false` (nested fan-out is a deliberate follow-up).

Ineligible (monolithic fallback): regional/household-scope/UK requests, `segmented: false`, and `include_cliffs` (cliff reconstruction through the reduce is not yet validated).

## Tests

- Contract: `segmented` round-trips; golden green (57 passed).
- Executor: partition invariants, dtype round-trip regression, reduce mechanics with recompute booby-trap, runner eligibility matrix + fail-fast + out-of-order collection, dispatch routing, budget-window pin (219 passed).
- Observability: 18 passed (two new segment names).
- Staging (isolated throwaway app, not the deploy pipeline): full segmented national + INV-2 reconciliation + district/section assertions + monolithic regression — all pass (log in the C7 section of the plan doc).

Merging this should take the deploy-time national integration test from ~20-25 min (timeout-prone) to ~4-5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)