### PR TITLE
Strip underscore-prefixed keys from logging redaction

### DIFF
--- a/projects/policyengine-simulation-executor/src/modal/logging_redaction.py
+++ b/projects/policyengine-simulation-executor/src/modal/logging_redaction.py
@@ -10,11 +10,10 @@ from __future__ import annotations
 
 # Keys in request payloads that must never reach observability backends.
 # ``data`` is a signed GCS/HF URL (may contain embedded short-lived
-# credentials), the reform/baseline parameter trees are potentially large
-# and reveal proprietary policy design, and ``_telemetry`` / ``_metadata``
-# hold internal routing and correlation fields we log separately via
-# dedicated structured attributes.
-SENSITIVE_PARAM_KEYS = ("data", "reform", "baseline", "_telemetry", "_metadata")
+# credentials), and the reform/baseline parameter trees are potentially
+# large and reveal proprietary policy design. Internal control/routing keys
+# are stripped separately by the underscore rule below.
+SENSITIVE_PARAM_KEYS = ("data", "reform", "baseline")
 
 
 def redact_params_for_logging(params) -> dict:
@@ -24,14 +23,22 @@ def redact_params_for_logging(params) -> dict:
     period, etc.) so operators can still trace which simulation a span
     corresponds to, but strip any field that may contain URLs with signed
     credentials or arbitrarily large user-submitted parameter trees.
-    Non-dict inputs return an empty dict so callers can splat the result
-    into operation attributes without additional guards.
+
+    Underscore-prefixed keys (``_telemetry``, ``_metadata``,
+    ``_emit_microdata``, and any future internal flag) are dropped: they are
+    internal control/routing fields, and observability backends reject
+    attribute keys that start with an underscore — so leaking one crashes
+    the span rather than merely over-logging. Correlation ids are surfaced
+    explicitly below. Non-dict inputs return an empty dict so callers can
+    splat the result into operation attributes without additional guards.
     """
 
     if not isinstance(params, dict):
         return {}
     redacted = {
-        key: value for key, value in params.items() if key not in SENSITIVE_PARAM_KEYS
+        key: value
+        for key, value in params.items()
+        if key not in SENSITIVE_PARAM_KEYS and not key.startswith("_")
     }
     # Surface only the correlation/run ids from telemetry, not the whole
     # envelope.

--- a/projects/policyengine-simulation-executor/tests/test_app_redaction.py
+++ b/projects/policyengine-simulation-executor/tests/test_app_redaction.py
@@ -37,6 +37,29 @@ def test_redact_params_strips_signed_urls_and_reform_bodies():
     assert all("SECRET" not in str(value) for value in redacted.values())
 
 
+def test_redact_params_strips_all_underscore_prefixed_keys():
+    """Underscore-prefixed internal keys must never reach observability
+    attributes: the backend rejects attribute keys starting with '_', so a
+    leaked key crashes the span. Regression for the segmented-national
+    child failure where `_emit_microdata` reached operation() (#640)."""
+    params = {
+        "country": "us",
+        "scope": "macro",
+        "region_group": ["state/hi", "state/ia"],
+        "_emit_microdata": True,
+        "_telemetry": {"run_id": "run-9"},
+        "_metadata": {"resolved_app_name": "x"},
+    }
+
+    redacted = redact_params_for_logging(params)
+
+    assert redacted["country"] == "us"
+    assert redacted["region_group"] == ["state/hi", "state/ia"]
+    assert redacted["run_id"] == "run-9"
+    # No underscore-prefixed key survives — this is what the backend forbids.
+    assert not any(key.startswith("_") for key in redacted)
+
+
 def test_redact_params_tolerates_non_dict_input():
     assert redact_params_for_logging(None) == {}
     assert redact_params_for_logging("string-payload") == {}


### PR DESCRIPTION
Fixes #640

## What

`redact_params_for_logging` now drops **all** underscore-prefixed keys, not just the hardcoded `_telemetry`/`_metadata`. Correlation ids are still surfaced explicitly.

## Why

Merging #637 turned segmented national on, and the deploy failed at beta integration: every segmented-national child (`run_simulation_segment`) crashed **before running any simulation**, in its observability wrapper —

```
File "/root/app.py", line 324, in run_simulation_segment
ValueError: Attribute keys cannot start with an underscore.
```

Child payloads carry `_emit_microdata: True` (required — it drives the child's microdata emission for the reduce). `run_simulation_segment` splats `redact_params_for_logging(params)` into `operation(..., **redacted_params)`; `_emit_microdata` survived redaction and reached the observability backend as an attribute key, which the backend rejects. The parent (`run_simulation`) never carries `_emit_microdata`, so only the children crashed — the fan-out mechanics and fail-fast otherwise worked. Prod was gated (skipped) and is unaffected; main's deploy pipeline is red until this lands.

#637's staging validation (C7) missed it because the throwaway benchmark's `run_simulation_segment` called `run_simulation_impl` directly with no observability wrapper — the exact wrapper that fails.

## Fix scope

One rule in `logging_redaction.py` (`not key.startswith("_")`) covers all three splat sites (`run_simulation`, `run_simulation_segment`, `run_budget_window_batch`), and future-proofs any new internal `_`-key. `redacted_params` feeds only observability attributes — nothing functional depends on it; the real params reach `run_simulation_impl` untouched.

## Tests

- `test_app_redaction.py`: new regression asserting no `_`-prefixed key survives redaction while routing context + `run_id` are preserved (4 pass).
- Full confirmation of the child path is the deploy pipeline's national integ test, fail-closed before prod. After this, the child runs the exact code path C7 validated end-to-end (microdata emit + reduce, bit-exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)