### PR TITLE
Add artifact-pipeline keys, store, runtime reader, and precompute app

### DIFF
--- a/projects/policyengine-simulation-executor/README.md
+++ b/projects/policyengine-simulation-executor/README.md
@@ -75,9 +75,14 @@ Operational notes:
   run plans against the store and computes only misses. A re-run against a
   warm store is a fast no-op. Version bumps rotate the keys and trigger
   recompute automatically — there is no staleness to manage.
-- Uploads are write-once. `--force` recomputes everything but cannot
-  replace an existing object; to heal a suspected-bad artifact, delete its
-  object from the bucket first, then re-run (with or without `--force`).
+- Uploads are write-once, by policy, not accident: an existing store
+  object is never overwritten by anything, including `--force` (which
+  recomputes and re-verifies but uploads nothing for existing keys). This
+  buys concurrent-warmer race safety, artifact auditability (verified
+  bytes can never drift), and protection against stale-code runners
+  clobbering trusted artifacts. The heal procedure for a bad artifact is
+  therefore always: delete its object from the bucket, then re-run the
+  precompute — deletion turns the key back into an ordinary miss.
 - A determinism gate runs whenever baselines were computed: one cohort's
   uploaded artifact is compared frame-by-frame against an independent
   fresh run. The run fails if they differ.

--- a/projects/policyengine-simulation-executor/README.md
+++ b/projects/policyengine-simulation-executor/README.md
@@ -59,7 +59,7 @@ The precompute app fills a content-addressed GCS store with single-year US
 datasets (2026, 2027, 2025) and the 20 per-cohort national baseline
 simulations per year, so a later deploy can bake them into the image and
 the runtime can load baselines instead of computing them. Library logic
-lives in `policyengine_simulation_executor/precompute.py` (keys:
+lives in `src/policyengine_simulation_executor/precompute.py` (keys:
 `artifact_keys.py`, store client: `artifact_store.py`); the Modal app
 (`src/modal/precompute_app.py`) is plumbing only.
 

--- a/projects/policyengine-simulation-executor/README.md
+++ b/projects/policyengine-simulation-executor/README.md
@@ -53,6 +53,37 @@ Operational notes:
   explicit `data` dataset or pinning a `data_version` bypasses it (see
   `_load_dataset` in `simulation_runtime.py`).
 
+## Artifact precompute (baseline artifact pipeline, phase 1)
+
+The precompute app fills a content-addressed GCS store with single-year US
+datasets (2026, 2027, 2025) and the 20 per-cohort national baseline
+simulations per year, so a later deploy can bake them into the image and
+the runtime can load baselines instead of computing them. Library logic
+lives in `policyengine_simulation_executor/precompute.py` (keys:
+`artifact_keys.py`, store client: `artifact_store.py`); the Modal app
+(`src/modal/precompute_app.py`) is plumbing only.
+
+Run it manually (phase 1; a CI deploy job takes over in a later phase):
+
+    export POLICYENGINE_ARTIFACT_BUCKET=<bucket-name>
+    uv run modal run --env=staging src/modal/precompute_app.py
+
+Operational notes:
+
+- Idempotent by construction: artifact keys digest the full input closure
+  (package versions, data content sha, certification fingerprint), so the
+  run plans against the store and computes only misses. A re-run against a
+  warm store is a fast no-op. Version bumps rotate the keys and trigger
+  recompute automatically — there is no staleness to manage.
+- Uploads are write-once. `--force` recomputes everything but cannot
+  replace an existing object; to heal a suspected-bad artifact, delete its
+  object from the bucket first, then re-run (with or without `--force`).
+- A determinism gate runs whenever baselines were computed: one cohort's
+  uploaded artifact is compared frame-by-frame against an independent
+  fresh run. The run fails if they differ.
+- The final stdout line `MANIFEST_DIGEST=<digest>` names the published
+  deploy manifest; the deploy pipeline consumes exactly that line.
+
 ## Observability
 
 The service currently runs two observability backends in parallel:

--- a/projects/policyengine-simulation-executor/fixtures/fake_modal.py
+++ b/projects/policyengine-simulation-executor/fixtures/fake_modal.py
@@ -1,0 +1,83 @@
+"""Shared fake `modal` module for image/app declaration tests.
+
+Extracted from test_modal_bundle_image so every test lane asserting Modal
+image layers or function declarations uses one recording fake instead of
+a per-file copy. The fakes record calls; they run nothing.
+"""
+
+import sys
+from types import ModuleType
+
+
+class FakeImage:
+    def __init__(self):
+        self.calls = []
+
+    @classmethod
+    def debian_slim(cls, python_version):
+        image = cls()
+        image.calls.append(("debian_slim", python_version))
+        return image
+
+    def pip_install(self, *packages):
+        self.calls.append(("pip_install", packages))
+        return self
+
+    def pip_install_from_requirements(self, requirements_txt, **kwargs):
+        self.calls.append(("pip_install_from_requirements", requirements_txt, kwargs))
+        return self
+
+    def uv_sync(self, uv_project_dir="./", **kwargs):
+        self.calls.append(("uv_sync", uv_project_dir, kwargs))
+        return self
+
+    def run_commands(self, *commands, **kwargs):
+        self.calls.append(("run_commands", commands, kwargs))
+        return self
+
+    def env(self, env):
+        self.calls.append(("env", env))
+        return self
+
+    def add_local_python_source(self, *args, **kwargs):
+        self.calls.append(("add_local_python_source", args, kwargs))
+        return self
+
+    def run_function(self, function, **kwargs):
+        self.calls.append(("run_function", function.__name__, kwargs))
+        return self
+
+
+class FakeSecret:
+    @staticmethod
+    def from_name(*args, **kwargs):
+        return {"args": args, "kwargs": kwargs}
+
+
+class FakeApp:
+    def __init__(self, name):
+        self.name = name
+        self.function_calls = []
+
+    def function(self, **kwargs):
+        def decorator(function):
+            self.function_calls.append((function.__name__, kwargs))
+            return function
+
+        return decorator
+
+    def local_entrypoint(self, **kwargs):
+        def decorator(function):
+            return function
+
+        return decorator
+
+
+def install_fake_modal(monkeypatch):
+    modal = ModuleType("modal")
+    modal.Image = FakeImage
+    modal.Secret = FakeSecret
+    modal.App = FakeApp
+    modal.is_local = lambda: True
+    modal.asgi_app = lambda: lambda function: function
+    monkeypatch.setitem(sys.modules, "modal", modal)

--- a/projects/policyengine-simulation-executor/fixtures/identity_stubs.py
+++ b/projects/policyengine-simulation-executor/fixtures/identity_stubs.py
@@ -1,0 +1,63 @@
+"""Shared stubs for ``collect_dataset_identity``'s input seams.
+
+The key-discipline tests (test_artifact_keys) and the writer==reader
+contract tests (test_precompute) must stub the SAME seam list —
+``release_bundle.get_country_release_bundle``,
+``release_bundle._receipt_dataset``,
+``manifest.resolve_dataset_reference``, ``manifest.dataset_logical_name``,
+``manifest.get_release_manifest`` — or one suite silently tests a stale
+list when identity collection grows a seam. This is that list's one home.
+"""
+
+from types import SimpleNamespace
+
+
+def install_identity_stubs(monkeypatch):
+    """Stub the identity seams with the canonical synthetic version-set.
+
+    Returns a mutable state (``bundle``, ``receipt_entry``) so tests can
+    vary the receipt or bundle per case after installation.
+    """
+    from policyengine.provenance import manifest as manifest_module
+
+    from policyengine_simulation_executor import release_bundle
+
+    bundle = SimpleNamespace(
+        country="us",
+        policyengine_version="4.22.0",
+        model_version="9.9.9",
+        data_version="1.2.3",
+        data_artifact_revision="rev-abc",
+        default_dataset="populace_cps",
+    )
+    receipt_entry = {
+        "country": "us",
+        "version": "1.2.3",
+        "installed_sha256": "feedbead" * 8,
+    }
+    state = SimpleNamespace(bundle=bundle, receipt_entry=receipt_entry)
+
+    monkeypatch.setattr(
+        release_bundle, "get_country_release_bundle", lambda country: state.bundle
+    )
+    monkeypatch.setattr(
+        release_bundle, "_receipt_dataset", lambda country: state.receipt_entry
+    )
+    monkeypatch.setattr(
+        manifest_module,
+        "resolve_dataset_reference",
+        lambda country, dataset: f"hf://org/repo/{dataset}.h5@rev-abc",
+    )
+    monkeypatch.setattr(
+        manifest_module,
+        "dataset_logical_name",
+        lambda reference: state.bundle.default_dataset,
+    )
+    monkeypatch.setattr(
+        manifest_module,
+        "get_release_manifest",
+        lambda country: SimpleNamespace(
+            certification=SimpleNamespace(data_build_fingerprint="fp-123")
+        ),
+    )
+    return state

--- a/projects/policyengine-simulation-executor/pyproject.toml
+++ b/projects/policyengine-simulation-executor/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "modal>=0.73.0",
     "policyengine-observability[fastapi]>=1.3.0,<2",
     "logfire>=3.0.0",
+    # Imported directly by the artifact store client; do not rely on the
+    # transitive pin via policyengine.
+    "google-cloud-storage>=2",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -50,6 +53,10 @@ modal-simulation-image = [
     # but does not declare it (see issue #602).
     "importlib-metadata>=8",
     "policyengine-observability[fastapi]>=1.3.0,<2",
+    # The artifact fetch layer and store client read GCS. The lib is also a
+    # transitive dependency of policyengine, but the image must not depend
+    # on an upstream package keeping it.
+    "google-cloud-storage>=2",
 ]
 # The executor's budget-window scheduler tests exercise the gateway app
 # end-to-end; the gateway project rides in as a dev-only path dependency.

--- a/projects/policyengine-simulation-executor/src/modal/precompute_app.py
+++ b/projects/policyengine-simulation-executor/src/modal/precompute_app.py
@@ -1,35 +1,18 @@
 """Ephemeral precompute app: fill the artifact store for the installed bundle.
 
-Runs the write half of the artifact pipeline as a `modal run` (no deploy):
+Modal plumbing only — every function body lives in
+``policyengine_simulation_executor.precompute`` (the deployed app's split:
+thin decorated wrappers, library implementations). Run as a `modal run`
+(no deploy):
 
     uv run modal run --env=staging src/modal/precompute_app.py
     uv run modal run --env=staging src/modal/precompute_app.py --force
 
 Wave 1 builds the single-year US datasets (one container per year), wave 2
 computes the 20 per-cohort national baselines per year (one container per
-cohort, sized like the production ``run_simulation_segment`` workers). All
-store interaction and ALL identity collection happen inside containers —
-the container has the installed bundle receipt the keys digest, the local
-machine does not — so the local entrypoint only orchestrates spawns.
-
-The store is content-addressed, so this app is idempotent: it plans against
-the store first and spawns only missing work. A re-run against a warm store
-is a no-op that finishes in about a container start. ``--force`` recomputes
-everything (the escape hatch for a suspected bad artifact; uploads are
-write-once, so healing an EXISTING object additionally means deleting it
-first or bumping the key schema).
-
-Baselines are built through the executor's own request path
-(``_resolve_region`` + ``_build_simulation`` on a synthetic request), so
-scoping, extra variables, and the deterministic simulation id are the
-production child's by construction, not by convention. The budgetary-pair
-extras are applied exactly as ``economic_impact_analysis`` would before
-``ensure()``.
-
-A determinism gate (one cohort recomputed under a throwaway id and
-compared frame-by-frame) runs whenever baselines were computed — it is the
-direct check of the cache's core assumption that same key means same
-bytes.
+cohort, sized like the production ``run_simulation_segment`` workers). See
+the library module for the idempotency, ``--force``, and determinism-gate
+semantics.
 """
 
 from __future__ import annotations
@@ -45,13 +28,6 @@ from src.modal.app import (
 
 app = modal.App("policyengine-simulation-precompute")
 
-PRECOMPUTE_COUNTRY = "us"
-# The user-facing priority order (2026 first); with parallel waves it only
-# orders spawn submission, but keep it intentional.
-PRECOMPUTE_YEARS = [2026, 2027, 2025]
-
-MANIFEST_SCHEMA = "mf1"
-
 precompute_image = build_runtime_simulation_image().add_local_python_source(
     "src.modal",
     "policyengine_simulation_executor",
@@ -63,86 +39,6 @@ precompute_image = build_runtime_simulation_image().add_local_python_source(
 _worker_secrets = [gcp_secret, data_secret, hf_secret]
 
 
-def _cohort_params(year: int, group: list[str]) -> dict:
-    """The synthetic request a segmented-national child would receive."""
-    return {
-        "country": PRECOMPUTE_COUNTRY,
-        "scope": "macro",
-        "region_group": list(group),
-        "time_period": year,
-    }
-
-
-def _cohort_identity(year: int, group: list[str]):
-    """Identity via the executor's own resolution path (writer==reader)."""
-    from policyengine_simulation_executor.baseline_artifacts import (
-        qualifying_baseline_identity,
-    )
-    from policyengine_simulation_executor.simulation_runtime import (
-        _country_module,
-        _resolve_region,
-    )
-
-    params = _cohort_params(year, group)
-    country_module = _country_module(PRECOMPUTE_COUNTRY)
-    resolution = _resolve_region(
-        country_module=country_module,
-        country=PRECOMPUTE_COUNTRY,
-        params=params,
-    )
-    identity = qualifying_baseline_identity(
-        params,
-        country=PRECOMPUTE_COUNTRY,
-        policy=None,
-        region_code=resolution.code,
-        scoping_strategy=resolution.scoping_strategy,
-        year=year,
-    )
-    if identity is None:
-        raise RuntimeError(
-            f"Cohort request for year {year} group {group} does not qualify "
-            "for a deterministic baseline id — writer and reader predicates "
-            "have diverged."
-        )
-    return identity
-
-
-def select_work(plan: dict, *, force: bool) -> dict:
-    """Pure work selection: which plan entries need computing."""
-    datasets = [entry for entry in plan["datasets"] if force or not entry["exists"]]
-    baselines = [entry for entry in plan["baselines"] if force or not entry["exists"]]
-    return {"datasets": datasets, "baselines": baselines}
-
-
-def build_manifest_payload(plan: dict) -> dict:
-    """The deploy manifest: receipt + every artifact the image must fetch."""
-    artifacts = [
-        {
-            "type": "dataset",
-            "path": entry["path"],
-            "filename": entry["filename"],
-            "year": entry["year"],
-            "digest": entry["digest"],
-        }
-        for entry in plan["datasets"]
-    ] + [
-        {
-            "type": "baseline",
-            "path": entry["path"],
-            "filename": f"{entry['simulation_id']}.h5",
-            "year": entry["year"],
-            "digest": entry["digest"],
-        }
-        for entry in plan["baselines"]
-    ]
-    return {
-        "schema": MANIFEST_SCHEMA,
-        "country": PRECOMPUTE_COUNTRY,
-        "receipt": plan["receipt"],
-        "artifacts": artifacts,
-    }
-
-
 @app.function(
     image=precompute_image,
     cpu=4.0,
@@ -151,59 +47,9 @@ def build_manifest_payload(plan: dict) -> dict:
     secrets=_worker_secrets,
 )
 def plan_artifacts(bucket: str) -> dict:
-    """Compute every expected artifact identity and its store presence."""
-    from policyengine_simulation_executor.artifact_keys import (
-        collect_dataset_identity,
-    )
-    from policyengine_simulation_executor.artifact_store import ArtifactStore
-    from policyengine_simulation_executor.national_partition import (
-        national_region_groups,
-    )
-    from policyengine_simulation_executor.release_bundle import (
-        get_country_release_bundle,
-    )
+    from policyengine_simulation_executor.precompute import plan_artifacts_impl
 
-    store = ArtifactStore(bucket)
-    groups = national_region_groups(PRECOMPUTE_COUNTRY)
-    if not groups:
-        raise RuntimeError(f"No national partition for {PRECOMPUTE_COUNTRY!r}")
-
-    datasets = []
-    baselines = []
-    for year in PRECOMPUTE_YEARS:
-        dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
-        datasets.append(
-            {
-                "year": year,
-                "digest": dataset_identity.digest,
-                "path": dataset_identity.store_path,
-                "filename": dataset_identity.filename,
-                "exists": store.exists(dataset_identity.store_path),
-            }
-        )
-        for group in groups:
-            identity = _cohort_identity(year, group)
-            baselines.append(
-                {
-                    "year": year,
-                    "group": list(group),
-                    "region": identity.region,
-                    "digest": identity.digest,
-                    "path": identity.store_path,
-                    "simulation_id": identity.simulation_id,
-                    "exists": store.exists(identity.store_path),
-                }
-            )
-
-    bundle = get_country_release_bundle(PRECOMPUTE_COUNTRY)
-    receipt = {
-        "policyengine_version": bundle.policyengine_version,
-        "model_version": bundle.model_version,
-        "data_version": bundle.data_version,
-        "data_artifact_revision": bundle.data_artifact_revision,
-        "default_dataset": bundle.default_dataset,
-    }
-    return {"datasets": datasets, "baselines": baselines, "receipt": receipt}
+    return plan_artifacts_impl(bucket)
 
 
 @app.function(
@@ -214,106 +60,9 @@ def plan_artifacts(bucket: str) -> dict:
     secrets=_worker_secrets,
 )
 def build_dataset(bucket: str, year: int, expected_path: str) -> dict:
-    """Wave 1: build one single-year dataset and upload it."""
-    import os
-    import time
-    from importlib import import_module
-    from pathlib import Path
+    from policyengine_simulation_executor.precompute import build_dataset_impl
 
-    from policyengine_simulation_executor.artifact_keys import (
-        collect_dataset_identity,
-    )
-    from policyengine_simulation_executor.artifact_store import ArtifactStore
-    from policyengine_simulation_executor.release_bundle import (
-        get_country_release_bundle,
-    )
-
-    identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
-    if identity.store_path != expected_path:
-        raise RuntimeError(
-            "Planned and in-container dataset identities disagree "
-            f"({expected_path} != {identity.store_path}); refusing to upload "
-            "under a mismatched key."
-        )
-
-    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
-    country_module = import_module(
-        f"policyengine.tax_benefit_models.{PRECOMPUTE_COUNTRY}"
-    )
-    started = time.monotonic()
-    country_module.ensure_datasets(
-        datasets=[get_country_release_bundle(PRECOMPUTE_COUNTRY).default_dataset],
-        years=[year],
-        data_folder=data_folder,
-    )
-    build_seconds = time.monotonic() - started
-
-    local_file = Path(data_folder) / identity.filename
-    if not local_file.exists():
-        raise RuntimeError(f"ensure_datasets produced no file at {local_file}")
-    uploaded = ArtifactStore(bucket).upload_file(identity.store_path, local_file)
-    return {
-        "year": year,
-        "path": identity.store_path,
-        "uploaded": uploaded,
-        "build_seconds": round(build_seconds, 1),
-        "size_bytes": local_file.stat().st_size,
-    }
-
-
-def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
-    """Shared by compute and verify: dataset download + simulation build."""
-    import os
-    from pathlib import Path
-
-    from policyengine_simulation_executor.artifact_keys import (
-        collect_dataset_identity,
-    )
-    from policyengine_simulation_executor.artifact_store import ArtifactStore
-    from policyengine_simulation_executor.simulation_runtime import (
-        _build_simulation,
-        _country_module,
-        _load_dataset,
-        _resolve_region,
-    )
-
-    store = ArtifactStore(bucket)
-    data_folder = Path(
-        os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
-    )
-
-    dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
-    local_dataset = data_folder / dataset_identity.filename
-    if not local_dataset.exists():
-        store.download_file(dataset_identity.store_path, local_dataset)
-
-    params = _cohort_params(year, group)
-    country_module = _country_module(PRECOMPUTE_COUNTRY)
-    resolution = _resolve_region(
-        country_module=country_module,
-        country=PRECOMPUTE_COUNTRY,
-        params=params,
-    )
-    dataset = _load_dataset(
-        params, country_module=country_module, region_resolution=resolution
-    )
-    baseline = _build_simulation(
-        params,
-        dataset=dataset,
-        policy=None,
-        scoping_strategy=resolution.scoping_strategy,
-        region_code=resolution.code,
-    )
-
-    # The extras economic_impact_analysis applies unconditionally before
-    # ensure(); the artifact must carry them or every request would fail
-    # the column guard and recompute.
-    from policyengine.tax_benefit_models.us.analysis import (
-        configure_budgetary_impact_variables,
-    )
-
-    configure_budgetary_impact_variables(baseline, baseline)
-    return store, data_folder, baseline
+    return build_dataset_impl(bucket, year, expected_path)
 
 
 @app.function(
@@ -324,43 +73,9 @@ def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
     secrets=_worker_secrets,
 )
 def compute_baseline(bucket: str, year: int, group: list[str], expected: dict) -> dict:
-    """Wave 2: compute one cohort baseline and upload its output."""
-    import time
+    from policyengine_simulation_executor.precompute import compute_baseline_impl
 
-    from policyengine_simulation_executor.baseline_artifacts import (
-        ArtifactBaselineSimulation,
-    )
-
-    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
-    if not isinstance(baseline, ArtifactBaselineSimulation):
-        raise RuntimeError(
-            "Precompute built a plain Simulation — the qualifying predicate "
-            "rejected the cohort request shape."
-        )
-    if baseline.id != expected["simulation_id"]:
-        raise RuntimeError(
-            "Planned and in-container baseline ids disagree "
-            f"({expected['simulation_id']} != {baseline.id}); refusing to "
-            "upload under a mismatched key."
-        )
-
-    started = time.monotonic()
-    baseline.ensure()
-    compute_seconds = time.monotonic() - started
-
-    artifact_file = data_folder / f"{baseline.id}.h5"
-    if not artifact_file.exists():
-        raise RuntimeError(f"ensure() left no artifact at {artifact_file}")
-    uploaded = store.upload_file(expected["path"], artifact_file)
-    return {
-        "year": year,
-        "group": list(group),
-        "simulation_id": baseline.id,
-        "outcome": baseline.artifact_outcome,
-        "uploaded": uploaded,
-        "compute_seconds": round(compute_seconds, 1),
-        "size_bytes": artifact_file.stat().st_size,
-    }
+    return compute_baseline_impl(bucket, year, group, expected)
 
 
 @app.function(
@@ -373,59 +88,9 @@ def compute_baseline(bucket: str, year: int, group: list[str], expected: dict) -
 def verify_determinism(
     bucket: str, year: int, group: list[str], expected: dict
 ) -> dict:
-    """Load the uploaded artifact, recompute independently, compare frames.
+    from policyengine_simulation_executor.precompute import verify_determinism_impl
 
-    Exact comparison of every entity column (values and dtypes) between the
-    store artifact (downloaded and loaded through ``ensure()``, so the save/
-    load round-trip is under test too) and a fresh independent run — the
-    direct check of "same key, same bytes". File-level byte equality is
-    deliberately not used (HDF5 container metadata is not guaranteed
-    stable).
-    """
-    from policyengine.core import Simulation
-
-    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
-    if baseline.id != expected["simulation_id"]:
-        raise RuntimeError(
-            "Planned and in-container baseline ids disagree "
-            f"({expected['simulation_id']} != {baseline.id})"
-        )
-    artifact_file = data_folder / f"{baseline.id}.h5"
-    if not artifact_file.exists():
-        store.download_file(expected["path"], artifact_file)
-    baseline.ensure()
-    if baseline.artifact_outcome != "hit":
-        raise RuntimeError(
-            "Determinism gate could not load the artifact it verifies "
-            f"(outcome={baseline.artifact_outcome})"
-        )
-
-    fresh = Simulation(
-        dataset=baseline.dataset,
-        tax_benefit_model_version=baseline.tax_benefit_model_version,
-        policy=None,
-        scoping_strategy=baseline.scoping_strategy,
-        extra_variables=dict(baseline.extra_variables),
-    )
-    fresh.run()
-
-    differences = []
-    loaded = baseline.output_dataset.data.entity_data
-    recomputed = fresh.output_dataset.data.entity_data
-    for entity in sorted(set(loaded) | set(recomputed)):
-        left, right = loaded.get(entity), recomputed.get(entity)
-        if left is None or right is None:
-            differences.append(f"{entity}: missing on one side")
-            continue
-        left_cols, right_cols = set(left.columns), set(right.columns)
-        for column in sorted(left_cols ^ right_cols):
-            differences.append(f"{entity}.{column}: only on one side")
-        for column in sorted(left_cols & right_cols):
-            if str(left[column].dtype) != str(right[column].dtype):
-                differences.append(f"{entity}.{column}: dtype differs")
-            elif not left[column].equals(right[column]):
-                differences.append(f"{entity}.{column}: values differ")
-    return {"equal": not differences, "differences": differences[:50]}
+    return verify_determinism_impl(bucket, year, group, expected)
 
 
 @app.function(
@@ -436,65 +101,22 @@ def verify_determinism(
     secrets=_worker_secrets,
 )
 def publish_manifest(bucket: str, plan: dict) -> str:
-    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.precompute import publish_manifest_impl
 
-    return ArtifactStore(bucket).write_manifest(build_manifest_payload(plan))
+    return publish_manifest_impl(bucket, plan)
 
 
 @app.local_entrypoint()
 def main(force: bool = False):
-    from policyengine_simulation_executor.artifact_store import (
-        resolve_bucket_name,
+    from policyengine_simulation_executor.artifact_store import resolve_bucket_name
+    from policyengine_simulation_executor.precompute import run_precompute
+
+    run_precompute(
+        resolve_bucket_name(),
+        force=force,
+        plan_artifacts=plan_artifacts,
+        build_dataset=build_dataset,
+        compute_baseline=compute_baseline,
+        verify_determinism=verify_determinism,
+        publish_manifest=publish_manifest,
     )
-
-    bucket = resolve_bucket_name()
-    print(f"Planning against gs://{bucket} (force={force})")
-    plan = plan_artifacts.remote(bucket)
-    work = select_work(plan, force=force)
-    print(
-        f"Plan: {len(plan['datasets'])} datasets ({len(work['datasets'])} to "
-        f"build), {len(plan['baselines'])} baselines "
-        f"({len(work['baselines'])} to compute)"
-    )
-
-    dataset_handles = [
-        build_dataset.spawn(bucket, entry["year"], entry["path"])
-        for entry in work["datasets"]
-    ]
-    for handle in dataset_handles:
-        result = handle.get()
-        print(
-            f"dataset year={result['year']} built in "
-            f"{result['build_seconds']}s ({result['size_bytes']} bytes, "
-            f"uploaded={result['uploaded']})"
-        )
-
-    baseline_handles = [
-        compute_baseline.spawn(bucket, entry["year"], entry["group"], entry)
-        for entry in work["baselines"]
-    ]
-    for handle in baseline_handles:
-        result = handle.get()
-        print(
-            f"baseline year={result['year']} id={result['simulation_id']} "
-            f"outcome={result['outcome']} in {result['compute_seconds']}s "
-            f"(uploaded={result['uploaded']})"
-        )
-
-    if work["baselines"]:
-        probe = work["baselines"][0]
-        print(
-            f"Determinism gate: recomputing year={probe['year']} group={probe['group']}"
-        )
-        verdict = verify_determinism.remote(
-            bucket, probe["year"], probe["group"], probe
-        )
-        if not verdict["equal"]:
-            raise SystemExit(
-                "Determinism gate FAILED: " + "; ".join(verdict["differences"])
-            )
-        print("Determinism gate passed")
-
-    manifest_digest = publish_manifest.remote(bucket, plan)
-    # Parseable by CI: the deploy consumes exactly this line.
-    print(f"MANIFEST_DIGEST={manifest_digest}")

--- a/projects/policyengine-simulation-executor/src/modal/precompute_app.py
+++ b/projects/policyengine-simulation-executor/src/modal/precompute_app.py
@@ -39,6 +39,12 @@ precompute_image = build_runtime_simulation_image().add_local_python_source(
 _worker_secrets = [gcp_secret, data_secret, hf_secret]
 
 
+# Wrapper signatures use plain dicts: they sit on Modal's serialization
+# boundary. Each validates into the strict precompute_models schema on the
+# way in and dumps on the way out, so planner/worker shape drift fails
+# loudly at the edge.
+
+
 @app.function(
     image=precompute_image,
     cpu=4.0,
@@ -49,7 +55,7 @@ _worker_secrets = [gcp_secret, data_secret, hf_secret]
 def plan_artifacts(bucket: str) -> dict:
     from policyengine_simulation_executor.precompute import plan_artifacts_impl
 
-    return plan_artifacts_impl(bucket)
+    return plan_artifacts_impl(bucket).model_dump()
 
 
 @app.function(
@@ -59,10 +65,13 @@ def plan_artifacts(bucket: str) -> dict:
     timeout=2 * 60 * 60,
     secrets=_worker_secrets,
 )
-def build_dataset(bucket: str, year: int, expected_path: str) -> dict:
+def build_dataset(bucket: str, expected: dict) -> dict:
     from policyengine_simulation_executor.precompute import build_dataset_impl
+    from policyengine_simulation_executor.precompute_models import DatasetPlanEntry
 
-    return build_dataset_impl(bucket, year, expected_path)
+    return build_dataset_impl(
+        bucket, DatasetPlanEntry.model_validate(expected)
+    ).model_dump()
 
 
 @app.function(
@@ -72,10 +81,13 @@ def build_dataset(bucket: str, year: int, expected_path: str) -> dict:
     timeout=3600,
     secrets=_worker_secrets,
 )
-def compute_baseline(bucket: str, year: int, group: list[str], expected: dict) -> dict:
+def compute_baseline(bucket: str, expected: dict) -> dict:
     from policyengine_simulation_executor.precompute import compute_baseline_impl
+    from policyengine_simulation_executor.precompute_models import BaselinePlanEntry
 
-    return compute_baseline_impl(bucket, year, group, expected)
+    return compute_baseline_impl(
+        bucket, BaselinePlanEntry.model_validate(expected)
+    ).model_dump()
 
 
 @app.function(
@@ -85,12 +97,13 @@ def compute_baseline(bucket: str, year: int, group: list[str], expected: dict) -
     timeout=3600,
     secrets=_worker_secrets,
 )
-def verify_determinism(
-    bucket: str, year: int, group: list[str], expected: dict
-) -> dict:
+def verify_determinism(bucket: str, expected: dict) -> dict:
     from policyengine_simulation_executor.precompute import verify_determinism_impl
+    from policyengine_simulation_executor.precompute_models import BaselinePlanEntry
 
-    return verify_determinism_impl(bucket, year, group, expected)
+    return verify_determinism_impl(
+        bucket, BaselinePlanEntry.model_validate(expected)
+    ).model_dump()
 
 
 @app.function(
@@ -102,8 +115,9 @@ def verify_determinism(
 )
 def publish_manifest(bucket: str, plan: dict) -> str:
     from policyengine_simulation_executor.precompute import publish_manifest_impl
+    from policyengine_simulation_executor.precompute_models import PrecomputePlan
 
-    return publish_manifest_impl(bucket, plan)
+    return publish_manifest_impl(bucket, PrecomputePlan.model_validate(plan))
 
 
 @app.local_entrypoint()

--- a/projects/policyengine-simulation-executor/src/modal/precompute_app.py
+++ b/projects/policyengine-simulation-executor/src/modal/precompute_app.py
@@ -40,9 +40,10 @@ _worker_secrets = [gcp_secret, data_secret, hf_secret]
 
 
 # Wrapper signatures use plain dicts: they sit on Modal's serialization
-# boundary. Each validates into the strict precompute_models schema on the
-# way in and dumps on the way out, so planner/worker shape drift fails
-# loudly at the edge.
+# boundary. Every structured value validates into the strict
+# precompute_models schema on the way in and dumps back to a dict on the
+# way out (bare strings — the bucket, publish_manifest's digest — cross
+# as-is), so planner/worker shape drift fails loudly at the edge.
 
 
 @app.function(

--- a/projects/policyengine-simulation-executor/src/modal/precompute_app.py
+++ b/projects/policyengine-simulation-executor/src/modal/precompute_app.py
@@ -1,0 +1,500 @@
+"""Ephemeral precompute app: fill the artifact store for the installed bundle.
+
+Runs the write half of the artifact pipeline as a `modal run` (no deploy):
+
+    uv run modal run --env=staging src/modal/precompute_app.py
+    uv run modal run --env=staging src/modal/precompute_app.py --force
+
+Wave 1 builds the single-year US datasets (one container per year), wave 2
+computes the 20 per-cohort national baselines per year (one container per
+cohort, sized like the production ``run_simulation_segment`` workers). All
+store interaction and ALL identity collection happen inside containers —
+the container has the installed bundle receipt the keys digest, the local
+machine does not — so the local entrypoint only orchestrates spawns.
+
+The store is content-addressed, so this app is idempotent: it plans against
+the store first and spawns only missing work. A re-run against a warm store
+is a no-op that finishes in about a container start. ``--force`` recomputes
+everything (the escape hatch for a suspected bad artifact; uploads are
+write-once, so healing an EXISTING object additionally means deleting it
+first or bumping the key schema).
+
+Baselines are built through the executor's own request path
+(``_resolve_region`` + ``_build_simulation`` on a synthetic request), so
+scoping, extra variables, and the deterministic simulation id are the
+production child's by construction, not by convention. The budgetary-pair
+extras are applied exactly as ``economic_impact_analysis`` would before
+``ensure()``.
+
+A determinism gate (one cohort recomputed under a throwaway id and
+compared frame-by-frame) runs whenever baselines were computed — it is the
+direct check of the cache's core assumption that same key means same
+bytes.
+"""
+
+from __future__ import annotations
+
+import modal
+
+from src.modal.app import (
+    build_runtime_simulation_image,
+    data_secret,
+    gcp_secret,
+    hf_secret,
+)
+
+app = modal.App("policyengine-simulation-precompute")
+
+PRECOMPUTE_COUNTRY = "us"
+# The user-facing priority order (2026 first); with parallel waves it only
+# orders spawn submission, but keep it intentional.
+PRECOMPUTE_YEARS = [2026, 2027, 2025]
+
+MANIFEST_SCHEMA = "mf1"
+
+precompute_image = build_runtime_simulation_image().add_local_python_source(
+    "src.modal",
+    "policyengine_simulation_executor",
+    "policyengine_simulation_observability",
+    "policyengine_simulation_contract",
+    copy=True,
+)
+
+_worker_secrets = [gcp_secret, data_secret, hf_secret]
+
+
+def _cohort_params(year: int, group: list[str]) -> dict:
+    """The synthetic request a segmented-national child would receive."""
+    return {
+        "country": PRECOMPUTE_COUNTRY,
+        "scope": "macro",
+        "region_group": list(group),
+        "time_period": year,
+    }
+
+
+def _cohort_identity(year: int, group: list[str]):
+    """Identity via the executor's own resolution path (writer==reader)."""
+    from policyengine_simulation_executor.baseline_artifacts import (
+        qualifying_baseline_identity,
+    )
+    from policyengine_simulation_executor.simulation_runtime import (
+        _country_module,
+        _resolve_region,
+    )
+
+    params = _cohort_params(year, group)
+    country_module = _country_module(PRECOMPUTE_COUNTRY)
+    resolution = _resolve_region(
+        country_module=country_module,
+        country=PRECOMPUTE_COUNTRY,
+        params=params,
+    )
+    identity = qualifying_baseline_identity(
+        params,
+        country=PRECOMPUTE_COUNTRY,
+        policy=None,
+        region_code=resolution.code,
+        scoping_strategy=resolution.scoping_strategy,
+        year=year,
+    )
+    if identity is None:
+        raise RuntimeError(
+            f"Cohort request for year {year} group {group} does not qualify "
+            "for a deterministic baseline id — writer and reader predicates "
+            "have diverged."
+        )
+    return identity
+
+
+def select_work(plan: dict, *, force: bool) -> dict:
+    """Pure work selection: which plan entries need computing."""
+    datasets = [entry for entry in plan["datasets"] if force or not entry["exists"]]
+    baselines = [entry for entry in plan["baselines"] if force or not entry["exists"]]
+    return {"datasets": datasets, "baselines": baselines}
+
+
+def build_manifest_payload(plan: dict) -> dict:
+    """The deploy manifest: receipt + every artifact the image must fetch."""
+    artifacts = [
+        {
+            "type": "dataset",
+            "path": entry["path"],
+            "filename": entry["filename"],
+            "year": entry["year"],
+            "digest": entry["digest"],
+        }
+        for entry in plan["datasets"]
+    ] + [
+        {
+            "type": "baseline",
+            "path": entry["path"],
+            "filename": f"{entry['simulation_id']}.h5",
+            "year": entry["year"],
+            "digest": entry["digest"],
+        }
+        for entry in plan["baselines"]
+    ]
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "country": PRECOMPUTE_COUNTRY,
+        "receipt": plan["receipt"],
+        "artifacts": artifacts,
+    }
+
+
+@app.function(
+    image=precompute_image,
+    cpu=4.0,
+    memory=16384,
+    timeout=1800,
+    secrets=_worker_secrets,
+)
+def plan_artifacts(bucket: str) -> dict:
+    """Compute every expected artifact identity and its store presence."""
+    from policyengine_simulation_executor.artifact_keys import (
+        collect_dataset_identity,
+    )
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.national_partition import (
+        national_region_groups,
+    )
+    from policyengine_simulation_executor.release_bundle import (
+        get_country_release_bundle,
+    )
+
+    store = ArtifactStore(bucket)
+    groups = national_region_groups(PRECOMPUTE_COUNTRY)
+    if not groups:
+        raise RuntimeError(f"No national partition for {PRECOMPUTE_COUNTRY!r}")
+
+    datasets = []
+    baselines = []
+    for year in PRECOMPUTE_YEARS:
+        dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+        datasets.append(
+            {
+                "year": year,
+                "digest": dataset_identity.digest,
+                "path": dataset_identity.store_path,
+                "filename": dataset_identity.filename,
+                "exists": store.exists(dataset_identity.store_path),
+            }
+        )
+        for group in groups:
+            identity = _cohort_identity(year, group)
+            baselines.append(
+                {
+                    "year": year,
+                    "group": list(group),
+                    "region": identity.region,
+                    "digest": identity.digest,
+                    "path": identity.store_path,
+                    "simulation_id": identity.simulation_id,
+                    "exists": store.exists(identity.store_path),
+                }
+            )
+
+    bundle = get_country_release_bundle(PRECOMPUTE_COUNTRY)
+    receipt = {
+        "policyengine_version": bundle.policyengine_version,
+        "model_version": bundle.model_version,
+        "data_version": bundle.data_version,
+        "data_artifact_revision": bundle.data_artifact_revision,
+        "default_dataset": bundle.default_dataset,
+    }
+    return {"datasets": datasets, "baselines": baselines, "receipt": receipt}
+
+
+@app.function(
+    image=precompute_image,
+    cpu=8.0,
+    memory=65536,
+    timeout=2 * 60 * 60,
+    secrets=_worker_secrets,
+)
+def build_dataset(bucket: str, year: int, expected_path: str) -> dict:
+    """Wave 1: build one single-year dataset and upload it."""
+    import os
+    import time
+    from importlib import import_module
+    from pathlib import Path
+
+    from policyengine_simulation_executor.artifact_keys import (
+        collect_dataset_identity,
+    )
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.release_bundle import (
+        get_country_release_bundle,
+    )
+
+    identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+    if identity.store_path != expected_path:
+        raise RuntimeError(
+            "Planned and in-container dataset identities disagree "
+            f"({expected_path} != {identity.store_path}); refusing to upload "
+            "under a mismatched key."
+        )
+
+    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    country_module = import_module(
+        f"policyengine.tax_benefit_models.{PRECOMPUTE_COUNTRY}"
+    )
+    started = time.monotonic()
+    country_module.ensure_datasets(
+        datasets=[get_country_release_bundle(PRECOMPUTE_COUNTRY).default_dataset],
+        years=[year],
+        data_folder=data_folder,
+    )
+    build_seconds = time.monotonic() - started
+
+    local_file = Path(data_folder) / identity.filename
+    if not local_file.exists():
+        raise RuntimeError(f"ensure_datasets produced no file at {local_file}")
+    uploaded = ArtifactStore(bucket).upload_file(identity.store_path, local_file)
+    return {
+        "year": year,
+        "path": identity.store_path,
+        "uploaded": uploaded,
+        "build_seconds": round(build_seconds, 1),
+        "size_bytes": local_file.stat().st_size,
+    }
+
+
+def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
+    """Shared by compute and verify: dataset download + simulation build."""
+    import os
+    from pathlib import Path
+
+    from policyengine_simulation_executor.artifact_keys import (
+        collect_dataset_identity,
+    )
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.simulation_runtime import (
+        _build_simulation,
+        _country_module,
+        _load_dataset,
+        _resolve_region,
+    )
+
+    store = ArtifactStore(bucket)
+    data_folder = Path(
+        os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    )
+
+    dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+    local_dataset = data_folder / dataset_identity.filename
+    if not local_dataset.exists():
+        store.download_file(dataset_identity.store_path, local_dataset)
+
+    params = _cohort_params(year, group)
+    country_module = _country_module(PRECOMPUTE_COUNTRY)
+    resolution = _resolve_region(
+        country_module=country_module,
+        country=PRECOMPUTE_COUNTRY,
+        params=params,
+    )
+    dataset = _load_dataset(
+        params, country_module=country_module, region_resolution=resolution
+    )
+    baseline = _build_simulation(
+        params,
+        dataset=dataset,
+        policy=None,
+        scoping_strategy=resolution.scoping_strategy,
+        region_code=resolution.code,
+    )
+
+    # The extras economic_impact_analysis applies unconditionally before
+    # ensure(); the artifact must carry them or every request would fail
+    # the column guard and recompute.
+    from policyengine.tax_benefit_models.us.analysis import (
+        configure_budgetary_impact_variables,
+    )
+
+    configure_budgetary_impact_variables(baseline, baseline)
+    return store, data_folder, baseline
+
+
+@app.function(
+    image=precompute_image,
+    cpu=8.0,
+    memory=32768,
+    timeout=3600,
+    secrets=_worker_secrets,
+)
+def compute_baseline(bucket: str, year: int, group: list[str], expected: dict) -> dict:
+    """Wave 2: compute one cohort baseline and upload its output."""
+    import time
+
+    from policyengine_simulation_executor.baseline_artifacts import (
+        ArtifactBaselineSimulation,
+    )
+
+    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
+    if not isinstance(baseline, ArtifactBaselineSimulation):
+        raise RuntimeError(
+            "Precompute built a plain Simulation — the qualifying predicate "
+            "rejected the cohort request shape."
+        )
+    if baseline.id != expected["simulation_id"]:
+        raise RuntimeError(
+            "Planned and in-container baseline ids disagree "
+            f"({expected['simulation_id']} != {baseline.id}); refusing to "
+            "upload under a mismatched key."
+        )
+
+    started = time.monotonic()
+    baseline.ensure()
+    compute_seconds = time.monotonic() - started
+
+    artifact_file = data_folder / f"{baseline.id}.h5"
+    if not artifact_file.exists():
+        raise RuntimeError(f"ensure() left no artifact at {artifact_file}")
+    uploaded = store.upload_file(expected["path"], artifact_file)
+    return {
+        "year": year,
+        "group": list(group),
+        "simulation_id": baseline.id,
+        "outcome": baseline.artifact_outcome,
+        "uploaded": uploaded,
+        "compute_seconds": round(compute_seconds, 1),
+        "size_bytes": artifact_file.stat().st_size,
+    }
+
+
+@app.function(
+    image=precompute_image,
+    cpu=8.0,
+    memory=32768,
+    timeout=3600,
+    secrets=_worker_secrets,
+)
+def verify_determinism(
+    bucket: str, year: int, group: list[str], expected: dict
+) -> dict:
+    """Load the uploaded artifact, recompute independently, compare frames.
+
+    Exact comparison of every entity column (values and dtypes) between the
+    store artifact (downloaded and loaded through ``ensure()``, so the save/
+    load round-trip is under test too) and a fresh independent run — the
+    direct check of "same key, same bytes". File-level byte equality is
+    deliberately not used (HDF5 container metadata is not guaranteed
+    stable).
+    """
+    from policyengine.core import Simulation
+
+    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
+    if baseline.id != expected["simulation_id"]:
+        raise RuntimeError(
+            "Planned and in-container baseline ids disagree "
+            f"({expected['simulation_id']} != {baseline.id})"
+        )
+    artifact_file = data_folder / f"{baseline.id}.h5"
+    if not artifact_file.exists():
+        store.download_file(expected["path"], artifact_file)
+    baseline.ensure()
+    if baseline.artifact_outcome != "hit":
+        raise RuntimeError(
+            "Determinism gate could not load the artifact it verifies "
+            f"(outcome={baseline.artifact_outcome})"
+        )
+
+    fresh = Simulation(
+        dataset=baseline.dataset,
+        tax_benefit_model_version=baseline.tax_benefit_model_version,
+        policy=None,
+        scoping_strategy=baseline.scoping_strategy,
+        extra_variables=dict(baseline.extra_variables),
+    )
+    fresh.run()
+
+    differences = []
+    loaded = baseline.output_dataset.data.entity_data
+    recomputed = fresh.output_dataset.data.entity_data
+    for entity in sorted(set(loaded) | set(recomputed)):
+        left, right = loaded.get(entity), recomputed.get(entity)
+        if left is None or right is None:
+            differences.append(f"{entity}: missing on one side")
+            continue
+        left_cols, right_cols = set(left.columns), set(right.columns)
+        for column in sorted(left_cols ^ right_cols):
+            differences.append(f"{entity}.{column}: only on one side")
+        for column in sorted(left_cols & right_cols):
+            if str(left[column].dtype) != str(right[column].dtype):
+                differences.append(f"{entity}.{column}: dtype differs")
+            elif not left[column].equals(right[column]):
+                differences.append(f"{entity}.{column}: values differ")
+    return {"equal": not differences, "differences": differences[:50]}
+
+
+@app.function(
+    image=precompute_image,
+    cpu=2.0,
+    memory=8192,
+    timeout=600,
+    secrets=_worker_secrets,
+)
+def publish_manifest(bucket: str, plan: dict) -> str:
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+
+    return ArtifactStore(bucket).write_manifest(build_manifest_payload(plan))
+
+
+@app.local_entrypoint()
+def main(force: bool = False):
+    from policyengine_simulation_executor.artifact_store import (
+        resolve_bucket_name,
+    )
+
+    bucket = resolve_bucket_name()
+    print(f"Planning against gs://{bucket} (force={force})")
+    plan = plan_artifacts.remote(bucket)
+    work = select_work(plan, force=force)
+    print(
+        f"Plan: {len(plan['datasets'])} datasets ({len(work['datasets'])} to "
+        f"build), {len(plan['baselines'])} baselines "
+        f"({len(work['baselines'])} to compute)"
+    )
+
+    dataset_handles = [
+        build_dataset.spawn(bucket, entry["year"], entry["path"])
+        for entry in work["datasets"]
+    ]
+    for handle in dataset_handles:
+        result = handle.get()
+        print(
+            f"dataset year={result['year']} built in "
+            f"{result['build_seconds']}s ({result['size_bytes']} bytes, "
+            f"uploaded={result['uploaded']})"
+        )
+
+    baseline_handles = [
+        compute_baseline.spawn(bucket, entry["year"], entry["group"], entry)
+        for entry in work["baselines"]
+    ]
+    for handle in baseline_handles:
+        result = handle.get()
+        print(
+            f"baseline year={result['year']} id={result['simulation_id']} "
+            f"outcome={result['outcome']} in {result['compute_seconds']}s "
+            f"(uploaded={result['uploaded']})"
+        )
+
+    if work["baselines"]:
+        probe = work["baselines"][0]
+        print(
+            f"Determinism gate: recomputing year={probe['year']} group={probe['group']}"
+        )
+        verdict = verify_determinism.remote(
+            bucket, probe["year"], probe["group"], probe
+        )
+        if not verdict["equal"]:
+            raise SystemExit(
+                "Determinism gate FAILED: " + "; ".join(verdict["differences"])
+            )
+        print("Determinism gate passed")
+
+    manifest_digest = publish_manifest.remote(bucket, plan)
+    # Parseable by CI: the deploy consumes exactly this line.
+    print(f"MANIFEST_DIGEST={manifest_digest}")

--- a/projects/policyengine-simulation-executor/src/modal/segmented_national.py
+++ b/projects/policyengine-simulation-executor/src/modal/segmented_national.py
@@ -41,7 +41,7 @@ from src.modal.fanout import build_child_payload, next_backoff
 logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_INITIAL_SECONDS = 0.5
-POLL_INTERVAL_MAX_SECONDS = 15.0
+POLL_INTERVAL_MAX_SECONDS = 8.0
 POLL_INTERVAL_BACKOFF_FACTOR = 2.0
 
 # The dedicated children pool (see module docstring).

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_keys.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_keys.py
@@ -1,0 +1,332 @@
+"""Content-addressed identity for precomputed simulation artifacts.
+
+The artifact pipeline caches two artifact types in a shared store: single-year
+dataset files and precomputed baseline simulation outputs. An artifact's key is
+a sha256 digest over the FULL closure of inputs that determine its bytes, so
+"is it cached?" and "is it stale?" are the same question, answered by key
+equality: same key implies a byte-identical artifact; any input change rotates
+the key and the old object simply stops being referenced (garbage collection
+deletes by key with no correctness risk — a wrongly deleted artifact costs a
+recompute, never a wrong answer).
+
+Key discipline: every field that can change an artifact's bytes must appear in
+its payload. Version labels alone are not enough — a data re-release under an
+unchanged version label is a known event — so the payloads also carry the
+receipt's content sha256 and the certification data-build fingerprint when
+available. ``None`` fields are serialized as explicit nulls, so presence and
+absence are distinct identities. Bump the schema constants when the payload
+shape or the artifact format itself changes.
+
+The baseline payload nests the dataset digest, so anything that rotates a
+dataset key transitively rotates every baseline built on it. ``country`` and
+``region`` are partially redundant with ``scope_key`` and the nested dataset
+key; the redundancy is deliberate — for a cache key, explicitness only ever
+makes identity more specific, and it means UK or single-state baselines need
+no schema change later.
+
+This module is the single source of truth for keys, ids, and store paths: the
+precompute writer, the runtime reader, and the GC planner all import it, so a
+drift between writer and reader is a code-review diff here, not a silent
+cache miss in production.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Optional
+
+DATASET_KEY_SCHEMA = "ds1"
+BASELINE_KEY_SCHEMA = "bl1"
+
+# Length of the digest prefix used in simulation ids and store paths. 16 hex
+# chars (64 bits) is far beyond collision range for this population while
+# keeping filenames readable in logs.
+_ID_DIGEST_CHARS = 16
+
+CURRENT_LAW_POLICY = "current-law"
+NATIONAL_REGION = "national"
+
+
+def canonical_digest(payload: Mapping[str, Any]) -> str:
+    """sha256 over the canonical JSON encoding of ``payload``.
+
+    Canonical means: keys sorted, no whitespace, ASCII-only escapes. Any
+    nested structure must itself be JSON-serializable with deterministic
+    content (no sets, no floats that vary in repr).
+    """
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def dataset_key(
+    *,
+    country: str,
+    dataset: str,
+    year: int,
+    data_version: str,
+    data_artifact_revision: str,
+    source_sha256: Optional[str],
+    data_build_fingerprint: Optional[str],
+    model_version: str,
+    policyengine_version: str,
+) -> str:
+    """Digest identifying one single-year dataset artifact.
+
+    ``model_version`` and ``policyengine_version`` belong here because the
+    single-year build runs a full Microsimulation pass — its output depends
+    on model code, not just source data. ``source_sha256`` is the installed
+    multi-year source's content hash from the bundle receipt (byte identity;
+    closes the same-version re-release hole), ``data_build_fingerprint`` the
+    certification fingerprint; both may be None when unavailable.
+    """
+    return canonical_digest(
+        {
+            "schema": DATASET_KEY_SCHEMA,
+            "country": country.lower(),
+            "dataset": dataset,
+            "year": int(year),
+            "data_version": data_version,
+            "data_artifact_revision": data_artifact_revision,
+            "source_sha256": source_sha256,
+            "data_build_fingerprint": data_build_fingerprint,
+            "model_version": model_version,
+            "policyengine_version": policyengine_version,
+        }
+    )
+
+
+def baseline_key(
+    *,
+    country: str,
+    region: str,
+    scope_key: Optional[str],
+    dataset_digest: str,
+    model_version: str,
+    policyengine_version: str,
+    policy: str = CURRENT_LAW_POLICY,
+) -> str:
+    """Digest identifying one precomputed baseline simulation artifact.
+
+    ``scope_key`` is the ``ScopingStrategy.cache_key`` string (None for an
+    unscoped national run); ``region`` is the human-readable label
+    ("national", "state/ca", ...). The simulation year rides in via
+    ``dataset_digest``.
+    """
+    return canonical_digest(
+        {
+            "schema": BASELINE_KEY_SCHEMA,
+            "country": country.lower(),
+            "region": region,
+            "scope_key": scope_key,
+            "dataset_key": dataset_digest,
+            "policy": policy,
+            "model_version": model_version,
+            "policyengine_version": policyengine_version,
+        }
+    )
+
+
+def baseline_simulation_id(baseline_digest: str) -> str:
+    """The deterministic ``Simulation.id`` for a baseline artifact.
+
+    The id doubles as the artifact filename stem (``{id}.h5`` beside the
+    dataset — the path ``Simulation.ensure()`` already loads from), so it
+    must be filename-safe and must not collide with the dataset filename
+    pattern ``{stem}_year_{year}.h5``.
+    """
+    return f"{BASELINE_KEY_SCHEMA}-{baseline_digest[:_ID_DIGEST_CHARS]}"
+
+
+# --- Store layout ---------------------------------------------------------
+#
+# datasets/<country>/<digest>/<stem>_year_<year>.h5
+# baselines/<country>/<digest>/<id>.h5
+# manifests/<digest>.json
+# deployed/<environment>.json
+#
+# The filename inside a dataset object's path is EXACTLY the name the
+# runtime's ensure_datasets existence check resolves — the fetch layer
+# downloads objects to POLICYENGINE_DATA_FOLDER under their basenames, so
+# the object basename IS the runtime filename contract.
+
+
+def dataset_artifact_filename(stem: str, year: int) -> str:
+    return f"{stem}_year_{year}.h5"
+
+
+def dataset_artifact_path(
+    country: str, dataset_digest: str, stem: str, year: int
+) -> str:
+    return (
+        f"datasets/{country.lower()}/{dataset_digest}/"
+        f"{dataset_artifact_filename(stem, year)}"
+    )
+
+
+def baseline_artifact_path(
+    country: str, baseline_digest: str, simulation_id: str
+) -> str:
+    return f"baselines/{country.lower()}/{baseline_digest}/{simulation_id}.h5"
+
+
+def manifest_path(manifest_digest: str) -> str:
+    return f"manifests/{manifest_digest}.json"
+
+
+def deployed_marker_path(environment: str) -> str:
+    return f"deployed/{environment}.json"
+
+
+# --- Version-identity collection ------------------------------------------
+
+
+@dataclass(frozen=True)
+class DatasetArtifactIdentity:
+    """Everything needed to key and name one single-year dataset artifact."""
+
+    country: str
+    dataset: str
+    stem: str
+    year: int
+    data_version: str
+    data_artifact_revision: str
+    source_sha256: Optional[str]
+    data_build_fingerprint: Optional[str]
+    model_version: str
+    policyengine_version: str
+
+    @property
+    def digest(self) -> str:
+        return dataset_key(
+            country=self.country,
+            dataset=self.dataset,
+            year=self.year,
+            data_version=self.data_version,
+            data_artifact_revision=self.data_artifact_revision,
+            source_sha256=self.source_sha256,
+            data_build_fingerprint=self.data_build_fingerprint,
+            model_version=self.model_version,
+            policyengine_version=self.policyengine_version,
+        )
+
+    @property
+    def filename(self) -> str:
+        return dataset_artifact_filename(self.stem, self.year)
+
+    @property
+    def store_path(self) -> str:
+        return dataset_artifact_path(self.country, self.digest, self.stem, self.year)
+
+
+@dataclass(frozen=True)
+class BaselineArtifactIdentity:
+    """Everything needed to key, id, and name one baseline artifact."""
+
+    country: str
+    region: str
+    scope_key: Optional[str]
+    dataset: DatasetArtifactIdentity
+
+    @property
+    def digest(self) -> str:
+        return baseline_key(
+            country=self.country,
+            region=self.region,
+            scope_key=self.scope_key,
+            dataset_digest=self.dataset.digest,
+            model_version=self.dataset.model_version,
+            policyengine_version=self.dataset.policyengine_version,
+        )
+
+    @property
+    def simulation_id(self) -> str:
+        return baseline_simulation_id(self.digest)
+
+    @property
+    def store_path(self) -> str:
+        return baseline_artifact_path(self.country, self.digest, self.simulation_id)
+
+
+def _receipt_source_sha256(country: str, data_version: str) -> Optional[str]:
+    """Content hash of the installed multi-year source, when certifiable.
+
+    Only trusted when the receipt entry's version matches the bundle's data
+    version (mirroring ``resolve_local_bundle_dataset_path``) — a receipt
+    left over from a different install must not leak into the key.
+    """
+    from policyengine_simulation_executor.release_bundle import _receipt_dataset
+
+    entry = _receipt_dataset(country)
+    if not isinstance(entry, Mapping):
+        return None
+    if entry.get("version") != data_version:
+        return None
+    for field in ("installed_sha256", "expected_sha256"):
+        value = entry.get(field)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _certification_fingerprint(country: str) -> Optional[str]:
+    from policyengine.provenance.manifest import get_release_manifest
+
+    certification = getattr(get_release_manifest(country), "certification", None)
+    fingerprint = getattr(certification, "data_build_fingerprint", None)
+    return fingerprint if isinstance(fingerprint, str) and fingerprint else None
+
+
+def collect_dataset_identity(country: str, year: int) -> DatasetArtifactIdentity:
+    """Identity of the default single-year dataset for this installed bundle.
+
+    Reads the same sources the runtime trusts: the release bundle (versions),
+    the bundle receipt (content sha), and the manifest certification
+    (fingerprint). The stem comes through the same manifest helpers the
+    prebuild and runtime lookups use, so filename coupling is inherited, not
+    re-derived.
+    """
+    from policyengine.provenance.manifest import (
+        dataset_logical_name,
+        resolve_dataset_reference,
+    )
+
+    from policyengine_simulation_executor.release_bundle import (
+        get_country_release_bundle,
+    )
+
+    bundle = get_country_release_bundle(country)
+    stem = dataset_logical_name(
+        resolve_dataset_reference(bundle.country, bundle.default_dataset)
+    )
+    return DatasetArtifactIdentity(
+        country=bundle.country,
+        dataset=bundle.default_dataset,
+        stem=stem,
+        year=int(year),
+        data_version=bundle.data_version,
+        data_artifact_revision=bundle.data_artifact_revision,
+        source_sha256=_receipt_source_sha256(bundle.country, bundle.data_version),
+        data_build_fingerprint=_certification_fingerprint(bundle.country),
+        model_version=bundle.model_version,
+        policyengine_version=bundle.policyengine_version,
+    )
+
+
+def collect_baseline_identity(
+    country: str,
+    year: int,
+    *,
+    region: str,
+    scope_key: Optional[str],
+) -> BaselineArtifactIdentity:
+    return BaselineArtifactIdentity(
+        country=country.lower(),
+        region=region,
+        scope_key=scope_key,
+        dataset=collect_dataset_identity(country, year),
+    )

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_keys.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_keys.py
@@ -159,6 +159,10 @@ def dataset_artifact_filename(stem: str, year: int) -> str:
     return f"{stem}_year_{year}.h5"
 
 
+def baseline_artifact_filename(simulation_id: str) -> str:
+    return f"{simulation_id}.h5"
+
+
 def dataset_artifact_path(
     country: str, dataset_digest: str, stem: str, year: int
 ) -> str:
@@ -171,7 +175,10 @@ def dataset_artifact_path(
 def baseline_artifact_path(
     country: str, baseline_digest: str, simulation_id: str
 ) -> str:
-    return f"baselines/{country.lower()}/{baseline_digest}/{simulation_id}.h5"
+    return (
+        f"baselines/{country.lower()}/{baseline_digest}/"
+        f"{baseline_artifact_filename(simulation_id)}"
+    )
 
 
 def manifest_path(manifest_digest: str) -> str:

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_store.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_store.py
@@ -115,9 +115,7 @@ class ArtifactStore:
     def write_manifest(self, payload: Mapping[str, Any]) -> str:
         """Store a manifest under its own content digest; returns the digest."""
         digest = artifact_keys.canonical_digest(payload)
-        self._upload_json(
-            artifact_keys.manifest_path(digest), payload, overwrite=False
-        )
+        self._upload_json(artifact_keys.manifest_path(digest), payload, overwrite=False)
         return digest
 
     def read_manifest(self, digest: str) -> Optional[Mapping[str, Any]]:

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_store.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_store.py
@@ -1,0 +1,136 @@
+"""GCS-backed content-addressed store for precomputed simulation artifacts.
+
+Object paths come from ``artifact_keys`` (the single source of truth for
+layout). Two write disciplines coexist:
+
+* **Artifacts and manifests are write-once.** Uploads pass
+  ``if_generation_match=0`` so the first writer wins and a concurrent
+  duplicate write (e.g. the beta and prod deploy legs racing on the same
+  key) fails the precondition instead of clobbering. Because a key digests
+  the full input closure, the loser's bytes are identical to the winner's,
+  so ``PreconditionFailed`` is reported as success-without-upload.
+* **Deployed-environment markers are last-writer-wins.** They are pointers,
+  not artifacts; each successful deploy overwrites its environment's marker.
+
+Credentials: the store materializes ``GOOGLE_APPLICATION_CREDENTIALS_JSON``
+via the existing ``setup_gcp_credentials`` helper only while constructing
+the real client; injected fake clients (tests) never touch credentials or
+the network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Optional
+
+from google.api_core.exceptions import NotFound, PreconditionFailed
+
+from policyengine_simulation_executor import artifact_keys
+
+ARTIFACT_BUCKET_ENV = "POLICYENGINE_ARTIFACT_BUCKET"
+
+
+def resolve_bucket_name(explicit: Optional[str] = None) -> str:
+    bucket = explicit or os.environ.get(ARTIFACT_BUCKET_ENV)
+    if not bucket:
+        raise RuntimeError(
+            f"No artifact bucket configured: pass one or set {ARTIFACT_BUCKET_ENV}."
+        )
+    return bucket
+
+
+def _default_client():
+    from google.cloud import storage
+
+    from policyengine_simulation_executor.simulation_runtime import (
+        setup_gcp_credentials,
+    )
+
+    # The client reads ADC at construction time, so the materialized
+    # credentials file only needs to exist inside this block.
+    with setup_gcp_credentials():
+        return storage.Client()
+
+
+class ArtifactStore:
+    def __init__(self, bucket_name: Optional[str] = None, *, client: Any = None):
+        self.bucket_name = resolve_bucket_name(bucket_name)
+        self._client = client
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            self._client = _default_client()
+        return self._client
+
+    def _blob(self, path: str):
+        return self.client.bucket(self.bucket_name).blob(path)
+
+    def exists(self, path: str) -> bool:
+        return bool(self._blob(path).exists())
+
+    def upload_file(self, path: str, local_path: str | Path) -> bool:
+        """Write-once upload. Returns True if this call uploaded the object,
+        False if an identical-keyed object already existed (see module
+        docstring for why that is success)."""
+        try:
+            self._blob(path).upload_from_filename(
+                str(local_path), if_generation_match=0
+            )
+        except PreconditionFailed:
+            return False
+        return True
+
+    def download_file(self, path: str, local_path: str | Path) -> None:
+        destination = Path(local_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        self._blob(path).download_to_filename(str(destination))
+
+    def _upload_json(self, path: str, payload: Mapping[str, Any], *, overwrite: bool):
+        data = json.dumps(payload, sort_keys=True, indent=2)
+        blob = self._blob(path)
+        if overwrite:
+            blob.upload_from_string(data, content_type="application/json")
+            return True
+        try:
+            blob.upload_from_string(
+                data, content_type="application/json", if_generation_match=0
+            )
+        except PreconditionFailed:
+            return False
+        return True
+
+    def read_json(self, path: str) -> Optional[Mapping[str, Any]]:
+        try:
+            payload = json.loads(self._blob(path).download_as_bytes())
+        except NotFound:
+            return None
+        return payload if isinstance(payload, Mapping) else None
+
+    # --- Manifests (write-once, content-addressed) ------------------------
+
+    def write_manifest(self, payload: Mapping[str, Any]) -> str:
+        """Store a manifest under its own content digest; returns the digest."""
+        digest = artifact_keys.canonical_digest(payload)
+        self._upload_json(
+            artifact_keys.manifest_path(digest), payload, overwrite=False
+        )
+        return digest
+
+    def read_manifest(self, digest: str) -> Optional[Mapping[str, Any]]:
+        return self.read_json(artifact_keys.manifest_path(digest))
+
+    # --- Deployed-environment markers (last-writer-wins) ------------------
+
+    def write_deployed_marker(
+        self, environment: str, payload: Mapping[str, Any]
+    ) -> None:
+        self._upload_json(
+            artifact_keys.deployed_marker_path(environment), payload, overwrite=True
+        )
+
+    def read_deployed_marker(self, environment: str) -> Optional[Mapping[str, Any]]:
+        return self.read_json(artifact_keys.deployed_marker_path(environment))

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_store.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/artifact_store.py
@@ -87,7 +87,17 @@ class ArtifactStore:
     def download_file(self, path: str, local_path: str | Path) -> None:
         destination = Path(local_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
-        self._blob(path).download_to_filename(str(destination))
+        # Download to a sibling temp name and rename: callers guard on
+        # exists(), so a mid-stream failure must never leave a truncated
+        # file at the final name (it would poison the container's later
+        # work for the rest of the run).
+        partial = destination.with_name(destination.name + ".partial")
+        try:
+            self._blob(path).download_to_filename(str(partial))
+        except BaseException:
+            partial.unlink(missing_ok=True)
+            raise
+        partial.replace(destination)
 
     def _upload_json(self, path: str, payload: Mapping[str, Any], *, overwrite: bool):
         data = json.dumps(payload, sort_keys=True, indent=2)

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/baseline_artifacts.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/baseline_artifacts.py
@@ -1,0 +1,182 @@
+"""Deterministic baseline simulation ids and the validate-on-load guard.
+
+The runtime read path of the artifact pipeline. A baseline simulation whose
+identity is fully determined by the installed version-set (current-law
+policy, default data, national or region-group scope) gets a deterministic
+``Simulation.id`` from ``artifact_keys``; ``Simulation.ensure()`` then finds
+``{id}.h5`` beside the dataset when a precomputed artifact was baked into
+the image, and loads in seconds instead of running the model.
+
+Safety inversion: a load is trusted only after validation. Requests can
+demand output columns beyond what an artifact was built with (cliff
+variables, labor-supply-response columns), and ``ensure()`` alone would
+serve the stale column set. ``ArtifactBaselineSimulation`` therefore diffs
+``resolve_entity_variables`` against the loaded frames and falls back to
+``run()`` on any gap — so a missing or incomplete artifact can only ever
+cost compute, never correctness. With no artifact present this class
+behaves exactly like ``Simulation`` (FileNotFoundError -> run + save),
+which is what makes it safe to ship before any artifacts exist.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from pydantic import PrivateAttr
+
+from policyengine.core import Simulation
+
+from policyengine_simulation_executor import artifact_keys
+
+logger = logging.getLogger(__name__)
+
+# Artifact outcomes reported via the `baseline_artifact` observability
+# attribute. "hit": loaded (disk or in-process cache) and complete;
+# "incomplete": loaded but missing requested columns -> recomputed;
+# "miss": no artifact -> computed (today's behavior).
+OUTCOME_HIT = "hit"
+OUTCOME_INCOMPLETE = "incomplete"
+OUTCOME_MISS = "miss"
+
+
+def qualifying_baseline_identity(
+    params: dict[str, Any],
+    *,
+    country: str,
+    policy: Any,
+    region_code: Optional[str],
+    scoping_strategy: Any,
+    year: int,
+) -> Optional[artifact_keys.BaselineArtifactIdentity]:
+    """Full artifact identity for a qualifying baseline, else None.
+
+    Qualifying means the simulation's bytes are a pure function of the
+    installed version-set: current-law policy, macro scope, default data
+    (custom ``data``/``data_version`` requests resolve different datasets
+    AND live outside the baked folder), and a scope the pipeline produces
+    artifacts for — unscoped national or a region group. Single states stay
+    on random ids in v1.
+
+    Both the runtime reader (via ``deterministic_baseline_id``) and the
+    precompute writer derive identity through THIS function, so writer and
+    reader cannot disagree by construction. Identity-collection errors
+    propagate: the writer must fail loudly on them.
+    """
+    from policyengine.core.scoping_strategy import RegionGroupStrategy
+
+    if policy is not None:
+        return None
+    if str(params.get("scope") or "").lower() != "macro":
+        return None
+    if params.get("data") is not None or params.get("data_version") is not None:
+        return None
+    if region_code is None:
+        return None
+
+    country = country.lower()
+    if scoping_strategy is None:
+        if region_code != country:
+            return None
+        region, scope_key = artifact_keys.NATIONAL_REGION, None
+    elif isinstance(scoping_strategy, RegionGroupStrategy):
+        region, scope_key = region_code, scoping_strategy.cache_key
+    else:
+        return None
+
+    return artifact_keys.collect_baseline_identity(
+        country, year, region=region, scope_key=scope_key
+    )
+
+
+def deterministic_baseline_id(
+    params: dict[str, Any],
+    *,
+    country: str,
+    policy: Any,
+    region_code: Optional[str],
+    scoping_strategy: Any,
+    year: int,
+) -> Optional[str]:
+    """The runtime wrapper: id for a qualifying baseline, else None.
+
+    Unlike the writer, the read path must never fail a request over
+    identity collection (a manifest/receipt hiccup) — it degrades to a
+    random id, meaning no artifact reuse for that request.
+    """
+    try:
+        identity = qualifying_baseline_identity(
+            params,
+            country=country,
+            policy=policy,
+            region_code=region_code,
+            scoping_strategy=scoping_strategy,
+            year=year,
+        )
+    except Exception:
+        logger.warning(
+            "Could not collect baseline artifact identity for %s; "
+            "using a random simulation id",
+            country,
+            exc_info=True,
+        )
+        return None
+    return None if identity is None else identity.simulation_id
+
+
+class ArtifactBaselineSimulation(Simulation):
+    """A Simulation whose ``ensure()`` validates what it loads."""
+
+    _computed_this_process: bool = PrivateAttr(default=False)
+    _artifact_outcome: Optional[str] = PrivateAttr(default=None)
+
+    @property
+    def artifact_outcome(self) -> Optional[str]:
+        """Set by ``ensure()``; None until then."""
+        return self._artifact_outcome
+
+    def run(self):
+        self._computed_this_process = True
+        super().run()
+
+    def ensure(self) -> None:
+        self._computed_this_process = False
+        super().ensure()
+        if self._computed_this_process:
+            self._artifact_outcome = OUTCOME_MISS
+            return
+
+        missing = self._missing_output_columns()
+        if not missing:
+            self._artifact_outcome = OUTCOME_HIT
+            return
+
+        logger.warning(
+            "Baseline artifact %s is missing output columns %s; recomputing",
+            self.id,
+            missing,
+        )
+        self._artifact_outcome = OUTCOME_INCOMPLETE
+        self.run()
+        self.save()
+        # Mirror ensure()'s tail: replace the in-process cache entry so the
+        # next request in this container gets the completed output instead
+        # of revalidating (and re-running) against the incomplete one.
+        from policyengine.core.simulation import _cache
+
+        _cache.add(self.id, self)
+
+    def _missing_output_columns(self) -> list[tuple[str, str]]:
+        data = getattr(self.output_dataset, "data", None)
+        frames = getattr(data, "entity_data", None)
+        resolved = self.tax_benefit_model_version.resolve_entity_variables(self)
+        if not frames:
+            return [(entity, "<no output data>") for entity in resolved]
+        missing: list[tuple[str, str]] = []
+        for entity, variables in resolved.items():
+            frame = frames.get(entity)
+            columns = set(getattr(frame, "columns", ()))
+            missing.extend(
+                (entity, variable) for variable in variables if variable not in columns
+            )
+        return missing

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/baseline_artifacts.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/baseline_artifacts.py
@@ -40,6 +40,18 @@ OUTCOME_INCOMPLETE = "incomplete"
 OUTCOME_MISS = "miss"
 
 
+def uses_custom_data(params: dict[str, Any]) -> bool:
+    """True when the request asks for non-default data.
+
+    Shared by the qualifying predicate below and ``_load_dataset``'s
+    baked-folder guard: both sites must see the same request facts, or a
+    custom-data request could be given a default-data deterministic id —
+    and in a warm container the in-process cache (keyed on id alone) would
+    then serve default-data output the column guard cannot distinguish.
+    """
+    return params.get("data") is not None or params.get("data_version") is not None
+
+
 def qualifying_baseline_identity(
     params: dict[str, Any],
     *,
@@ -74,7 +86,7 @@ def qualifying_baseline_identity(
         return None
     if str(params.get("scope") or "").lower() != "macro":
         return None
-    if params.get("data") is not None or params.get("data_version") is not None:
+    if uses_custom_data(params):
         return None
     if region_code is None:
         return None
@@ -144,16 +156,30 @@ class ArtifactBaselineSimulation(Simulation):
         self._computed_this_process = True
         super().run()
 
+    def _record_outcome(self, outcome: str) -> None:
+        """First outcome wins for the life of this instance.
+
+        Every request ensures its baseline more than once (the economic
+        impact analysis and the decile impacts each call ``ensure()``), and
+        after a miss the later calls self-hit the in-process cache with a
+        now-complete column set — without the latch they would overwrite a
+        genuine ``miss`` with ``hit`` and blind the rollout metric. The
+        runtime builds a fresh instance per request, so latching per
+        instance is latching per request.
+        """
+        if self._artifact_outcome is None:
+            self._artifact_outcome = outcome
+
     def ensure(self) -> None:
         self._computed_this_process = False
         super().ensure()
         if self._computed_this_process:
-            self._artifact_outcome = OUTCOME_MISS
+            self._record_outcome(OUTCOME_MISS)
             return
 
         missing = self._missing_output_columns()
         if not missing:
-            self._artifact_outcome = OUTCOME_HIT
+            self._record_outcome(OUTCOME_HIT)
             return
 
         logger.warning(
@@ -161,14 +187,17 @@ class ArtifactBaselineSimulation(Simulation):
             self.id,
             missing,
         )
-        self._artifact_outcome = OUTCOME_INCOMPLETE
+        self._record_outcome(OUTCOME_INCOMPLETE)
         self.run()
         self.save()
-        # Mirror ensure()'s tail: replace the in-process cache entry so the
-        # next request in this container gets the completed output instead
-        # of revalidating (and re-running) against the incomplete one.
+        # Replace the in-process cache entry so this request's second
+        # ensure() and every later request in this container get the
+        # completed output instead of revalidating (and re-running) against
+        # the incomplete one. LRUCache.add keeps the OLD value for an
+        # existing key and exposes no remove, so evict directly first.
         from policyengine.core.simulation import _cache
 
+        _cache._cache.pop(self.id, None)
         _cache.add(self.id, self)
 
     def _missing_output_columns(self) -> list[tuple[str, str]]:

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/baseline_artifacts.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/baseline_artifacts.py
@@ -58,6 +58,11 @@ def qualifying_baseline_identity(
     artifacts for — unscoped national or a region group. Single states stay
     on random ids in v1.
 
+    Deliberately broader than what the store contains: UK national and
+    off-precompute years qualify too, get deterministic ids, miss, and
+    compute — a free in-process-cache win for warm containers, and their
+    artifacts appear automatically if the precompute ever produces them.
+
     Both the runtime reader (via ``deterministic_baseline_id``) and the
     precompute writer derive identity through THIS function, so writer and
     reader cannot disagree by construction. Identity-collection errors

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute.py
@@ -8,10 +8,11 @@ executor package makes it testable without Modal fakes and importable by
 the CI deploy job and the GC planner.
 
 Data flow is strictly typed via ``precompute_models``: plans, entries,
-receipts, manifests, and worker results are Pydantic models everywhere
-inside the library; plain dicts appear only at the Modal serialization
-boundary (the app wrappers dump on the way out and validate on the way
-in).
+version identities, manifests, and worker results are Pydantic models
+everywhere inside the library; plain dicts appear only at the Modal
+serialization boundary (the app wrappers validate structured inputs on
+the way in and dump model results on the way out; bare strings — the
+bucket, the manifest digest — cross as-is).
 
 The store is content-addressed, so a precompute run is idempotent: it
 plans against the store and computes only misses; a re-run against a warm
@@ -37,12 +38,13 @@ from typing import Callable
 
 from policyengine_simulation_executor.artifact_keys import (
     BaselineArtifactIdentity,
+    baseline_artifact_filename,
 )
 from policyengine_simulation_executor.precompute_models import (
     ArtifactManifest,
     BaselineComputeResult,
     BaselinePlanEntry,
-    BundleReceipt,
+    BundleVersionIdentity,
     DatasetBuildResult,
     DatasetPlanEntry,
     DeterminismVerdict,
@@ -80,11 +82,14 @@ def cohort_params(year: int, group: list[str]) -> dict:
     }
 
 
-def cohort_identity(year: int, group: list[str]) -> BaselineArtifactIdentity:
-    """Identity via the executor's own resolution path (writer==reader)."""
-    from policyengine_simulation_executor.baseline_artifacts import (
-        qualifying_baseline_identity,
-    )
+def _cohort_resolution(year: int, group: list[str]):
+    """Cohort request params, country module, and region resolution.
+
+    The planner's identity (``cohort_identity``) and the worker's
+    simulation (``_prepare_cohort_baseline``) must derive from ONE
+    resolution or the in-container id checks abort the run; sharing this
+    prologue removes the drift surface.
+    """
     from policyengine_simulation_executor.simulation_runtime import (
         _country_module,
         _resolve_region,
@@ -97,6 +102,16 @@ def cohort_identity(year: int, group: list[str]) -> BaselineArtifactIdentity:
         country=PRECOMPUTE_COUNTRY,
         params=params,
     )
+    return params, country_module, resolution
+
+
+def cohort_identity(year: int, group: list[str]) -> BaselineArtifactIdentity:
+    """Identity via the executor's own resolution path (writer==reader)."""
+    from policyengine_simulation_executor.baseline_artifacts import (
+        qualifying_baseline_identity,
+    )
+
+    params, _, resolution = _cohort_resolution(year, group)
     identity = qualifying_baseline_identity(
         params,
         country=PRECOMPUTE_COUNTRY,
@@ -137,7 +152,7 @@ def build_manifest(plan: PrecomputePlan) -> ArtifactManifest:
         ManifestArtifact(
             type="baseline",
             path=entry.path,
-            filename=f"{entry.simulation_id}.h5",
+            filename=baseline_artifact_filename(entry.simulation_id),
             year=entry.year,
             digest=entry.digest,
         )
@@ -197,7 +212,7 @@ def plan_artifacts_impl(bucket: str) -> PrecomputePlan:
             )
 
     bundle = get_country_release_bundle(PRECOMPUTE_COUNTRY)
-    receipt = BundleReceipt(
+    receipt = BundleVersionIdentity(
         policyengine_version=bundle.policyengine_version,
         model_version=bundle.model_version,
         data_version=bundle.data_version,
@@ -209,7 +224,6 @@ def plan_artifacts_impl(bucket: str) -> PrecomputePlan:
 
 def build_dataset_impl(bucket: str, expected: DatasetPlanEntry) -> DatasetBuildResult:
     """Wave 1: build one single-year dataset and upload it."""
-    import os
     from pathlib import Path
 
     from policyengine_simulation_executor.artifact_keys import (
@@ -221,6 +235,7 @@ def build_dataset_impl(bucket: str, expected: DatasetPlanEntry) -> DatasetBuildR
     )
     from policyengine_simulation_executor.simulation_runtime import (
         _country_module,
+        resolve_data_folder,
     )
 
     identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, expected.year)
@@ -231,7 +246,7 @@ def build_dataset_impl(bucket: str, expected: DatasetPlanEntry) -> DatasetBuildR
             "under a mismatched key."
         )
 
-    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    data_folder = resolve_data_folder()
     country_module = _country_module(PRECOMPUTE_COUNTRY)
     started = time.monotonic()
     country_module.ensure_datasets(
@@ -256,7 +271,6 @@ def build_dataset_impl(bucket: str, expected: DatasetPlanEntry) -> DatasetBuildR
 
 def _prepare_cohort_baseline(bucket: str, expected: BaselinePlanEntry):
     """Shared by compute and verify: dataset download + simulation build."""
-    import os
     from pathlib import Path
 
     from policyengine_simulation_executor.artifact_keys import (
@@ -265,27 +279,20 @@ def _prepare_cohort_baseline(bucket: str, expected: BaselinePlanEntry):
     from policyengine_simulation_executor.artifact_store import ArtifactStore
     from policyengine_simulation_executor.simulation_runtime import (
         _build_simulation,
-        _country_module,
         _load_dataset,
-        _resolve_region,
+        resolve_data_folder,
     )
 
     store = ArtifactStore(bucket)
-    data_folder = Path(
-        os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
-    )
+    data_folder = Path(resolve_data_folder())
 
     dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, expected.year)
     local_dataset = data_folder / dataset_identity.filename
     if not local_dataset.exists():
         store.download_file(dataset_identity.store_path, local_dataset)
 
-    params = cohort_params(expected.year, expected.group)
-    country_module = _country_module(PRECOMPUTE_COUNTRY)
-    resolution = _resolve_region(
-        country_module=country_module,
-        country=PRECOMPUTE_COUNTRY,
-        params=params,
+    params, country_module, resolution = _cohort_resolution(
+        expected.year, expected.group
     )
     dataset = _load_dataset(
         params, country_module=country_module, region_resolution=resolution
@@ -334,7 +341,7 @@ def compute_baseline_impl(
     baseline.ensure()
     compute_seconds = time.monotonic() - started
 
-    artifact_file = data_folder / f"{baseline.id}.h5"
+    artifact_file = data_folder / baseline_artifact_filename(baseline.id)
     if not artifact_file.exists():
         raise RuntimeError(f"ensure() left no artifact at {artifact_file}")
     uploaded = store.upload_file(expected.path, artifact_file)
@@ -363,12 +370,14 @@ def verify_determinism_impl(
     """
     from policyengine.core import Simulation
 
+    from policyengine_simulation_executor.baseline_artifacts import OUTCOME_HIT
+
     store, data_folder, baseline = _prepare_cohort_baseline(bucket, expected)
-    artifact_file = data_folder / f"{baseline.id}.h5"
+    artifact_file = data_folder / baseline_artifact_filename(baseline.id)
     if not artifact_file.exists():
         store.download_file(expected.path, artifact_file)
     baseline.ensure()
-    if baseline.artifact_outcome != "hit":
+    if baseline.artifact_outcome != OUTCOME_HIT:
         raise RuntimeError(
             "Determinism gate could not load the artifact it verifies "
             f"(outcome={baseline.artifact_outcome})"

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute.py
@@ -7,6 +7,12 @@ here, mirroring the deployed app's split (``run_simulation`` ->
 executor package makes it testable without Modal fakes and importable by
 the CI deploy job and the GC planner.
 
+Data flow is strictly typed via ``precompute_models``: plans, entries,
+receipts, manifests, and worker results are Pydantic models everywhere
+inside the library; plain dicts appear only at the Modal serialization
+boundary (the app wrappers dump on the way out and validate on the way
+in).
+
 The store is content-addressed, so a precompute run is idempotent: it
 plans against the store and computes only misses; a re-run against a warm
 store is a no-op. ``force`` recomputes everything but CANNOT replace
@@ -27,7 +33,24 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Callable
+from typing import Callable
+
+from policyengine_simulation_executor.artifact_keys import (
+    BaselineArtifactIdentity,
+)
+from policyengine_simulation_executor.precompute_models import (
+    ArtifactManifest,
+    BaselineComputeResult,
+    BaselinePlanEntry,
+    BundleReceipt,
+    DatasetBuildResult,
+    DatasetPlanEntry,
+    DeterminismVerdict,
+    ManifestArtifact,
+    PrecomputePlan,
+    RemoteFunction,
+    WorkSelection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +80,7 @@ def cohort_params(year: int, group: list[str]) -> dict:
     }
 
 
-def cohort_identity(year: int, group: list[str]):
+def cohort_identity(year: int, group: list[str]) -> BaselineArtifactIdentity:
     """Identity via the executor's own resolution path (writer==reader)."""
     from policyengine_simulation_executor.baseline_artifacts import (
         qualifying_baseline_identity,
@@ -91,43 +114,44 @@ def cohort_identity(year: int, group: list[str]):
     return identity
 
 
-def select_work(plan: dict, *, force: bool) -> dict:
-    """Pure work selection: which plan entries need computing."""
-    datasets = [entry for entry in plan["datasets"] if force or not entry["exists"]]
-    baselines = [entry for entry in plan["baselines"] if force or not entry["exists"]]
-    return {"datasets": datasets, "baselines": baselines}
+def select_work(plan: PrecomputePlan, *, force: bool) -> WorkSelection:
+    """Which plan entries need computing."""
+    return WorkSelection(
+        datasets=[entry for entry in plan.datasets if force or not entry.exists],
+        baselines=[entry for entry in plan.baselines if force or not entry.exists],
+    )
 
 
-def build_manifest_payload(plan: dict) -> dict:
+def build_manifest(plan: PrecomputePlan) -> ArtifactManifest:
     """The deploy manifest: receipt + every artifact the image must fetch."""
     artifacts = [
-        {
-            "type": "dataset",
-            "path": entry["path"],
-            "filename": entry["filename"],
-            "year": entry["year"],
-            "digest": entry["digest"],
-        }
-        for entry in plan["datasets"]
+        ManifestArtifact(
+            type="dataset",
+            path=entry.path,
+            filename=entry.filename,
+            year=entry.year,
+            digest=entry.digest,
+        )
+        for entry in plan.datasets
     ] + [
-        {
-            "type": "baseline",
-            "path": entry["path"],
-            "filename": f"{entry['simulation_id']}.h5",
-            "year": entry["year"],
-            "digest": entry["digest"],
-        }
-        for entry in plan["baselines"]
+        ManifestArtifact(
+            type="baseline",
+            path=entry.path,
+            filename=f"{entry.simulation_id}.h5",
+            year=entry.year,
+            digest=entry.digest,
+        )
+        for entry in plan.baselines
     ]
-    return {
-        "schema": MANIFEST_SCHEMA,
-        "country": PRECOMPUTE_COUNTRY,
-        "receipt": plan["receipt"],
-        "artifacts": artifacts,
-    }
+    return ArtifactManifest(
+        manifest_schema=MANIFEST_SCHEMA,
+        country=PRECOMPUTE_COUNTRY,
+        receipt=plan.receipt,
+        artifacts=artifacts,
+    )
 
 
-def plan_artifacts_impl(bucket: str) -> dict:
+def plan_artifacts_impl(bucket: str) -> PrecomputePlan:
     """Compute every expected artifact identity and its store presence."""
     from policyengine_simulation_executor.artifact_keys import (
         collect_dataset_identity,
@@ -145,45 +169,45 @@ def plan_artifacts_impl(bucket: str) -> dict:
     if not groups:
         raise RuntimeError(f"No national partition for {PRECOMPUTE_COUNTRY!r}")
 
-    datasets = []
-    baselines = []
+    datasets: list[DatasetPlanEntry] = []
+    baselines: list[BaselinePlanEntry] = []
     for year in PRECOMPUTE_YEARS:
         dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
         datasets.append(
-            {
-                "year": year,
-                "digest": dataset_identity.digest,
-                "path": dataset_identity.store_path,
-                "filename": dataset_identity.filename,
-                "exists": store.exists(dataset_identity.store_path),
-            }
+            DatasetPlanEntry(
+                year=year,
+                digest=dataset_identity.digest,
+                path=dataset_identity.store_path,
+                filename=dataset_identity.filename,
+                exists=store.exists(dataset_identity.store_path),
+            )
         )
         for group in groups:
             identity = cohort_identity(year, group)
             baselines.append(
-                {
-                    "year": year,
-                    "group": list(group),
-                    "region": identity.region,
-                    "digest": identity.digest,
-                    "path": identity.store_path,
-                    "simulation_id": identity.simulation_id,
-                    "exists": store.exists(identity.store_path),
-                }
+                BaselinePlanEntry(
+                    year=year,
+                    group=list(group),
+                    region=identity.region,
+                    digest=identity.digest,
+                    path=identity.store_path,
+                    simulation_id=identity.simulation_id,
+                    exists=store.exists(identity.store_path),
+                )
             )
 
     bundle = get_country_release_bundle(PRECOMPUTE_COUNTRY)
-    receipt = {
-        "policyengine_version": bundle.policyengine_version,
-        "model_version": bundle.model_version,
-        "data_version": bundle.data_version,
-        "data_artifact_revision": bundle.data_artifact_revision,
-        "default_dataset": bundle.default_dataset,
-    }
-    return {"datasets": datasets, "baselines": baselines, "receipt": receipt}
+    receipt = BundleReceipt(
+        policyengine_version=bundle.policyengine_version,
+        model_version=bundle.model_version,
+        data_version=bundle.data_version,
+        data_artifact_revision=bundle.data_artifact_revision,
+        default_dataset=bundle.default_dataset,
+    )
+    return PrecomputePlan(datasets=datasets, baselines=baselines, receipt=receipt)
 
 
-def build_dataset_impl(bucket: str, year: int, expected_path: str) -> dict:
+def build_dataset_impl(bucket: str, expected: DatasetPlanEntry) -> DatasetBuildResult:
     """Wave 1: build one single-year dataset and upload it."""
     import os
     from pathlib import Path
@@ -199,11 +223,11 @@ def build_dataset_impl(bucket: str, year: int, expected_path: str) -> dict:
         _country_module,
     )
 
-    identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
-    if identity.store_path != expected_path:
+    identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, expected.year)
+    if identity.store_path != expected.path:
         raise RuntimeError(
             "Planned and in-container dataset identities disagree "
-            f"({expected_path} != {identity.store_path}); refusing to upload "
+            f"({expected.path} != {identity.store_path}); refusing to upload "
             "under a mismatched key."
         )
 
@@ -212,7 +236,7 @@ def build_dataset_impl(bucket: str, year: int, expected_path: str) -> dict:
     started = time.monotonic()
     country_module.ensure_datasets(
         datasets=[get_country_release_bundle(PRECOMPUTE_COUNTRY).default_dataset],
-        years=[year],
+        years=[expected.year],
         data_folder=data_folder,
     )
     build_seconds = time.monotonic() - started
@@ -221,16 +245,16 @@ def build_dataset_impl(bucket: str, year: int, expected_path: str) -> dict:
     if not local_file.exists():
         raise RuntimeError(f"ensure_datasets produced no file at {local_file}")
     uploaded = ArtifactStore(bucket).upload_file(identity.store_path, local_file)
-    return {
-        "year": year,
-        "path": identity.store_path,
-        "uploaded": uploaded,
-        "build_seconds": round(build_seconds, 1),
-        "size_bytes": local_file.stat().st_size,
-    }
+    return DatasetBuildResult(
+        year=expected.year,
+        path=identity.store_path,
+        uploaded=uploaded,
+        build_seconds=round(build_seconds, 1),
+        size_bytes=local_file.stat().st_size,
+    )
 
 
-def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
+def _prepare_cohort_baseline(bucket: str, expected: BaselinePlanEntry):
     """Shared by compute and verify: dataset download + simulation build."""
     import os
     from pathlib import Path
@@ -251,12 +275,12 @@ def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
         os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
     )
 
-    dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+    dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, expected.year)
     local_dataset = data_folder / dataset_identity.filename
     if not local_dataset.exists():
         store.download_file(dataset_identity.store_path, local_dataset)
 
-    params = cohort_params(year, group)
+    params = cohort_params(expected.year, expected.group)
     country_module = _country_module(PRECOMPUTE_COUNTRY)
     resolution = _resolve_region(
         country_module=country_module,
@@ -273,6 +297,12 @@ def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
         scoping_strategy=resolution.scoping_strategy,
         region_code=resolution.code,
     )
+    if baseline.id != expected.simulation_id:
+        raise RuntimeError(
+            "Planned and in-container baseline ids disagree "
+            f"({expected.simulation_id} != {baseline.id}); refusing to act "
+            "under a mismatched key."
+        )
 
     # The extras economic_impact_analysis applies unconditionally before
     # ensure(); the artifact must carry them or every request would fail
@@ -286,24 +316,18 @@ def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
 
 
 def compute_baseline_impl(
-    bucket: str, year: int, group: list[str], expected: dict
-) -> dict:
+    bucket: str, expected: BaselinePlanEntry
+) -> BaselineComputeResult:
     """Wave 2: compute one cohort baseline and upload its output."""
     from policyengine_simulation_executor.baseline_artifacts import (
         ArtifactBaselineSimulation,
     )
 
-    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
+    store, data_folder, baseline = _prepare_cohort_baseline(bucket, expected)
     if not isinstance(baseline, ArtifactBaselineSimulation):
         raise RuntimeError(
             "Precompute built a plain Simulation — the qualifying predicate "
             "rejected the cohort request shape."
-        )
-    if baseline.id != expected["simulation_id"]:
-        raise RuntimeError(
-            "Planned and in-container baseline ids disagree "
-            f"({expected['simulation_id']} != {baseline.id}); refusing to "
-            "upload under a mismatched key."
         )
 
     started = time.monotonic()
@@ -313,21 +337,21 @@ def compute_baseline_impl(
     artifact_file = data_folder / f"{baseline.id}.h5"
     if not artifact_file.exists():
         raise RuntimeError(f"ensure() left no artifact at {artifact_file}")
-    uploaded = store.upload_file(expected["path"], artifact_file)
-    return {
-        "year": year,
-        "group": list(group),
-        "simulation_id": baseline.id,
-        "outcome": baseline.artifact_outcome,
-        "uploaded": uploaded,
-        "compute_seconds": round(compute_seconds, 1),
-        "size_bytes": artifact_file.stat().st_size,
-    }
+    uploaded = store.upload_file(expected.path, artifact_file)
+    return BaselineComputeResult(
+        year=expected.year,
+        group=list(expected.group),
+        simulation_id=baseline.id,
+        outcome=baseline.artifact_outcome,
+        uploaded=uploaded,
+        compute_seconds=round(compute_seconds, 1),
+        size_bytes=artifact_file.stat().st_size,
+    )
 
 
 def verify_determinism_impl(
-    bucket: str, year: int, group: list[str], expected: dict
-) -> dict:
+    bucket: str, expected: BaselinePlanEntry
+) -> DeterminismVerdict:
     """Load the uploaded artifact, recompute independently, compare frames.
 
     Exact comparison of every entity column (values and dtypes) between the
@@ -339,15 +363,10 @@ def verify_determinism_impl(
     """
     from policyengine.core import Simulation
 
-    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
-    if baseline.id != expected["simulation_id"]:
-        raise RuntimeError(
-            "Planned and in-container baseline ids disagree "
-            f"({expected['simulation_id']} != {baseline.id})"
-        )
+    store, data_folder, baseline = _prepare_cohort_baseline(bucket, expected)
     artifact_file = data_folder / f"{baseline.id}.h5"
     if not artifact_file.exists():
-        store.download_file(expected["path"], artifact_file)
+        store.download_file(expected.path, artifact_file)
     baseline.ensure()
     if baseline.artifact_outcome != "hit":
         raise RuntimeError(
@@ -380,81 +399,81 @@ def verify_determinism_impl(
                 differences.append(f"{entity}.{column}: dtype differs")
             elif not left[column].equals(right[column]):
                 differences.append(f"{entity}.{column}: values differ")
-    return {"equal": not differences, "differences": differences[:50]}
+    return DeterminismVerdict(equal=not differences, differences=differences[:50])
 
 
-def publish_manifest_impl(bucket: str, plan: dict) -> str:
+def publish_manifest_impl(bucket: str, plan: PrecomputePlan) -> str:
     from policyengine_simulation_executor.artifact_store import ArtifactStore
 
-    return ArtifactStore(bucket).write_manifest(build_manifest_payload(plan))
+    manifest = build_manifest(plan)
+    return ArtifactStore(bucket).write_manifest(manifest.canonical_payload())
 
 
 def run_precompute(
     bucket: str,
     *,
     force: bool,
-    plan_artifacts: Any,
-    build_dataset: Any,
-    compute_baseline: Any,
-    verify_determinism: Any,
-    publish_manifest: Any,
+    plan_artifacts: RemoteFunction,
+    build_dataset: RemoteFunction,
+    compute_baseline: RemoteFunction,
+    verify_determinism: RemoteFunction,
+    publish_manifest: RemoteFunction,
     echo: Callable[[str], None] = print,
 ) -> str:
     """The local-entrypoint orchestration: plan, spawn misses, gate, publish.
 
     Takes the five Modal function handles as parameters (each offering
-    ``.remote``/``.spawn``) so the flow is testable with plain fakes. The
-    determinism gate runs only when baselines were actually computed (a
-    no-op run must stay a no-op). Returns the manifest digest; the LAST
-    echoed line is the ``MANIFEST_DIGEST=`` contract the deploy job parses.
+    ``.remote``/``.spawn``) so the flow is testable with plain fakes.
+    Everything crossing a handle is a plain dict (Modal's serialization
+    boundary); it is validated back into models immediately on return.
+    The determinism gate runs only when baselines were actually computed
+    (a no-op run must stay a no-op). Returns the manifest digest; the
+    LAST echoed line is the ``MANIFEST_DIGEST=`` contract the deploy job
+    parses.
     """
     echo(f"Planning against gs://{bucket} (force={force})")
-    plan = plan_artifacts.remote(bucket)
+    plan = PrecomputePlan.model_validate(plan_artifacts.remote(bucket))
     work = select_work(plan, force=force)
     echo(
-        f"Plan: {len(plan['datasets'])} datasets ({len(work['datasets'])} to "
-        f"build), {len(plan['baselines'])} baselines "
-        f"({len(work['baselines'])} to compute)"
+        f"Plan: {len(plan.datasets)} datasets ({len(work.datasets)} to "
+        f"build), {len(plan.baselines)} baselines "
+        f"({len(work.baselines)} to compute)"
     )
 
     dataset_handles = [
-        build_dataset.spawn(bucket, entry["year"], entry["path"])
-        for entry in work["datasets"]
+        build_dataset.spawn(bucket, entry.model_dump()) for entry in work.datasets
     ]
     for handle in dataset_handles:
-        result = handle.get()
+        result = DatasetBuildResult.model_validate(handle.get())
         echo(
-            f"dataset year={result['year']} built in "
-            f"{result['build_seconds']}s ({result['size_bytes']} bytes, "
-            f"uploaded={result['uploaded']})"
+            f"dataset year={result.year} built in "
+            f"{result.build_seconds}s ({result.size_bytes} bytes, "
+            f"uploaded={result.uploaded})"
         )
 
     baseline_handles = [
-        compute_baseline.spawn(bucket, entry["year"], entry["group"], entry)
-        for entry in work["baselines"]
+        compute_baseline.spawn(bucket, entry.model_dump()) for entry in work.baselines
     ]
     for handle in baseline_handles:
-        result = handle.get()
+        result = BaselineComputeResult.model_validate(handle.get())
         echo(
-            f"baseline year={result['year']} id={result['simulation_id']} "
-            f"outcome={result['outcome']} in {result['compute_seconds']}s "
-            f"(uploaded={result['uploaded']})"
+            f"baseline year={result.year} id={result.simulation_id} "
+            f"outcome={result.outcome} in {result.compute_seconds}s "
+            f"(uploaded={result.uploaded})"
         )
 
-    if work["baselines"]:
-        probe = work["baselines"][0]
-        echo(
-            f"Determinism gate: recomputing year={probe['year']} group={probe['group']}"
+    if work.baselines:
+        probe = work.baselines[0]
+        echo(f"Determinism gate: recomputing year={probe.year} group={probe.group}")
+        verdict = DeterminismVerdict.model_validate(
+            verify_determinism.remote(bucket, probe.model_dump())
         )
-        verdict = verify_determinism.remote(
-            bucket, probe["year"], probe["group"], probe
-        )
-        if not verdict["equal"]:
+        if not verdict.equal:
             raise SystemExit(
-                "Determinism gate FAILED: " + "; ".join(verdict["differences"])
+                "Determinism gate FAILED: " + "; ".join(verdict.differences)
             )
         echo("Determinism gate passed")
 
-    manifest_digest = publish_manifest.remote(bucket, plan)
+    manifest_digest = publish_manifest.remote(bucket, plan.model_dump())
     echo(manifest_digest_line(manifest_digest))
     return manifest_digest

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute.py
@@ -1,0 +1,460 @@
+"""Library half of the artifact precompute (the write path of the pipeline).
+
+``src/modal/precompute_app.py`` holds only the Modal plumbing — app, image,
+function declarations, local entrypoint — and every function body lives
+here, mirroring the deployed app's split (``run_simulation`` ->
+``simulation_runtime.run_simulation_impl``). Keeping the logic in the
+executor package makes it testable without Modal fakes and importable by
+the CI deploy job and the GC planner.
+
+The store is content-addressed, so a precompute run is idempotent: it
+plans against the store and computes only misses; a re-run against a warm
+store is a no-op. ``force`` recomputes everything but CANNOT replace
+existing store objects (uploads are write-once) — healing a bad artifact
+means deleting its object first, then re-running.
+
+Cohort baselines are built through the executor's own request path
+(``_resolve_region`` + ``_build_simulation`` on a synthetic child request),
+so scoping, extra variables, and the deterministic simulation id match the
+production child's by construction, not by convention — and a regression
+test asserts the writer and reader derive identical identities. All
+identity collection and store I/O must run inside containers: the bundle
+receipt that the keys digest lives in the image, not on the deploying
+machine.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+PRECOMPUTE_COUNTRY = "us"
+# The user-facing priority order (2026 first); with parallel waves it only
+# orders spawn submission, but keep it intentional.
+PRECOMPUTE_YEARS = [2026, 2027, 2025]
+
+MANIFEST_SCHEMA = "mf1"
+
+# The stdout contract the CI deploy job parses; keep format changes in
+# lockstep with the workflow side (covered by a regression test).
+MANIFEST_DIGEST_PREFIX = "MANIFEST_DIGEST="
+
+
+def manifest_digest_line(digest: str) -> str:
+    return f"{MANIFEST_DIGEST_PREFIX}{digest}"
+
+
+def cohort_params(year: int, group: list[str]) -> dict:
+    """The synthetic request a segmented-national child would receive."""
+    return {
+        "country": PRECOMPUTE_COUNTRY,
+        "scope": "macro",
+        "region_group": list(group),
+        "time_period": year,
+    }
+
+
+def cohort_identity(year: int, group: list[str]):
+    """Identity via the executor's own resolution path (writer==reader)."""
+    from policyengine_simulation_executor.baseline_artifacts import (
+        qualifying_baseline_identity,
+    )
+    from policyengine_simulation_executor.simulation_runtime import (
+        _country_module,
+        _resolve_region,
+    )
+
+    params = cohort_params(year, group)
+    country_module = _country_module(PRECOMPUTE_COUNTRY)
+    resolution = _resolve_region(
+        country_module=country_module,
+        country=PRECOMPUTE_COUNTRY,
+        params=params,
+    )
+    identity = qualifying_baseline_identity(
+        params,
+        country=PRECOMPUTE_COUNTRY,
+        policy=None,
+        region_code=resolution.code,
+        scoping_strategy=resolution.scoping_strategy,
+        year=year,
+    )
+    if identity is None:
+        raise RuntimeError(
+            f"Cohort request for year {year} group {group} does not qualify "
+            "for a deterministic baseline id — writer and reader predicates "
+            "have diverged."
+        )
+    return identity
+
+
+def select_work(plan: dict, *, force: bool) -> dict:
+    """Pure work selection: which plan entries need computing."""
+    datasets = [entry for entry in plan["datasets"] if force or not entry["exists"]]
+    baselines = [entry for entry in plan["baselines"] if force or not entry["exists"]]
+    return {"datasets": datasets, "baselines": baselines}
+
+
+def build_manifest_payload(plan: dict) -> dict:
+    """The deploy manifest: receipt + every artifact the image must fetch."""
+    artifacts = [
+        {
+            "type": "dataset",
+            "path": entry["path"],
+            "filename": entry["filename"],
+            "year": entry["year"],
+            "digest": entry["digest"],
+        }
+        for entry in plan["datasets"]
+    ] + [
+        {
+            "type": "baseline",
+            "path": entry["path"],
+            "filename": f"{entry['simulation_id']}.h5",
+            "year": entry["year"],
+            "digest": entry["digest"],
+        }
+        for entry in plan["baselines"]
+    ]
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "country": PRECOMPUTE_COUNTRY,
+        "receipt": plan["receipt"],
+        "artifacts": artifacts,
+    }
+
+
+def plan_artifacts_impl(bucket: str) -> dict:
+    """Compute every expected artifact identity and its store presence."""
+    from policyengine_simulation_executor.artifact_keys import (
+        collect_dataset_identity,
+    )
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.national_partition import (
+        national_region_groups,
+    )
+    from policyengine_simulation_executor.release_bundle import (
+        get_country_release_bundle,
+    )
+
+    store = ArtifactStore(bucket)
+    groups = national_region_groups(PRECOMPUTE_COUNTRY)
+    if not groups:
+        raise RuntimeError(f"No national partition for {PRECOMPUTE_COUNTRY!r}")
+
+    datasets = []
+    baselines = []
+    for year in PRECOMPUTE_YEARS:
+        dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+        datasets.append(
+            {
+                "year": year,
+                "digest": dataset_identity.digest,
+                "path": dataset_identity.store_path,
+                "filename": dataset_identity.filename,
+                "exists": store.exists(dataset_identity.store_path),
+            }
+        )
+        for group in groups:
+            identity = cohort_identity(year, group)
+            baselines.append(
+                {
+                    "year": year,
+                    "group": list(group),
+                    "region": identity.region,
+                    "digest": identity.digest,
+                    "path": identity.store_path,
+                    "simulation_id": identity.simulation_id,
+                    "exists": store.exists(identity.store_path),
+                }
+            )
+
+    bundle = get_country_release_bundle(PRECOMPUTE_COUNTRY)
+    receipt = {
+        "policyengine_version": bundle.policyengine_version,
+        "model_version": bundle.model_version,
+        "data_version": bundle.data_version,
+        "data_artifact_revision": bundle.data_artifact_revision,
+        "default_dataset": bundle.default_dataset,
+    }
+    return {"datasets": datasets, "baselines": baselines, "receipt": receipt}
+
+
+def build_dataset_impl(bucket: str, year: int, expected_path: str) -> dict:
+    """Wave 1: build one single-year dataset and upload it."""
+    import os
+    from pathlib import Path
+
+    from policyengine_simulation_executor.artifact_keys import (
+        collect_dataset_identity,
+    )
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.release_bundle import (
+        get_country_release_bundle,
+    )
+    from policyengine_simulation_executor.simulation_runtime import (
+        _country_module,
+    )
+
+    identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+    if identity.store_path != expected_path:
+        raise RuntimeError(
+            "Planned and in-container dataset identities disagree "
+            f"({expected_path} != {identity.store_path}); refusing to upload "
+            "under a mismatched key."
+        )
+
+    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    country_module = _country_module(PRECOMPUTE_COUNTRY)
+    started = time.monotonic()
+    country_module.ensure_datasets(
+        datasets=[get_country_release_bundle(PRECOMPUTE_COUNTRY).default_dataset],
+        years=[year],
+        data_folder=data_folder,
+    )
+    build_seconds = time.monotonic() - started
+
+    local_file = Path(data_folder) / identity.filename
+    if not local_file.exists():
+        raise RuntimeError(f"ensure_datasets produced no file at {local_file}")
+    uploaded = ArtifactStore(bucket).upload_file(identity.store_path, local_file)
+    return {
+        "year": year,
+        "path": identity.store_path,
+        "uploaded": uploaded,
+        "build_seconds": round(build_seconds, 1),
+        "size_bytes": local_file.stat().st_size,
+    }
+
+
+def _prepare_cohort_baseline(bucket: str, year: int, group: list[str]):
+    """Shared by compute and verify: dataset download + simulation build."""
+    import os
+    from pathlib import Path
+
+    from policyengine_simulation_executor.artifact_keys import (
+        collect_dataset_identity,
+    )
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+    from policyengine_simulation_executor.simulation_runtime import (
+        _build_simulation,
+        _country_module,
+        _load_dataset,
+        _resolve_region,
+    )
+
+    store = ArtifactStore(bucket)
+    data_folder = Path(
+        os.environ.get("POLICYENGINE_DATA_FOLDER", "/opt/policyengine/data")
+    )
+
+    dataset_identity = collect_dataset_identity(PRECOMPUTE_COUNTRY, year)
+    local_dataset = data_folder / dataset_identity.filename
+    if not local_dataset.exists():
+        store.download_file(dataset_identity.store_path, local_dataset)
+
+    params = cohort_params(year, group)
+    country_module = _country_module(PRECOMPUTE_COUNTRY)
+    resolution = _resolve_region(
+        country_module=country_module,
+        country=PRECOMPUTE_COUNTRY,
+        params=params,
+    )
+    dataset = _load_dataset(
+        params, country_module=country_module, region_resolution=resolution
+    )
+    baseline = _build_simulation(
+        params,
+        dataset=dataset,
+        policy=None,
+        scoping_strategy=resolution.scoping_strategy,
+        region_code=resolution.code,
+    )
+
+    # The extras economic_impact_analysis applies unconditionally before
+    # ensure(); the artifact must carry them or every request would fail
+    # the column guard and recompute.
+    from policyengine.tax_benefit_models.us.analysis import (
+        configure_budgetary_impact_variables,
+    )
+
+    configure_budgetary_impact_variables(baseline, baseline)
+    return store, data_folder, baseline
+
+
+def compute_baseline_impl(
+    bucket: str, year: int, group: list[str], expected: dict
+) -> dict:
+    """Wave 2: compute one cohort baseline and upload its output."""
+    from policyengine_simulation_executor.baseline_artifacts import (
+        ArtifactBaselineSimulation,
+    )
+
+    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
+    if not isinstance(baseline, ArtifactBaselineSimulation):
+        raise RuntimeError(
+            "Precompute built a plain Simulation — the qualifying predicate "
+            "rejected the cohort request shape."
+        )
+    if baseline.id != expected["simulation_id"]:
+        raise RuntimeError(
+            "Planned and in-container baseline ids disagree "
+            f"({expected['simulation_id']} != {baseline.id}); refusing to "
+            "upload under a mismatched key."
+        )
+
+    started = time.monotonic()
+    baseline.ensure()
+    compute_seconds = time.monotonic() - started
+
+    artifact_file = data_folder / f"{baseline.id}.h5"
+    if not artifact_file.exists():
+        raise RuntimeError(f"ensure() left no artifact at {artifact_file}")
+    uploaded = store.upload_file(expected["path"], artifact_file)
+    return {
+        "year": year,
+        "group": list(group),
+        "simulation_id": baseline.id,
+        "outcome": baseline.artifact_outcome,
+        "uploaded": uploaded,
+        "compute_seconds": round(compute_seconds, 1),
+        "size_bytes": artifact_file.stat().st_size,
+    }
+
+
+def verify_determinism_impl(
+    bucket: str, year: int, group: list[str], expected: dict
+) -> dict:
+    """Load the uploaded artifact, recompute independently, compare frames.
+
+    Exact comparison of every entity column (values and dtypes) between the
+    store artifact (downloaded and loaded through ``ensure()``, so the save/
+    load round-trip is under test too) and a fresh independent run — the
+    direct check of "same key, same bytes". File-level byte equality is
+    deliberately not used (HDF5 container metadata is not guaranteed
+    stable).
+    """
+    from policyengine.core import Simulation
+
+    store, data_folder, baseline = _prepare_cohort_baseline(bucket, year, group)
+    if baseline.id != expected["simulation_id"]:
+        raise RuntimeError(
+            "Planned and in-container baseline ids disagree "
+            f"({expected['simulation_id']} != {baseline.id})"
+        )
+    artifact_file = data_folder / f"{baseline.id}.h5"
+    if not artifact_file.exists():
+        store.download_file(expected["path"], artifact_file)
+    baseline.ensure()
+    if baseline.artifact_outcome != "hit":
+        raise RuntimeError(
+            "Determinism gate could not load the artifact it verifies "
+            f"(outcome={baseline.artifact_outcome})"
+        )
+
+    fresh = Simulation(
+        dataset=baseline.dataset,
+        tax_benefit_model_version=baseline.tax_benefit_model_version,
+        policy=None,
+        scoping_strategy=baseline.scoping_strategy,
+        extra_variables=dict(baseline.extra_variables),
+    )
+    fresh.run()
+
+    differences = []
+    loaded = baseline.output_dataset.data.entity_data
+    recomputed = fresh.output_dataset.data.entity_data
+    for entity in sorted(set(loaded) | set(recomputed)):
+        left, right = loaded.get(entity), recomputed.get(entity)
+        if left is None or right is None:
+            differences.append(f"{entity}: missing on one side")
+            continue
+        left_cols, right_cols = set(left.columns), set(right.columns)
+        for column in sorted(left_cols ^ right_cols):
+            differences.append(f"{entity}.{column}: only on one side")
+        for column in sorted(left_cols & right_cols):
+            if str(left[column].dtype) != str(right[column].dtype):
+                differences.append(f"{entity}.{column}: dtype differs")
+            elif not left[column].equals(right[column]):
+                differences.append(f"{entity}.{column}: values differ")
+    return {"equal": not differences, "differences": differences[:50]}
+
+
+def publish_manifest_impl(bucket: str, plan: dict) -> str:
+    from policyengine_simulation_executor.artifact_store import ArtifactStore
+
+    return ArtifactStore(bucket).write_manifest(build_manifest_payload(plan))
+
+
+def run_precompute(
+    bucket: str,
+    *,
+    force: bool,
+    plan_artifacts: Any,
+    build_dataset: Any,
+    compute_baseline: Any,
+    verify_determinism: Any,
+    publish_manifest: Any,
+    echo: Callable[[str], None] = print,
+) -> str:
+    """The local-entrypoint orchestration: plan, spawn misses, gate, publish.
+
+    Takes the five Modal function handles as parameters (each offering
+    ``.remote``/``.spawn``) so the flow is testable with plain fakes. The
+    determinism gate runs only when baselines were actually computed (a
+    no-op run must stay a no-op). Returns the manifest digest; the LAST
+    echoed line is the ``MANIFEST_DIGEST=`` contract the deploy job parses.
+    """
+    echo(f"Planning against gs://{bucket} (force={force})")
+    plan = plan_artifacts.remote(bucket)
+    work = select_work(plan, force=force)
+    echo(
+        f"Plan: {len(plan['datasets'])} datasets ({len(work['datasets'])} to "
+        f"build), {len(plan['baselines'])} baselines "
+        f"({len(work['baselines'])} to compute)"
+    )
+
+    dataset_handles = [
+        build_dataset.spawn(bucket, entry["year"], entry["path"])
+        for entry in work["datasets"]
+    ]
+    for handle in dataset_handles:
+        result = handle.get()
+        echo(
+            f"dataset year={result['year']} built in "
+            f"{result['build_seconds']}s ({result['size_bytes']} bytes, "
+            f"uploaded={result['uploaded']})"
+        )
+
+    baseline_handles = [
+        compute_baseline.spawn(bucket, entry["year"], entry["group"], entry)
+        for entry in work["baselines"]
+    ]
+    for handle in baseline_handles:
+        result = handle.get()
+        echo(
+            f"baseline year={result['year']} id={result['simulation_id']} "
+            f"outcome={result['outcome']} in {result['compute_seconds']}s "
+            f"(uploaded={result['uploaded']})"
+        )
+
+    if work["baselines"]:
+        probe = work["baselines"][0]
+        echo(
+            f"Determinism gate: recomputing year={probe['year']} group={probe['group']}"
+        )
+        verdict = verify_determinism.remote(
+            bucket, probe["year"], probe["group"], probe
+        )
+        if not verdict["equal"]:
+            raise SystemExit(
+                "Determinism gate FAILED: " + "; ".join(verdict["differences"])
+            )
+        echo("Determinism gate passed")
+
+    manifest_digest = publish_manifest.remote(bucket, plan)
+    echo(manifest_digest_line(manifest_digest))
+    return manifest_digest

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute_models.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute_models.py
@@ -1,0 +1,135 @@
+"""Typed schemas for the precompute pipeline's data flow.
+
+Every structure that crosses a function boundary in the precompute — the
+plan, its entries, the bundle receipt, the deploy manifest, and the worker
+results — is a strict Pydantic model (``extra="forbid"``), matching the
+gateway contract's discipline. Plain dicts exist only at the Modal
+serialization boundary: the app wrappers ``model_dump()`` on the way out
+of a container and ``model_validate()`` on the way in, so a shape drift
+between planner and worker fails loudly at the edge instead of surfacing
+as a KeyError mid-computation.
+
+Wire-compatibility constraint: ``ArtifactManifest.canonical_payload()``
+must keep producing the exact key/value shape the store already holds —
+the manifest is content-addressed, so any change here rotates published
+digests. A regression test locks the digest of a fixed payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Mirrors baseline_artifacts.OUTCOME_*; the artifact outcome a worker
+# observed when ensuring a baseline.
+ArtifactOutcome = Literal["hit", "incomplete", "miss"]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class BundleReceipt(_StrictModel):
+    """The version identity of the installed bundle a plan was made for."""
+
+    policyengine_version: str
+    model_version: str
+    data_version: str
+    data_artifact_revision: str
+    default_dataset: str
+
+
+class DatasetPlanEntry(_StrictModel):
+    """One single-year dataset artifact: identity plus store presence."""
+
+    year: int
+    digest: str
+    path: str
+    filename: str
+    exists: bool
+
+
+class BaselinePlanEntry(_StrictModel):
+    """One cohort baseline artifact: identity plus store presence."""
+
+    year: int
+    group: list[str]
+    region: str
+    digest: str
+    path: str
+    simulation_id: str
+    exists: bool
+
+
+class PrecomputePlan(_StrictModel):
+    """Everything the store should contain for the installed bundle."""
+
+    datasets: list[DatasetPlanEntry]
+    baselines: list[BaselinePlanEntry]
+    receipt: BundleReceipt
+
+
+class WorkSelection(_StrictModel):
+    """The subset of a plan that actually needs computing."""
+
+    datasets: list[DatasetPlanEntry]
+    baselines: list[BaselinePlanEntry]
+
+
+class ManifestArtifact(_StrictModel):
+    """One artifact the deploy image must fetch."""
+
+    type: Literal["dataset", "baseline"]
+    path: str
+    filename: str
+    year: int
+    digest: str
+
+
+class ArtifactManifest(_StrictModel):
+    """The published deploy manifest (content-addressed in the store)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    # "schema" is the wire key; the Python name avoids shadowing
+    # BaseModel's deprecated .schema attribute.
+    manifest_schema: str = Field(alias="schema")
+    country: str
+    receipt: BundleReceipt
+    artifacts: list[ManifestArtifact]
+
+    def canonical_payload(self) -> dict[str, Any]:
+        """The exact dict shape that gets digested and stored."""
+        return self.model_dump(by_alias=True)
+
+
+class DatasetBuildResult(_StrictModel):
+    year: int
+    path: str
+    uploaded: bool
+    build_seconds: float
+    size_bytes: int
+
+
+class BaselineComputeResult(_StrictModel):
+    year: int
+    group: list[str]
+    simulation_id: str
+    outcome: Optional[ArtifactOutcome]
+    uploaded: bool
+    compute_seconds: float
+    size_bytes: int
+
+
+class DeterminismVerdict(_StrictModel):
+    equal: bool
+    differences: list[str]
+
+
+class RemoteFunction(Protocol):
+    """The slice of a Modal function handle the orchestration uses."""
+
+    def remote(self, *args: Any) -> Any: ...
+
+    def spawn(self, *args: Any) -> Any: ...

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute_models.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/precompute_models.py
@@ -1,13 +1,15 @@
 """Typed schemas for the precompute pipeline's data flow.
 
 Every structure that crosses a function boundary in the precompute — the
-plan, its entries, the bundle receipt, the deploy manifest, and the worker
-results — is a strict Pydantic model (``extra="forbid"``), matching the
-gateway contract's discipline. Plain dicts exist only at the Modal
-serialization boundary: the app wrappers ``model_dump()`` on the way out
-of a container and ``model_validate()`` on the way in, so a shape drift
-between planner and worker fails loudly at the edge instead of surfacing
-as a KeyError mid-computation.
+plan, its entries, the bundle version identity, the deploy manifest, and
+the worker results — is a strict Pydantic model (``extra="forbid"``),
+matching the gateway contract's discipline. Plain dicts exist only at the
+Modal serialization boundary: wherever a structured value crosses, the
+app wrappers ``model_dump()`` on the way out of a container and
+``model_validate()`` on the way in (bare strings — the bucket, the
+manifest digest — cross as-is), so a shape drift between planner and
+worker fails loudly at the edge instead of surfacing as a KeyError
+mid-computation.
 
 Wire-compatibility constraint: ``ArtifactManifest.canonical_payload()``
 must keep producing the exact key/value shape the store already holds —
@@ -30,8 +32,14 @@ class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class BundleReceipt(_StrictModel):
-    """The version identity of the installed bundle a plan was made for."""
+class BundleVersionIdentity(_StrictModel):
+    """The version identity of the installed bundle a plan was made for.
+
+    Travels under the frozen wire key ``receipt``, but is deliberately NOT
+    the install receipt file (``.policyengine-bundle-receipt.json``): that
+    carries per-dataset content hashes, which live inside the artifact
+    digests here, not in this version tuple.
+    """
 
     policyengine_version: str
     model_version: str
@@ -67,7 +75,7 @@ class PrecomputePlan(_StrictModel):
 
     datasets: list[DatasetPlanEntry]
     baselines: list[BaselinePlanEntry]
-    receipt: BundleReceipt
+    receipt: BundleVersionIdentity
 
 
 class WorkSelection(_StrictModel):
@@ -96,7 +104,7 @@ class ArtifactManifest(_StrictModel):
     # BaseModel's deprecated .schema attribute.
     manifest_schema: str = Field(alias="schema")
     country: str
-    receipt: BundleReceipt
+    receipt: BundleVersionIdentity
     artifacts: list[ManifestArtifact]
 
     def canonical_payload(self) -> dict[str, Any]:

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_runtime.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_runtime.py
@@ -422,6 +422,16 @@ def _country_module(country: str):
     return import_module(f"policyengine.tax_benefit_models.{country}")
 
 
+def resolve_data_folder() -> str:
+    """The folder datasets and baseline artifacts are read from and saved to.
+
+    One home for the default: the precompute downloads store artifacts into
+    this folder for ``ensure_datasets``/``Simulation.ensure()`` to find, so
+    any divergence from ``_load_dataset``'s resolution strands them.
+    """
+    return os.environ.get("POLICYENGINE_DATA_FOLDER", "/tmp/policyengine-data")
+
+
 def _load_dataset(
     params: dict[str, Any],
     *,
@@ -436,7 +446,9 @@ def _load_dataset(
         if region_resolution is not None and region_resolution.dataset_reference
         else _resolve_dataset_reference(country, params)
     )
-    data_folder = os.environ.get("POLICYENGINE_DATA_FOLDER", "/tmp/policyengine-data")
+    from policyengine_simulation_executor.baseline_artifacts import uses_custom_data
+
+    data_folder = resolve_data_folder()
     # TEMPORARY: remove once single-year datasets are published (issue #596).
     # The image bakes default-revision single-year files into
     # POLICYENGINE_DATA_FOLDER, and ensure_datasets keys its cache on a
@@ -444,7 +456,7 @@ def _load_dataset(
     # stem matches the default would silently read the baked files. Only
     # pure default requests may use the baked folder. (Region requests
     # resolve their dataset without the "data" param, so they keep it.)
-    if params.get("data") is not None or params.get("data_version") is not None:
+    if uses_custom_data(params):
         data_folder = "/tmp/policyengine-data"
 
     start = time.monotonic()

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_runtime.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/simulation_runtime.py
@@ -469,10 +469,36 @@ def _build_simulation(
     dataset,
     policy: dict[str, Any] | None,
     scoping_strategy=None,
+    region_code: str | None = None,
 ):
     from policyengine.core import Simulation
 
-    country_module = _country_module(params.get("country", "us"))
+    from policyengine_simulation_executor.baseline_artifacts import (
+        ArtifactBaselineSimulation,
+        deterministic_baseline_id,
+    )
+
+    country = params.get("country", "us")
+    country_module = _country_module(country)
+    simulation_id = deterministic_baseline_id(
+        params,
+        country=country,
+        policy=policy,
+        region_code=region_code,
+        scoping_strategy=scoping_strategy,
+        year=_parse_year(params),
+    )
+    if simulation_id is not None:
+        # Deterministic id: ensure() loads a precomputed baseline artifact
+        # when one is baked beside the dataset, and the subclass validates
+        # the load (falling back to run()) — see baseline_artifacts.
+        return ArtifactBaselineSimulation(
+            id=simulation_id,
+            dataset=dataset,
+            tax_benefit_model_version=country_module.model,
+            policy=policy,
+            scoping_strategy=scoping_strategy,
+        )
     return Simulation(
         dataset=dataset,
         tax_benefit_model_version=country_module.model,
@@ -529,6 +555,7 @@ def _run_simulation_impl_core(params: dict) -> dict:
             dataset=dataset,
             policy=baseline_policy,
             scoping_strategy=region_resolution.scoping_strategy,
+            region_code=region_resolution.code,
         )
     with segment(SegmentName.SIMULATION_BUILD, simulation_kind="reform"):
         reform = _build_simulation(
@@ -536,6 +563,7 @@ def _run_simulation_impl_core(params: dict) -> dict:
             dataset=dataset,
             policy=reform_policy,
             scoping_strategy=region_resolution.scoping_strategy,
+            region_code=region_resolution.code,
         )
 
     logger.info("Calculating economic impact")
@@ -550,6 +578,12 @@ def _run_simulation_impl_core(params: dict) -> dict:
         resolved_region_code=region_resolution.code,
     )
     output = builder.serialize()
+    # ensure() has run inside the builder by now, so the artifact outcome
+    # (hit / incomplete / miss) is known for deterministic-id baselines.
+    artifact_outcome = getattr(baseline, "artifact_outcome", None)
+    if artifact_outcome is not None:
+        set_attribute("baseline_artifact", artifact_outcome)
+        logger.info("Baseline artifact outcome: %s", artifact_outcome)
     logger.info("Comparison complete")
     if params.get("_emit_microdata"):
         from policyengine_simulation_executor.simulation_microdata import (

--- a/projects/policyengine-simulation-executor/tests/test_artifact_keys.py
+++ b/projects/policyengine-simulation-executor/tests/test_artifact_keys.py
@@ -1,0 +1,217 @@
+"""Artifact key discipline tests.
+
+The content-addressed store's whole correctness story rests on three
+properties pinned here: (1) digests are canonical (field order never
+matters), (2) every payload field independently rotates the digest (no
+input silently outside the key), and (3) the digests and the upstream
+``ScopingStrategy.cache_key`` strings are STABLE — the golden pins turn
+any change into a conscious, reviewable diff instead of silent cache
+churn (or, worse, a writer/reader mismatch).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from policyengine_simulation_executor import artifact_keys as ak
+
+
+_DATASET_KWARGS = dict(
+    country="us",
+    dataset="populace_cps",
+    year=2026,
+    data_version="1.2.3",
+    data_artifact_revision="rev-abc",
+    source_sha256="feedbead" * 8,
+    data_build_fingerprint="fp-123",
+    model_version="9.9.9",
+    policyengine_version="4.22.0",
+)
+
+_DATASET_GOLDEN = "183ffe49d74669b653fb408b0b7298128ba7c6e990f4479487712a5d79553be3"
+_DATASET_NO_SHA_GOLDEN = (
+    "25dded8192092f477e4502dae07709e72b6e579f372a9f8346b5eabce07d91b6"
+)
+
+_BASELINE_KWARGS = dict(
+    country="us",
+    region="national",
+    scope_key="region_group:row_filter:state_code=CA|row_filter:state_code=WV",
+    dataset_digest=_DATASET_GOLDEN,
+    model_version="9.9.9",
+    policyengine_version="4.22.0",
+)
+
+_BASELINE_GOLDEN = "f9cac05d94509895eb48ea33ea5f72d40eb9b954989df05ca6506009d8dedae2"
+
+
+class TestDigests:
+    def test_dataset_key_golden(self):
+        assert ak.dataset_key(**_DATASET_KWARGS) == _DATASET_GOLDEN
+
+    def test_none_field_is_a_distinct_identity(self):
+        digest = ak.dataset_key(**{**_DATASET_KWARGS, "source_sha256": None})
+        assert digest == _DATASET_NO_SHA_GOLDEN
+        assert digest != _DATASET_GOLDEN
+
+    def test_baseline_key_golden(self):
+        assert ak.baseline_key(**_BASELINE_KWARGS) == _BASELINE_GOLDEN
+
+    @pytest.mark.parametrize("field", sorted(_DATASET_KWARGS))
+    def test_every_dataset_field_perturbs_digest(self, field):
+        perturbed = {**_DATASET_KWARGS, field: 2027 if field == "year" else "other"}
+        assert ak.dataset_key(**perturbed) != _DATASET_GOLDEN
+
+    @pytest.mark.parametrize("field", sorted(_BASELINE_KWARGS))
+    def test_every_baseline_field_perturbs_digest(self, field):
+        perturbed = {**_BASELINE_KWARGS, field: "other"}
+        assert ak.baseline_key(**perturbed) != _BASELINE_GOLDEN
+
+    def test_canonical_digest_ignores_insertion_order(self):
+        forward = {"a": 1, "b": {"c": 2, "d": None}}
+        backward = {"b": {"d": None, "c": 2}, "a": 1}
+        assert ak.canonical_digest(forward) == ak.canonical_digest(backward)
+
+    def test_simulation_id_shape(self):
+        sim_id = ak.baseline_simulation_id(_BASELINE_GOLDEN)
+        assert sim_id == "bl1-f9cac05d94509895"
+        # Filename-safe and disjoint from the dataset filename pattern.
+        assert "/" not in sim_id
+        assert "_year_" not in sim_id
+
+
+class TestStoreLayout:
+    def test_dataset_path(self):
+        path = ak.dataset_artifact_path("US", "d" * 64, "populace_cps", 2026)
+        assert path == f"datasets/us/{'d' * 64}/populace_cps_year_2026.h5"
+
+    def test_baseline_path(self):
+        path = ak.baseline_artifact_path("us", "b" * 64, "bl1-abc")
+        assert path == f"baselines/us/{'b' * 64}/bl1-abc.h5"
+
+    def test_manifest_and_marker_paths(self):
+        assert ak.manifest_path("m" * 64) == f"manifests/{'m' * 64}.json"
+        assert ak.deployed_marker_path("beta") == "deployed/beta.json"
+
+
+class TestUpstreamCacheKeyPins:
+    """Golden pins on policyengine's ScopingStrategy.cache_key.
+
+    The baseline key embeds these strings verbatim. If a policyengine pin
+    bump breaks one of these tests, the upstream format changed: every
+    baseline key rotates (correct but a full recompute) — flag it in the
+    bump PR rather than discovering it as a silent 100%-miss deploy.
+    """
+
+    def test_row_filter_cache_key_pin(self):
+        from policyengine.core.scoping_strategy import RowFilterStrategy
+
+        strategy = RowFilterStrategy(variable_name="state_code", variable_value="CA")
+        assert strategy.cache_key == "row_filter:state_code=CA"
+
+    def test_region_group_cache_key_pin_and_order_invariance(self):
+        from policyengine.core.scoping_strategy import (
+            RegionGroupStrategy,
+            RowFilterStrategy,
+        )
+
+        ca = RowFilterStrategy(variable_name="state_code", variable_value="CA")
+        wv = RowFilterStrategy(variable_name="state_code", variable_value="WV")
+        expected = "region_group:row_filter:state_code=CA|row_filter:state_code=WV"
+        assert RegionGroupStrategy(members=[wv, ca]).cache_key == expected
+        assert RegionGroupStrategy(members=[ca, wv]).cache_key == expected
+
+
+@pytest.fixture
+def stub_identity_sources(monkeypatch):
+    """Stub the bundle/manifest/receipt seams collect_dataset_identity reads."""
+    from policyengine.provenance import manifest as manifest_module
+
+    from policyengine_simulation_executor import release_bundle
+
+    bundle = SimpleNamespace(
+        country="us",
+        policyengine_version="4.22.0",
+        model_version="9.9.9",
+        data_version="1.2.3",
+        data_artifact_revision="rev-abc",
+        default_dataset="populace_cps",
+    )
+    receipt_entry = {
+        "country": "us",
+        "version": "1.2.3",
+        "installed_sha256": "feedbead" * 8,
+    }
+    state = SimpleNamespace(bundle=bundle, receipt_entry=receipt_entry)
+
+    monkeypatch.setattr(
+        release_bundle, "get_country_release_bundle", lambda country: state.bundle
+    )
+    monkeypatch.setattr(
+        release_bundle, "_receipt_dataset", lambda country: state.receipt_entry
+    )
+    monkeypatch.setattr(
+        manifest_module,
+        "resolve_dataset_reference",
+        lambda country, dataset: f"hf://org/repo/{dataset}.h5@rev-abc",
+    )
+    monkeypatch.setattr(
+        manifest_module,
+        "dataset_logical_name",
+        lambda reference: "populace_cps",
+    )
+    monkeypatch.setattr(
+        manifest_module,
+        "get_release_manifest",
+        lambda country: SimpleNamespace(
+            certification=SimpleNamespace(data_build_fingerprint="fp-123")
+        ),
+    )
+    return state
+
+
+class TestIdentityCollection:
+    def test_collected_identity_matches_golden(self, stub_identity_sources):
+        identity = ak.collect_dataset_identity("us", 2026)
+        assert identity.digest == _DATASET_GOLDEN
+        assert identity.filename == "populace_cps_year_2026.h5"
+        assert identity.store_path == (
+            f"datasets/us/{_DATASET_GOLDEN}/populace_cps_year_2026.h5"
+        )
+
+    def test_receipt_version_mismatch_drops_source_sha(self, stub_identity_sources):
+        stub_identity_sources.receipt_entry = {
+            "country": "us",
+            "version": "0.0.1",
+            "installed_sha256": "feedbead" * 8,
+        }
+        identity = ak.collect_dataset_identity("us", 2026)
+        assert identity.source_sha256 is None
+        assert identity.digest == _DATASET_NO_SHA_GOLDEN
+
+    def test_missing_receipt_falls_back_to_none(self, stub_identity_sources):
+        stub_identity_sources.receipt_entry = None
+        identity = ak.collect_dataset_identity("us", 2026)
+        assert identity.source_sha256 is None
+        assert identity.digest == _DATASET_NO_SHA_GOLDEN
+
+    def test_expected_sha_used_when_installed_absent(self, stub_identity_sources):
+        stub_identity_sources.receipt_entry = {
+            "country": "us",
+            "version": "1.2.3",
+            "expected_sha256": "feedbead" * 8,
+        }
+        assert ak.collect_dataset_identity("us", 2026).digest == _DATASET_GOLDEN
+
+    def test_baseline_identity_composes(self, stub_identity_sources):
+        identity = ak.collect_baseline_identity(
+            "us",
+            2026,
+            region="national",
+            scope_key=_BASELINE_KWARGS["scope_key"],
+        )
+        assert identity.digest == _BASELINE_GOLDEN
+        assert identity.simulation_id == "bl1-f9cac05d94509895"
+        assert identity.store_path == (
+            f"baselines/us/{_BASELINE_GOLDEN}/bl1-f9cac05d94509895.h5"
+        )

--- a/projects/policyengine-simulation-executor/tests/test_artifact_keys.py
+++ b/projects/policyengine-simulation-executor/tests/test_artifact_keys.py
@@ -1,10 +1,10 @@
 """Artifact key discipline tests.
 
 The content-addressed store's whole correctness story rests on three
-properties pinned here: (1) digests are canonical (field order never
+properties locked in here: (1) digests are canonical (field order never
 matters), (2) every payload field independently rotates the digest (no
 input silently outside the key), and (3) the digests and the upstream
-``ScopingStrategy.cache_key`` strings are STABLE — the golden pins turn
+``ScopingStrategy.cache_key`` strings are STABLE — the golden tests turn
 any change into a conscious, reviewable diff instead of silent cache
 churn (or, worse, a writer/reader mismatch).
 """
@@ -94,8 +94,8 @@ class TestStoreLayout:
         assert ak.deployed_marker_path("beta") == "deployed/beta.json"
 
 
-class TestUpstreamCacheKeyPins:
-    """Golden pins on policyengine's ScopingStrategy.cache_key.
+class TestUpstreamCacheKeyGoldens:
+    """Golden tests on policyengine's ScopingStrategy.cache_key format.
 
     The baseline key embeds these strings verbatim. If a policyengine pin
     bump breaks one of these tests, the upstream format changed: every
@@ -103,13 +103,13 @@ class TestUpstreamCacheKeyPins:
     bump PR rather than discovering it as a silent 100%-miss deploy.
     """
 
-    def test_row_filter_cache_key_pin(self):
+    def test_row_filter_cache_key_golden(self):
         from policyengine.core.scoping_strategy import RowFilterStrategy
 
         strategy = RowFilterStrategy(variable_name="state_code", variable_value="CA")
         assert strategy.cache_key == "row_filter:state_code=CA"
 
-    def test_region_group_cache_key_pin_and_order_invariance(self):
+    def test_region_group_cache_key_golden_and_order_invariance(self):
         from policyengine.core.scoping_strategy import (
             RegionGroupStrategy,
             RowFilterStrategy,

--- a/projects/policyengine-simulation-executor/tests/test_artifact_keys.py
+++ b/projects/policyengine-simulation-executor/tests/test_artifact_keys.py
@@ -9,10 +9,9 @@ any change into a conscious, reviewable diff instead of silent cache
 churn (or, worse, a writer/reader mismatch).
 """
 
-from types import SimpleNamespace
-
 import pytest
 
+from fixtures.identity_stubs import install_identity_stubs
 from policyengine_simulation_executor import artifact_keys as ak
 
 
@@ -40,6 +39,9 @@ _BASELINE_KWARGS = dict(
     dataset_digest=_DATASET_GOLDEN,
     model_version="9.9.9",
     policyengine_version="4.22.0",
+    # Explicit (== the default) so the perturbation matrix proves the
+    # policy field participates in the digest.
+    policy=ak.CURRENT_LAW_POLICY,
 )
 
 _BASELINE_GOLDEN = "f9cac05d94509895eb48ea33ea5f72d40eb9b954989df05ca6506009d8dedae2"
@@ -125,49 +127,7 @@ class TestUpstreamCacheKeyGoldens:
 @pytest.fixture
 def stub_identity_sources(monkeypatch):
     """Stub the bundle/manifest/receipt seams collect_dataset_identity reads."""
-    from policyengine.provenance import manifest as manifest_module
-
-    from policyengine_simulation_executor import release_bundle
-
-    bundle = SimpleNamespace(
-        country="us",
-        policyengine_version="4.22.0",
-        model_version="9.9.9",
-        data_version="1.2.3",
-        data_artifact_revision="rev-abc",
-        default_dataset="populace_cps",
-    )
-    receipt_entry = {
-        "country": "us",
-        "version": "1.2.3",
-        "installed_sha256": "feedbead" * 8,
-    }
-    state = SimpleNamespace(bundle=bundle, receipt_entry=receipt_entry)
-
-    monkeypatch.setattr(
-        release_bundle, "get_country_release_bundle", lambda country: state.bundle
-    )
-    monkeypatch.setattr(
-        release_bundle, "_receipt_dataset", lambda country: state.receipt_entry
-    )
-    monkeypatch.setattr(
-        manifest_module,
-        "resolve_dataset_reference",
-        lambda country, dataset: f"hf://org/repo/{dataset}.h5@rev-abc",
-    )
-    monkeypatch.setattr(
-        manifest_module,
-        "dataset_logical_name",
-        lambda reference: "populace_cps",
-    )
-    monkeypatch.setattr(
-        manifest_module,
-        "get_release_manifest",
-        lambda country: SimpleNamespace(
-            certification=SimpleNamespace(data_build_fingerprint="fp-123")
-        ),
-    )
-    return state
+    return install_identity_stubs(monkeypatch)
 
 
 class TestIdentityCollection:

--- a/projects/policyengine-simulation-executor/tests/test_artifact_store.py
+++ b/projects/policyengine-simulation-executor/tests/test_artifact_store.py
@@ -1,0 +1,147 @@
+"""Store-client tests against an injected fake GCS client (no network).
+
+The load-bearing behaviors: write-once semantics (``if_generation_match=0``
+sent, ``PreconditionFailed`` reported as already-present success), marker
+overwrites, and manifest content-addressing.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from google.api_core.exceptions import NotFound, PreconditionFailed
+
+from policyengine_simulation_executor import artifact_keys as ak
+from policyengine_simulation_executor.artifact_store import (
+    ARTIFACT_BUCKET_ENV,
+    ArtifactStore,
+    resolve_bucket_name,
+)
+
+
+class FakeBlob:
+    def __init__(self, store, path):
+        self.store = store
+        self.path = path
+
+    def exists(self):
+        return self.path in self.store.objects
+
+    def _write(self, data, **kwargs):
+        self.store.upload_calls.append((self.path, kwargs))
+        if kwargs.get("if_generation_match") == 0 and self.path in self.store.objects:
+            raise PreconditionFailed(f"object exists: {self.path}")
+        self.store.objects[self.path] = data
+
+    def upload_from_filename(self, filename, **kwargs):
+        self._write(open(filename, "rb").read(), **kwargs)
+
+    def upload_from_string(self, data, **kwargs):
+        self._write(data.encode() if isinstance(data, str) else data, **kwargs)
+
+    def download_to_filename(self, filename):
+        if self.path not in self.store.objects:
+            raise NotFound(self.path)
+        with open(filename, "wb") as handle:
+            handle.write(self.store.objects[self.path])
+
+    def download_as_bytes(self):
+        if self.path not in self.store.objects:
+            raise NotFound(self.path)
+        return self.store.objects[self.path]
+
+
+class FakeClient:
+    def __init__(self):
+        self.objects = {}
+        self.upload_calls = []
+        self.bucket_names = []
+
+    def bucket(self, name):
+        self.bucket_names.append(name)
+        return SimpleNamespace(blob=lambda path: FakeBlob(self, path))
+
+
+@pytest.fixture
+def fake_client():
+    return FakeClient()
+
+
+@pytest.fixture
+def store(fake_client):
+    return ArtifactStore("test-bucket", client=fake_client)
+
+
+def test_bucket_name_resolution(monkeypatch):
+    monkeypatch.delenv(ARTIFACT_BUCKET_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=ARTIFACT_BUCKET_ENV):
+        resolve_bucket_name()
+    monkeypatch.setenv(ARTIFACT_BUCKET_ENV, "from-env")
+    assert resolve_bucket_name() == "from-env"
+    assert resolve_bucket_name("explicit") == "explicit"
+
+
+def test_gcs_client_importable():
+    """Canary for the explicit google-cloud-storage dependency."""
+    import google.cloud.storage  # noqa: F401
+
+
+def test_upload_is_write_once(store, fake_client, tmp_path):
+    payload = tmp_path / "artifact.h5"
+    payload.write_bytes(b"bytes-one")
+
+    assert store.upload_file("baselines/us/d/bl1-a.h5", payload) is True
+    # Every artifact upload must carry the write-once precondition.
+    assert fake_client.upload_calls[-1][1]["if_generation_match"] == 0
+
+    payload.write_bytes(b"bytes-two")
+    assert store.upload_file("baselines/us/d/bl1-a.h5", payload) is False
+    assert fake_client.objects["baselines/us/d/bl1-a.h5"] == b"bytes-one"
+
+
+def test_download_creates_parent_dirs(store, fake_client, tmp_path):
+    fake_client.objects["datasets/us/d/populace_year_2026.h5"] = b"content"
+    destination = tmp_path / "nested" / "dir" / "populace_year_2026.h5"
+    store.download_file("datasets/us/d/populace_year_2026.h5", destination)
+    assert destination.read_bytes() == b"content"
+
+
+def test_exists(store, fake_client):
+    assert store.exists("manifests/x.json") is False
+    fake_client.objects["manifests/x.json"] = b"{}"
+    assert store.exists("manifests/x.json") is True
+
+
+def test_read_json_missing_returns_none(store):
+    assert store.read_json("deployed/beta.json") is None
+
+
+def test_manifest_roundtrip_is_content_addressed(store, fake_client):
+    payload = {"artifacts": ["a", "b"], "receipt": {"policyengine_version": "4.22.0"}}
+    digest = store.write_manifest(payload)
+    assert digest == ak.canonical_digest(payload)
+    assert store.read_manifest(digest) == payload
+    # Manifests are write-once too: same content is a no-op, and the
+    # stored bytes remain the first write's.
+    stored_before = dict(fake_client.objects)
+    store.write_manifest(payload)
+    assert fake_client.objects == stored_before
+
+
+def test_deployed_marker_overwrites(store, fake_client):
+    store.write_deployed_marker("beta", {"manifest": "m1"})
+    store.write_deployed_marker("beta", {"manifest": "m2"})
+    assert store.read_deployed_marker("beta") == {"manifest": "m2"}
+    # Markers are pointers: no write-once precondition on the second write.
+    marker_calls = [
+        kwargs
+        for path, kwargs in fake_client.upload_calls
+        if path == "deployed/beta.json"
+    ]
+    assert all("if_generation_match" not in kwargs for kwargs in marker_calls)
+
+
+def test_marker_payload_is_json(store, fake_client):
+    store.write_deployed_marker("prod", {"manifest": "m1", "versions": {"us": "1"}})
+    raw = fake_client.objects["deployed/prod.json"]
+    assert json.loads(raw) == {"manifest": "m1", "versions": {"us": "1"}}

--- a/projects/policyengine-simulation-executor/tests/test_artifact_store.py
+++ b/projects/policyengine-simulation-executor/tests/test_artifact_store.py
@@ -42,6 +42,12 @@ class FakeBlob:
     def download_to_filename(self, filename):
         if self.path not in self.store.objects:
             raise NotFound(self.path)
+        if self.path in self.store.broken_downloads:
+            # Simulate a mid-stream failure: partial bytes hit disk, then
+            # the transport dies.
+            with open(filename, "wb") as handle:
+                handle.write(self.store.objects[self.path][:1])
+            raise ConnectionError("stream reset")
         with open(filename, "wb") as handle:
             handle.write(self.store.objects[self.path])
 
@@ -56,6 +62,7 @@ class FakeClient:
         self.objects = {}
         self.upload_calls = []
         self.bucket_names = []
+        self.broken_downloads = set()
 
     def bucket(self, name):
         self.bucket_names.append(name)
@@ -104,6 +111,20 @@ def test_download_creates_parent_dirs(store, fake_client, tmp_path):
     destination = tmp_path / "nested" / "dir" / "populace_year_2026.h5"
     store.download_file("datasets/us/d/populace_year_2026.h5", destination)
     assert destination.read_bytes() == b"content"
+    # The temp-then-rename download leaves no .partial residue on success.
+    assert list(destination.parent.iterdir()) == [destination]
+
+
+def test_failed_download_leaves_no_file_at_the_final_name(store, fake_client, tmp_path):
+    """Callers guard on exists(): a truncated file surviving at the final
+    name would be trusted as complete by the next run in the container."""
+    fake_client.objects["datasets/us/d/populace_year_2026.h5"] = b"content"
+    fake_client.broken_downloads.add("datasets/us/d/populace_year_2026.h5")
+    destination = tmp_path / "populace_year_2026.h5"
+    with pytest.raises(ConnectionError):
+        store.download_file("datasets/us/d/populace_year_2026.h5", destination)
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_exists(store, fake_client):
@@ -113,6 +134,11 @@ def test_exists(store, fake_client):
 
 
 def test_read_json_missing_returns_none(store):
+    assert store.read_json("deployed/beta.json") is None
+
+
+def test_read_json_non_mapping_payload_reads_as_none(store, fake_client):
+    fake_client.objects["deployed/beta.json"] = b'["not", "a", "marker"]'
     assert store.read_json("deployed/beta.json") is None
 
 

--- a/projects/policyengine-simulation-executor/tests/test_baseline_artifacts.py
+++ b/projects/policyengine-simulation-executor/tests/test_baseline_artifacts.py
@@ -251,6 +251,41 @@ class TestArtifactBaselineSimulation:
         # Cache hit short-circuits load; the guard still forces the run.
         assert model.calls == ["run", "save"]
 
+    def test_stale_cache_entry_is_replaced_after_recompute(self, fresh_cache):
+        """After a recompute that started from a cache hit on a DIFFERENT
+        (stale) object, the cache must hold the recomputed simulation.
+        LRUCache.add alone keeps the old value for an existing key, which
+        would make this request's second ensure() clobber the fresh output
+        and run the full model twice."""
+        stale = _make_sim(FakeModelVersion())
+        stale.output_dataset = _output(_incomplete_frames())
+        fresh_cache.add("bl1-test", stale)
+
+        model = FakeModelVersion()
+        sim = _make_sim(model)
+        sim.ensure()
+        assert fresh_cache.get("bl1-test") is sim
+
+        # The request's second ensure() self-hits the completed entry:
+        # no second full run.
+        sim.ensure()
+        assert model.calls == ["run", "save"]
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+
+    def test_container_converges_after_stale_recompute(self, fresh_cache):
+        stale = _make_sim(FakeModelVersion())
+        stale.output_dataset = _output(_incomplete_frames())
+        fresh_cache.add("bl1-test", stale)
+
+        _make_sim(FakeModelVersion()).ensure()
+
+        # A later request hits the enriched entry: zero model work.
+        later_model = FakeModelVersion()
+        later = _make_sim(later_model)
+        later.ensure()
+        assert later.artifact_outcome == ba.OUTCOME_HIT
+        assert later_model.calls == []
+
     def test_loaded_output_without_data_recomputes(self, fresh_cache):
         model = FakeModelVersion()
         model.load = lambda simulation: setattr(  # type: ignore[method-assign]
@@ -260,6 +295,29 @@ class TestArtifactBaselineSimulation:
         sim.ensure()
         assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
 
+    def test_second_ensure_keeps_a_genuine_miss(self, fresh_cache):
+        """Every request ensures the baseline twice (analysis + deciles).
+        The second call self-hits the in-process cache with a complete
+        column set — it must not overwrite the miss the request actually
+        experienced (the rollout metric depends on it)."""
+        model = FakeModelVersion(load_result="absent")
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_MISS
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_MISS
+        # The second ensure() was a pure cache hit: no extra model work.
+        assert model.calls == ["load", "run", "save"]
+
+    def test_second_ensure_keeps_an_incomplete_outcome(self, fresh_cache):
+        model = FakeModelVersion(load_result="incomplete")
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+        assert model.calls == ["load", "run", "save"]
+
 
 class TestBuildSimulationSelection:
     @pytest.fixture
@@ -268,7 +326,9 @@ class TestBuildSimulationSelection:
 
         from policyengine_simulation_executor import simulation_runtime as sr
 
-        recorded = SimpleNamespace(artifact_kwargs=None, plain_kwargs=None, id=None)
+        recorded = SimpleNamespace(
+            artifact_kwargs=None, plain_kwargs=None, id=None, id_kwargs=None
+        )
 
         class FakeArtifactSimulation:
             def __init__(self, **kwargs):
@@ -285,11 +345,12 @@ class TestBuildSimulationSelection:
             "_country_module",
             lambda country: SimpleNamespace(model=SimpleNamespace(id="us-model")),
         )
-        monkeypatch.setattr(
-            ba,
-            "deterministic_baseline_id",
-            lambda params, **kwargs: recorded.id,
-        )
+
+        def fake_deterministic_id(params, **kwargs):
+            recorded.id_kwargs = {"params": params, **kwargs}
+            return recorded.id
+
+        monkeypatch.setattr(ba, "deterministic_baseline_id", fake_deterministic_id)
         return recorded
 
     def test_qualifying_baseline_uses_artifact_class(self, wired):
@@ -306,6 +367,18 @@ class TestBuildSimulationSelection:
         assert wired.plain_kwargs is None
         assert wired.artifact_kwargs["id"] == "bl1-deadbeefdeadbeef"
         assert wired.artifact_kwargs["dataset"] == "dataset"
+        # The predicate must see the request's own facts. A wiring
+        # regression (e.g. policy=None passed unconditionally) would hand
+        # a REFORM simulation the baseline's deterministic id — and
+        # ensure() would then serve the baseline artifact as the reform.
+        assert wired.id_kwargs == {
+            "params": {"country": "us", "scope": "macro"},
+            "country": "us",
+            "policy": None,
+            "region_code": "us",
+            "scoping_strategy": None,
+            "year": sr.DEFAULT_YEAR,
+        }
 
     def test_non_qualifying_uses_plain_simulation(self, wired):
         from policyengine_simulation_executor import simulation_runtime as sr
@@ -321,6 +394,38 @@ class TestBuildSimulationSelection:
         assert wired.artifact_kwargs is None
         assert wired.plain_kwargs["policy"] == {"gov.x": 1}
         assert "id" not in wired.plain_kwargs
+        # The reform's own policy reaches the predicate (which returns a
+        # random id for it) — not a hardwired None.
+        assert wired.id_kwargs["policy"] == {"gov.x": 1}
+
+
+class TestIdentityErrorContract:
+    """The stated split: the writer path fails loud, the reader degrades."""
+
+    def _kwargs(self):
+        return dict(
+            params={"scope": "macro"},
+            country="us",
+            policy=None,
+            region_code="us",
+            scoping_strategy=None,
+            year=2026,
+        )
+
+    def test_qualifying_identity_propagates_collection_errors(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("receipt unreadable")
+
+        monkeypatch.setattr(ak, "collect_baseline_identity", boom)
+        with pytest.raises(RuntimeError, match="receipt unreadable"):
+            ba.qualifying_baseline_identity(**self._kwargs())
+
+    def test_deterministic_id_swallows_collection_errors(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("receipt unreadable")
+
+        monkeypatch.setattr(ak, "collect_baseline_identity", boom)
+        assert ba.deterministic_baseline_id(**self._kwargs()) is None
 
 
 def _year_data(person_columns=None):

--- a/projects/policyengine-simulation-executor/tests/test_baseline_artifacts.py
+++ b/projects/policyengine-simulation-executor/tests/test_baseline_artifacts.py
@@ -321,3 +321,161 @@ class TestBuildSimulationSelection:
         assert wired.artifact_kwargs is None
         assert wired.plain_kwargs["policy"] == {"gov.x": 1}
         assert "id" not in wired.plain_kwargs
+
+
+def _year_data(person_columns=None):
+    """Minimal real USYearData — six entities, weights included."""
+    from microdf import MicroDataFrame
+
+    from policyengine.tax_benefit_models.us.datasets import USYearData
+
+    person = {
+        "person_id": [1, 2],
+        "person_weight": [1.5, 2.5],
+        "age": [30.0, 40.0],
+        "employment_income": [1000.0, 2000.0],
+    }
+    if person_columns is not None:
+        person = {k: v for k, v in person.items() if k in person_columns}
+
+    def frame(entity, extra=None):
+        data = {f"{entity}_id": [1, 2], f"{entity}_weight": [1.0, 1.0], **(extra or {})}
+        return MicroDataFrame(pd.DataFrame(data), weights=f"{entity}_weight")
+
+    return USYearData(
+        person=MicroDataFrame(pd.DataFrame(person), weights="person_weight"),
+        marital_unit=frame("marital_unit"),
+        family=frame("family"),
+        spm_unit=frame("spm_unit"),
+        tax_unit=frame("tax_unit"),
+        household=frame("household", {"household_net_income": [900.0, 1800.0]}),
+    )
+
+
+class DiskModelVersion:
+    """Duck model version reusing the REAL load/save implementations, so
+    these tests exercise genuine h5 files on disk — including the exception
+    type a missing artifact raises — without loading the US tax system."""
+
+    def __init__(self):
+        from policyengine.tax_benefit_models.us.datasets import PolicyEngineUSDataset
+
+        self._dataset_class = PolicyEngineUSDataset
+        self.run_calls = 0
+
+    def resolve_entity_variables(self, simulation):
+        return {
+            "person": ["age", "employment_income"],
+            "household": ["household_net_income"],
+        }
+
+    def load(self, simulation):
+        from policyengine.tax_benefit_models.common.model_version import (
+            MicrosimulationModelVersion,
+        )
+
+        MicrosimulationModelVersion.load(self, simulation)
+
+    def save(self, simulation):
+        from policyengine.tax_benefit_models.common.model_version import (
+            MicrosimulationModelVersion,
+        )
+
+        MicrosimulationModelVersion.save(self, simulation)
+
+    def run(self, simulation):
+        from policyengine.tax_benefit_models.common.model_version import (
+            output_dataset_filepath,
+        )
+
+        self.run_calls += 1
+        simulation.output_dataset = self._dataset_class(
+            id=simulation.id,
+            name="output",
+            description="output",
+            filepath=str(output_dataset_filepath(simulation)),
+            year=simulation.dataset.year,
+            is_output_dataset=True,
+            data=_year_data(),
+        )
+
+
+def _make_disk_sim(model, tmp_path, sim_id):
+    dataset = model._dataset_class(
+        name="input",
+        description="input",
+        filepath=str(tmp_path / "populace_year_2026.h5"),
+        year=2026,
+        data=_year_data(),
+    )
+    return ba.ArtifactBaselineSimulation.model_construct(
+        id=sim_id,
+        dataset=dataset,
+        tax_benefit_model_version=model,
+        policy=None,
+        dynamic=None,
+        scoping_strategy=None,
+        extra_variables={},
+        output_dataset=None,
+    )
+
+
+class TestArtifactDiskRoundTrip:
+    """The guard against real h5 files, through the real load/save code.
+
+    Locks in what was only verified by hand before: a missing artifact
+    raises FileNotFoundError end-to-end (the clean miss branch, no
+    catch-all warning), a saved artifact loads as a hit with weight
+    columns intact, and an on-disk artifact missing a requested column
+    triggers the recompute-and-overwrite path.
+    """
+
+    def test_missing_artifact_is_a_clean_miss_that_saves(self, fresh_cache, tmp_path):
+        model = DiskModelVersion()
+        sim = _make_disk_sim(model, tmp_path, "bl1-roundtrip-miss")
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_MISS
+        assert model.run_calls == 1
+        assert (tmp_path / "bl1-roundtrip-miss.h5").exists()
+
+    def test_saved_artifact_loads_as_hit_with_weights(self, fresh_cache, tmp_path):
+        model = DiskModelVersion()
+        model._dataset_class(
+            name="artifact",
+            description="artifact",
+            filepath=str(tmp_path / "bl1-roundtrip-hit.h5"),
+            year=2026,
+            data=_year_data(),
+        ).save()
+
+        sim = _make_disk_sim(model, tmp_path, "bl1-roundtrip-hit")
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_HIT
+        assert model.run_calls == 0
+        person = sim.output_dataset.data.person
+        assert list(person["age"]) == [30.0, 40.0]
+        assert "person_weight" in person.columns
+
+    def test_incomplete_disk_artifact_recomputes_and_overwrites(
+        self, fresh_cache, tmp_path
+    ):
+        model = DiskModelVersion()
+        model._dataset_class(
+            name="artifact",
+            description="artifact",
+            filepath=str(tmp_path / "bl1-roundtrip-gap.h5"),
+            year=2026,
+            data=_year_data(person_columns={"person_id", "person_weight", "age"}),
+        ).save()
+
+        sim = _make_disk_sim(model, tmp_path, "bl1-roundtrip-gap")
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+        assert model.run_calls == 1
+        reloaded = model._dataset_class(
+            name="check",
+            description="check",
+            filepath=str(tmp_path / "bl1-roundtrip-gap.h5"),
+            year=2026,
+        )
+        assert "employment_income" in reloaded.data.person.columns

--- a/projects/policyengine-simulation-executor/tests/test_baseline_artifacts.py
+++ b/projects/policyengine-simulation-executor/tests/test_baseline_artifacts.py
@@ -1,0 +1,323 @@
+"""Runtime read path of the artifact pipeline.
+
+Covers the qualifying predicate (which sims get deterministic ids), the
+validate-on-load guard (loads are trusted only when column-complete), and
+the class selection in ``_build_simulation``. No model runs, no network:
+model versions are SimpleNamespace fakes and the policyengine in-process
+simulation cache is swapped per test.
+"""
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from policyengine_simulation_executor import artifact_keys as ak
+from policyengine_simulation_executor import baseline_artifacts as ba
+
+
+def _region_group():
+    from policyengine.core.scoping_strategy import (
+        RegionGroupStrategy,
+        RowFilterStrategy,
+    )
+
+    return RegionGroupStrategy(
+        members=[
+            RowFilterStrategy(variable_name="state_code", variable_value="CA"),
+            RowFilterStrategy(variable_name="state_code", variable_value="WV"),
+        ]
+    )
+
+
+class TestDeterministicBaselineId:
+    @pytest.fixture
+    def collected(self, monkeypatch):
+        calls = []
+
+        def fake_collect(country, year, *, region, scope_key):
+            calls.append(
+                {
+                    "country": country,
+                    "year": year,
+                    "region": region,
+                    "scope_key": scope_key,
+                }
+            )
+            return SimpleNamespace(simulation_id="bl1-deadbeefdeadbeef")
+
+        monkeypatch.setattr(ak, "collect_baseline_identity", fake_collect)
+        return calls
+
+    def _id(self, collected, **overrides):
+        kwargs = dict(
+            params={"scope": "macro"},
+            country="us",
+            policy=None,
+            region_code="us",
+            scoping_strategy=None,
+            year=2026,
+        )
+        kwargs.update(overrides)
+        return ba.deterministic_baseline_id(kwargs.pop("params"), **kwargs)
+
+    def test_national_baseline_qualifies(self, collected):
+        assert self._id(collected) == "bl1-deadbeefdeadbeef"
+        assert collected == [
+            {"country": "us", "year": 2026, "region": "national", "scope_key": None}
+        ]
+
+    def test_region_group_qualifies_with_cache_key(self, collected):
+        group = _region_group()
+        sim_id = self._id(
+            collected,
+            region_code="region_group/state/ca+state/wv",
+            scoping_strategy=group,
+        )
+        assert sim_id == "bl1-deadbeefdeadbeef"
+        assert collected[0]["region"] == "region_group/state/ca+state/wv"
+        assert collected[0]["scope_key"] == group.cache_key
+
+    def test_reform_policy_disqualifies(self, collected):
+        assert self._id(collected, policy={"gov.x": 1}) is None
+
+    @pytest.mark.parametrize("scope", [None, "", "household"])
+    def test_non_macro_scope_disqualifies(self, collected, scope):
+        params = {} if scope is None else {"scope": scope}
+        assert self._id(collected, params=params) is None
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"scope": "macro", "data": "other_dataset"},
+            {"scope": "macro", "data_version": "1.2.3"},
+        ],
+    )
+    def test_custom_data_disqualifies(self, collected, params):
+        assert self._id(collected, params=params) is None
+
+    def test_missing_region_code_disqualifies(self, collected):
+        assert self._id(collected, region_code=None) is None
+
+    def test_unscoped_non_national_region_disqualifies(self, collected):
+        assert self._id(collected, region_code="state/ca") is None
+
+    def test_single_state_scoping_disqualifies(self, collected):
+        from policyengine.core.scoping_strategy import RowFilterStrategy
+
+        strategy = RowFilterStrategy(variable_name="state_code", variable_value="CA")
+        assert (
+            self._id(collected, region_code="state/ca", scoping_strategy=strategy)
+            is None
+        )
+
+    def test_identity_collection_failure_degrades_to_random_id(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("manifest unavailable")
+
+        monkeypatch.setattr(ak, "collect_baseline_identity", boom)
+        assert (
+            ba.deterministic_baseline_id(
+                {"scope": "macro"},
+                country="us",
+                policy=None,
+                region_code="us",
+                scoping_strategy=None,
+                year=2026,
+            )
+            is None
+        )
+
+
+def _complete_frames():
+    return {"person": pd.DataFrame({"age": [30.0], "income": [1000.0]})}
+
+
+def _incomplete_frames():
+    return {"person": pd.DataFrame({"age": [30.0]})}
+
+
+def _output(frames):
+    return SimpleNamespace(data=SimpleNamespace(entity_data=frames))
+
+
+class FakeModelVersion:
+    """Duck-typed stand-in for a MicrosimulationModelVersion."""
+
+    def __init__(self, *, load_result="complete"):
+        self.load_result = load_result
+        self.calls = []
+
+    def resolve_entity_variables(self, simulation):
+        return {"person": ["age", "income"]}
+
+    def load(self, simulation):
+        self.calls.append("load")
+        if self.load_result == "absent":
+            raise FileNotFoundError("no artifact")
+        if self.load_result == "broken":
+            raise OSError("corrupt h5")
+        frames = (
+            _complete_frames()
+            if self.load_result == "complete"
+            else _incomplete_frames()
+        )
+        simulation.output_dataset = _output(frames)
+
+    def run(self, simulation):
+        self.calls.append("run")
+        simulation.output_dataset = _output(_complete_frames())
+
+    def save(self, simulation):
+        self.calls.append("save")
+
+
+@pytest.fixture
+def fresh_cache(monkeypatch):
+    from policyengine.core import simulation as simulation_module
+    from policyengine.core.cache import LRUCache
+
+    cache = LRUCache(max_size=10)
+    monkeypatch.setattr(simulation_module, "_cache", cache)
+    return cache
+
+
+def _make_sim(model_version, sim_id="bl1-test"):
+    return ba.ArtifactBaselineSimulation.model_construct(
+        id=sim_id,
+        dataset=None,
+        tax_benefit_model_version=model_version,
+        policy=None,
+        dynamic=None,
+        scoping_strategy=None,
+        extra_variables={},
+        output_dataset=None,
+    )
+
+
+class TestArtifactBaselineSimulation:
+    def test_complete_load_is_a_hit(self, fresh_cache):
+        model = FakeModelVersion(load_result="complete")
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_HIT
+        assert model.calls == ["load"]
+
+    def test_absent_artifact_is_a_miss_that_computes(self, fresh_cache):
+        model = FakeModelVersion(load_result="absent")
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_MISS
+        assert model.calls == ["load", "run", "save"]
+
+    def test_broken_load_degrades_to_miss(self, fresh_cache):
+        model = FakeModelVersion(load_result="broken")
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_MISS
+        assert model.calls == ["load", "run", "save"]
+
+    def test_incomplete_load_recomputes(self, fresh_cache):
+        model = FakeModelVersion(load_result="incomplete")
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+        assert model.calls == ["load", "run", "save"]
+        # The guard's recompute produced the full column set.
+        assert "income" in sim.output_dataset.data.entity_data["person"].columns
+
+    def test_recompute_replaces_cache_entry(self, fresh_cache):
+        model = FakeModelVersion(load_result="incomplete")
+        first = _make_sim(model)
+        first.ensure()
+        assert first.artifact_outcome == ba.OUTCOME_INCOMPLETE
+
+        # A second request in the same process must reuse the completed
+        # output from the cache — one recompute, not one per request.
+        second = _make_sim(model)
+        second.ensure()
+        assert second.artifact_outcome == ba.OUTCOME_HIT
+        assert model.calls == ["load", "run", "save"]
+
+    def test_cache_hit_is_validated_too(self, fresh_cache):
+        stale = _make_sim(FakeModelVersion())
+        stale.output_dataset = _output(_incomplete_frames())
+        fresh_cache.add("bl1-test", stale)
+
+        model = FakeModelVersion()
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+        # Cache hit short-circuits load; the guard still forces the run.
+        assert model.calls == ["run", "save"]
+
+    def test_loaded_output_without_data_recomputes(self, fresh_cache):
+        model = FakeModelVersion()
+        model.load = lambda simulation: setattr(  # type: ignore[method-assign]
+            simulation, "output_dataset", SimpleNamespace(data=None)
+        )
+        sim = _make_sim(model)
+        sim.ensure()
+        assert sim.artifact_outcome == ba.OUTCOME_INCOMPLETE
+
+
+class TestBuildSimulationSelection:
+    @pytest.fixture
+    def wired(self, monkeypatch):
+        from policyengine import core as policyengine_core
+
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        recorded = SimpleNamespace(artifact_kwargs=None, plain_kwargs=None, id=None)
+
+        class FakeArtifactSimulation:
+            def __init__(self, **kwargs):
+                recorded.artifact_kwargs = kwargs
+
+        class FakePlainSimulation:
+            def __init__(self, **kwargs):
+                recorded.plain_kwargs = kwargs
+
+        monkeypatch.setattr(ba, "ArtifactBaselineSimulation", FakeArtifactSimulation)
+        monkeypatch.setattr(policyengine_core, "Simulation", FakePlainSimulation)
+        monkeypatch.setattr(
+            sr,
+            "_country_module",
+            lambda country: SimpleNamespace(model=SimpleNamespace(id="us-model")),
+        )
+        monkeypatch.setattr(
+            ba,
+            "deterministic_baseline_id",
+            lambda params, **kwargs: recorded.id,
+        )
+        return recorded
+
+    def test_qualifying_baseline_uses_artifact_class(self, wired):
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        wired.id = "bl1-deadbeefdeadbeef"
+        sr._build_simulation(
+            {"country": "us", "scope": "macro"},
+            dataset="dataset",
+            policy=None,
+            scoping_strategy=None,
+            region_code="us",
+        )
+        assert wired.plain_kwargs is None
+        assert wired.artifact_kwargs["id"] == "bl1-deadbeefdeadbeef"
+        assert wired.artifact_kwargs["dataset"] == "dataset"
+
+    def test_non_qualifying_uses_plain_simulation(self, wired):
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        wired.id = None
+        sr._build_simulation(
+            {"country": "us", "scope": "macro"},
+            dataset="dataset",
+            policy={"gov.x": 1},
+            scoping_strategy=None,
+            region_code="us",
+        )
+        assert wired.artifact_kwargs is None
+        assert wired.plain_kwargs["policy"] == {"gov.x": 1}
+        assert "id" not in wired.plain_kwargs

--- a/projects/policyengine-simulation-executor/tests/test_modal_bundle_image.py
+++ b/projects/policyengine-simulation-executor/tests/test_modal_bundle_image.py
@@ -2,76 +2,8 @@ import importlib
 import sys
 import tomllib
 from pathlib import Path
-from types import ModuleType
 
-class FakeImage:
-    def __init__(self):
-        self.calls = []
-
-    @classmethod
-    def debian_slim(cls, python_version):
-        image = cls()
-        image.calls.append(("debian_slim", python_version))
-        return image
-
-    def pip_install(self, *packages):
-        self.calls.append(("pip_install", packages))
-        return self
-
-    def pip_install_from_requirements(self, requirements_txt, **kwargs):
-        self.calls.append(
-            ("pip_install_from_requirements", requirements_txt, kwargs)
-        )
-        return self
-
-    def uv_sync(self, uv_project_dir="./", **kwargs):
-        self.calls.append(("uv_sync", uv_project_dir, kwargs))
-        return self
-
-    def run_commands(self, *commands, **kwargs):
-        self.calls.append(("run_commands", commands, kwargs))
-        return self
-
-    def env(self, env):
-        self.calls.append(("env", env))
-        return self
-
-    def add_local_python_source(self, *args, **kwargs):
-        self.calls.append(("add_local_python_source", args, kwargs))
-        return self
-
-    def run_function(self, function, **kwargs):
-        self.calls.append(("run_function", function.__name__, kwargs))
-        return self
-
-
-class FakeSecret:
-    @staticmethod
-    def from_name(*args, **kwargs):
-        return {"args": args, "kwargs": kwargs}
-
-
-class FakeApp:
-    def __init__(self, name):
-        self.name = name
-        self.function_calls = []
-
-    def function(self, **kwargs):
-        def decorator(function):
-            self.function_calls.append((function.__name__, kwargs))
-            return function
-
-        return decorator
-
-
-def install_fake_modal(monkeypatch):
-    modal = ModuleType("modal")
-    modal.Image = FakeImage
-    modal.Secret = FakeSecret
-    modal.App = FakeApp
-    modal.is_local = lambda: True
-    modal.asgi_app = lambda: lambda function: function
-    monkeypatch.setitem(sys.modules, "modal", modal)
+from fixtures.fake_modal import install_fake_modal
 
 
 def test_modal_image_uses_policyengine_bundle_install(monkeypatch):
@@ -213,9 +145,7 @@ def test_app_module_imports_at_container_entrypoint_path(monkeypatch):
     monkeypatch.setenv("POLICYENGINE_UK_VERSION", "2.90.0")
     sys.modules.pop("src.modal.app", None)
 
-    source_path = (
-        Path(__file__).resolve().parents[1] / "src" / "modal" / "app.py"
-    )
+    source_path = Path(__file__).resolve().parents[1] / "src" / "modal" / "app.py"
     code = compile(source_path.read_text(), "/root/app.py", "exec")
     spec = importlib.util.spec_from_loader(
         "container_entrypoint_app", loader=None, origin="/root/app.py"

--- a/projects/policyengine-simulation-executor/tests/test_precompute.py
+++ b/projects/policyengine-simulation-executor/tests/test_precompute.py
@@ -7,24 +7,28 @@ a strict model from precompute_models; the fakes speak dicts, exactly
 like Modal's serialization boundary does.
 """
 
-from types import SimpleNamespace
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
+import pandas as pd
 import pytest
 from pydantic import ValidationError
 
+from fixtures.identity_stubs import install_identity_stubs
 from policyengine_simulation_executor import precompute
 from policyengine_simulation_executor.artifact_keys import canonical_digest
 from policyengine_simulation_executor.precompute_models import (
     ArtifactManifest,
     BaselinePlanEntry,
-    BundleReceipt,
+    BundleVersionIdentity,
     DatasetPlanEntry,
     PrecomputePlan,
 )
 
 
-def _receipt() -> BundleReceipt:
-    return BundleReceipt(
+def _receipt() -> BundleVersionIdentity:
+    return BundleVersionIdentity(
         policyengine_version="4.22.0",
         model_version="1.0.0",
         data_version="1.2.3",
@@ -91,6 +95,20 @@ class TestSchemas:
         del payload["baselines"][0]["simulation_id"]
         with pytest.raises(ValidationError):
             PrecomputePlan.model_validate(payload)
+
+    def test_artifact_outcome_mirrors_runtime_constants(self):
+        """The Literal must track baseline_artifacts.OUTCOME_*: drift would
+        surface as a ValidationError mid-precompute-run, not in review."""
+        from typing import get_args
+
+        from policyengine_simulation_executor import baseline_artifacts as ba
+        from policyengine_simulation_executor.precompute_models import ArtifactOutcome
+
+        assert set(get_args(ArtifactOutcome)) == {
+            ba.OUTCOME_HIT,
+            ba.OUTCOME_INCOMPLETE,
+            ba.OUTCOME_MISS,
+        }
 
 
 class TestPlanning:
@@ -265,6 +283,11 @@ class TestRunPrecompute:
         (verify_call,) = functions["verify_determinism"].remote_calls
         assert verify_call[1]["simulation_id"] == "bl1-bbbb"
         assert digest == "digest-123"
+        # The manifest publishes the FULL plan, never the miss-only work
+        # subset: the fetch layer needs every artifact listed.
+        assert functions["publish_manifest"].remote_calls == [
+            ("bucket-x", _plan().model_dump())
+        ]
 
     def test_last_echo_line_is_the_digest_contract(self):
         _, lines = self._run(self._functions())
@@ -282,10 +305,13 @@ class TestRunPrecompute:
         assert functions["build_dataset"].spawn_calls == []
         assert functions["compute_baseline"].spawn_calls == []
         assert functions["verify_determinism"].remote_calls == []
-        # The manifest still publishes: a no-op run must refresh nothing
-        # but the deploy still needs a digest for the fetch layer.
+        # The manifest still publishes — the full plan — because a no-op
+        # run must refresh nothing but the deploy still needs a digest.
         assert digest == "digest-123"
         assert lines[-1] == "MANIFEST_DIGEST=digest-123"
+        assert functions["publish_manifest"].remote_calls == [
+            ("bucket-x", noop_plan.model_dump())
+        ]
 
     def test_failed_gate_aborts_before_publishing(self):
         functions = self._functions(
@@ -309,36 +335,7 @@ class TestWriterReaderContract:
 
     @pytest.fixture
     def identity_stubs(self, monkeypatch):
-        from policyengine.provenance import manifest as manifest_module
-
-        from policyengine_simulation_executor import release_bundle
-
-        monkeypatch.setattr(
-            release_bundle,
-            "get_country_release_bundle",
-            lambda country: SimpleNamespace(
-                country="us",
-                policyengine_version="4.22.0",
-                model_version="9.9.9",
-                data_version="1.2.3",
-                data_artifact_revision="rev-abc",
-                default_dataset="populace_cps",
-            ),
-        )
-        monkeypatch.setattr(release_bundle, "_receipt_dataset", lambda country: None)
-        monkeypatch.setattr(
-            manifest_module,
-            "resolve_dataset_reference",
-            lambda country, dataset: f"{dataset}.h5",
-        )
-        monkeypatch.setattr(
-            manifest_module, "dataset_logical_name", lambda reference: "populace_cps"
-        )
-        monkeypatch.setattr(
-            manifest_module,
-            "get_release_manifest",
-            lambda country: SimpleNamespace(certification=None),
-        )
+        install_identity_stubs(monkeypatch)
 
     @pytest.fixture
     def fake_regions(self, monkeypatch):
@@ -416,3 +413,503 @@ class TestWriterReaderContract:
         finally:
             get_country_release_bundle.cache_clear()
         assert identity.filename == f"{expected_stem}_year_{DEFAULT_YEAR}.h5"
+
+
+class TestPlanArtifactsImpl:
+    """The 63-identity planner: enumeration, presence flags, receipt."""
+
+    @pytest.fixture
+    def planning_stubs(self, monkeypatch):
+        from policyengine_simulation_executor import (
+            artifact_keys,
+            artifact_store,
+            national_partition,
+            release_bundle,
+        )
+
+        existing = {
+            "datasets/us/ds-2026/populace_year_2026.h5",
+            "baselines/us/bl-2026-1/bl1-2026-1.h5",
+        }
+
+        class FakeStore:
+            def __init__(self, bucket):
+                self.bucket = bucket
+
+            def exists(self, path):
+                return path in existing
+
+        monkeypatch.setattr(artifact_store, "ArtifactStore", FakeStore)
+        monkeypatch.setattr(
+            national_partition,
+            "national_region_groups",
+            lambda country: [["state/ca"], ["state/ny", "state/wv"]],
+        )
+        monkeypatch.setattr(
+            artifact_keys,
+            "collect_dataset_identity",
+            lambda country, year: SimpleNamespace(
+                digest=f"ds-{year}",
+                store_path=f"datasets/us/ds-{year}/populace_year_{year}.h5",
+                filename=f"populace_year_{year}.h5",
+            ),
+        )
+
+        def fake_cohort_identity(year, group):
+            tag = f"{year}-{len(group)}"
+            return SimpleNamespace(
+                region="+".join(group),
+                digest=f"bl-{tag}",
+                store_path=f"baselines/us/bl-{tag}/bl1-{tag}.h5",
+                simulation_id=f"bl1-{tag}",
+            )
+
+        monkeypatch.setattr(precompute, "cohort_identity", fake_cohort_identity)
+        monkeypatch.setattr(
+            release_bundle,
+            "get_country_release_bundle",
+            lambda country: SimpleNamespace(
+                policyengine_version="4.22.0",
+                model_version="1.0.0",
+                data_version="1.2.3",
+                data_artifact_revision="rev-abc",
+                default_dataset="populace_cps",
+            ),
+        )
+        return SimpleNamespace(existing=existing)
+
+    def test_plan_enumerates_years_and_cohorts_with_presence(self, planning_stubs):
+        plan = precompute.plan_artifacts_impl("bucket-x")
+
+        assert [entry.year for entry in plan.datasets] == [2026, 2027, 2025]
+        assert [entry.exists for entry in plan.datasets] == [True, False, False]
+        assert plan.datasets[0].digest == "ds-2026"
+        assert plan.datasets[0].path == "datasets/us/ds-2026/populace_year_2026.h5"
+        assert plan.datasets[0].filename == "populace_year_2026.h5"
+
+        # Year-major, partition order inside each year.
+        assert [entry.simulation_id for entry in plan.baselines] == [
+            "bl1-2026-1",
+            "bl1-2026-2",
+            "bl1-2027-1",
+            "bl1-2027-2",
+            "bl1-2025-1",
+            "bl1-2025-2",
+        ]
+        assert [entry.exists for entry in plan.baselines] == [
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
+        assert plan.baselines[0].group == ["state/ca"]
+        assert plan.baselines[1].group == ["state/ny", "state/wv"]
+        assert plan.baselines[1].path == "baselines/us/bl-2026-2/bl1-2026-2.h5"
+
+        assert plan.receipt == BundleVersionIdentity(
+            policyengine_version="4.22.0",
+            model_version="1.0.0",
+            data_version="1.2.3",
+            data_artifact_revision="rev-abc",
+            default_dataset="populace_cps",
+        )
+        # An exists-flag inversion would make select_work recompute (or,
+        # worse, skip) the wrong entries — lock the wiring end to end.
+        work = precompute.select_work(plan, force=False)
+        assert [entry.year for entry in work.datasets] == [2027, 2025]
+        assert len(work.baselines) == 5
+
+    def test_empty_partition_fails_loudly(self, planning_stubs, monkeypatch):
+        from policyengine_simulation_executor import national_partition
+
+        monkeypatch.setattr(
+            national_partition, "national_region_groups", lambda country: []
+        )
+        with pytest.raises(RuntimeError, match="No national partition"):
+            precompute.plan_artifacts_impl("bucket-x")
+
+
+class TestCohortIdentityGuard:
+    def test_diverged_predicates_fail_loudly(self, monkeypatch):
+        from policyengine_simulation_executor import baseline_artifacts as ba
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        monkeypatch.setattr(sr, "_country_module", lambda country: SimpleNamespace())
+        monkeypatch.setattr(
+            sr,
+            "_resolve_region",
+            lambda **kwargs: SimpleNamespace(code="x", scoping_strategy=None),
+        )
+        monkeypatch.setattr(
+            ba, "qualifying_baseline_identity", lambda *args, **kwargs: None
+        )
+        with pytest.raises(RuntimeError, match="diverged"):
+            precompute.cohort_identity(2026, ["state/ca"])
+
+
+class TestBuildDatasetImpl:
+    @pytest.fixture
+    def dataset_stubs(self, monkeypatch, tmp_path):
+        from policyengine_simulation_executor import (
+            artifact_keys,
+            artifact_store,
+            release_bundle,
+        )
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        state = SimpleNamespace(
+            folder=tmp_path,
+            uploads=[],
+            ensure_calls=[],
+            write_file=True,
+            identity=SimpleNamespace(
+                digest="ds-2026",
+                store_path="datasets/us/ds-2026/populace_year_2026.h5",
+                filename="populace_year_2026.h5",
+            ),
+        )
+
+        class FakeStore:
+            def __init__(self, bucket):
+                self.bucket = bucket
+
+            def upload_file(self, path, local_path):
+                state.uploads.append((path, str(local_path)))
+                return True
+
+        def fake_ensure_datasets(*, datasets, years, data_folder):
+            state.ensure_calls.append((datasets, years, data_folder))
+            if state.write_file:
+                (tmp_path / state.identity.filename).write_bytes(b"h5-bytes")
+
+        monkeypatch.setattr(
+            artifact_keys, "collect_dataset_identity", lambda c, y: state.identity
+        )
+        monkeypatch.setattr(artifact_store, "ArtifactStore", FakeStore)
+        monkeypatch.setattr(sr, "resolve_data_folder", lambda: str(tmp_path))
+        monkeypatch.setattr(
+            sr,
+            "_country_module",
+            lambda country: SimpleNamespace(ensure_datasets=fake_ensure_datasets),
+        )
+        monkeypatch.setattr(
+            release_bundle,
+            "get_country_release_bundle",
+            lambda country: SimpleNamespace(default_dataset="populace_cps"),
+        )
+        return state
+
+    def _entry(self, path="datasets/us/ds-2026/populace_year_2026.h5"):
+        return DatasetPlanEntry(
+            year=2026,
+            digest="ds-2026",
+            path=path,
+            filename="populace_year_2026.h5",
+            exists=False,
+        )
+
+    def test_builds_and_uploads_under_the_planned_key(self, dataset_stubs):
+        result = precompute.build_dataset_impl("bucket-x", self._entry())
+        assert dataset_stubs.ensure_calls == [
+            (["populace_cps"], [2026], str(dataset_stubs.folder))
+        ]
+        assert dataset_stubs.uploads == [
+            (
+                "datasets/us/ds-2026/populace_year_2026.h5",
+                str(dataset_stubs.folder / "populace_year_2026.h5"),
+            )
+        ]
+        assert result.year == 2026
+        assert result.uploaded is True
+        assert result.size_bytes == len(b"h5-bytes")
+
+    def test_refuses_to_upload_under_a_mismatched_key(self, dataset_stubs):
+        with pytest.raises(RuntimeError, match="refusing to upload"):
+            precompute.build_dataset_impl(
+                "bucket-x", self._entry(path="datasets/us/OTHER/file.h5")
+            )
+        assert dataset_stubs.uploads == []
+
+    def test_fails_loudly_when_no_file_is_produced(self, dataset_stubs):
+        dataset_stubs.write_file = False
+        with pytest.raises(RuntimeError, match="produced no file"):
+            precompute.build_dataset_impl("bucket-x", self._entry())
+        assert dataset_stubs.uploads == []
+
+
+class TestComputeBaselineImpl:
+    @pytest.fixture
+    def cohort_stubs(self, monkeypatch, tmp_path):
+        from policyengine_simulation_executor import artifact_keys, artifact_store
+        from policyengine_simulation_executor import simulation_runtime as sr
+        from policyengine_simulation_executor.baseline_artifacts import (
+            ArtifactBaselineSimulation,
+        )
+
+        state = SimpleNamespace(
+            folder=tmp_path, downloads=[], uploads=[], configured=[]
+        )
+
+        class StubBaseline(ArtifactBaselineSimulation):
+            def ensure(self):
+                self._artifact_outcome = "miss"
+                (tmp_path / f"{self.id}.h5").write_bytes(b"artifact-bytes")
+
+        class SilentBaseline(ArtifactBaselineSimulation):
+            def ensure(self):
+                self._artifact_outcome = "miss"
+
+        state.baseline = StubBaseline.model_construct(id="bl1-cohort")
+        state.make_silent = lambda: SilentBaseline.model_construct(id="bl1-cohort")
+
+        class FakeStore:
+            def __init__(self, bucket):
+                self.bucket = bucket
+
+            def download_file(self, path, local_path):
+                state.downloads.append((path, str(local_path)))
+                Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+                Path(local_path).write_bytes(b"dataset-bytes")
+
+            def upload_file(self, path, local_path):
+                state.uploads.append((path, str(local_path)))
+                return True
+
+        fake_analysis = ModuleType("policyengine.tax_benefit_models.us.analysis")
+        fake_analysis.configure_budgetary_impact_variables = (
+            lambda baseline, reform: state.configured.append((baseline, reform))
+        )
+        monkeypatch.setitem(
+            sys.modules, "policyengine.tax_benefit_models.us.analysis", fake_analysis
+        )
+
+        monkeypatch.setattr(
+            artifact_keys,
+            "collect_dataset_identity",
+            lambda country, year: SimpleNamespace(
+                store_path=f"datasets/us/ds-{year}/populace_year_{year}.h5",
+                filename=f"populace_year_{year}.h5",
+            ),
+        )
+        monkeypatch.setattr(artifact_store, "ArtifactStore", FakeStore)
+        monkeypatch.setattr(sr, "resolve_data_folder", lambda: str(tmp_path))
+        monkeypatch.setattr(sr, "_country_module", lambda country: SimpleNamespace())
+        monkeypatch.setattr(
+            sr,
+            "_resolve_region",
+            lambda **kwargs: SimpleNamespace(
+                code="state/ca+state/wv",
+                scoping_strategy="scoping",
+                dataset_reference=None,
+            ),
+        )
+        monkeypatch.setattr(
+            sr,
+            "_load_dataset",
+            lambda params, country_module, region_resolution: "dataset",
+        )
+        monkeypatch.setattr(
+            sr, "_build_simulation", lambda params, **kwargs: state.baseline
+        )
+        return state
+
+    def _entry(self, sim_id="bl1-cohort"):
+        return BaselinePlanEntry(
+            year=2026,
+            group=["state/ca", "state/wv"],
+            region="state/ca+state/wv",
+            digest="bl-d",
+            path=f"baselines/us/bl-d/{sim_id}.h5",
+            simulation_id=sim_id,
+            exists=False,
+        )
+
+    def test_downloads_dataset_configures_extras_and_uploads(self, cohort_stubs):
+        result = precompute.compute_baseline_impl("bucket-x", self._entry())
+        assert cohort_stubs.downloads == [
+            (
+                "datasets/us/ds-2026/populace_year_2026.h5",
+                str(cohort_stubs.folder / "populace_year_2026.h5"),
+            )
+        ]
+        # The extras configuration is load-bearing: without it every
+        # production request fails the column guard and recomputes.
+        assert cohort_stubs.configured == [
+            (cohort_stubs.baseline, cohort_stubs.baseline)
+        ]
+        assert cohort_stubs.uploads == [
+            (
+                "baselines/us/bl-d/bl1-cohort.h5",
+                str(cohort_stubs.folder / "bl1-cohort.h5"),
+            )
+        ]
+        assert result.simulation_id == "bl1-cohort"
+        assert result.outcome == "miss"
+        assert result.uploaded is True
+        assert result.size_bytes == len(b"artifact-bytes")
+
+    def test_present_local_dataset_skips_download(self, cohort_stubs):
+        (cohort_stubs.folder / "populace_year_2026.h5").write_bytes(b"already-here")
+        precompute.compute_baseline_impl("bucket-x", self._entry())
+        assert cohort_stubs.downloads == []
+
+    def test_refuses_to_act_under_a_mismatched_id(self, cohort_stubs):
+        with pytest.raises(RuntimeError, match="refusing to act"):
+            precompute.compute_baseline_impl("bucket-x", self._entry("bl1-other"))
+        assert cohort_stubs.uploads == []
+
+    def test_refuses_a_plain_simulation(self, cohort_stubs):
+        cohort_stubs.baseline = SimpleNamespace(id="bl1-cohort")
+        with pytest.raises(RuntimeError, match="plain Simulation"):
+            precompute.compute_baseline_impl("bucket-x", self._entry())
+        assert cohort_stubs.uploads == []
+
+    def test_fails_loudly_when_ensure_leaves_no_artifact(self, cohort_stubs):
+        cohort_stubs.baseline = cohort_stubs.make_silent()
+        with pytest.raises(RuntimeError, match="left no artifact"):
+            precompute.compute_baseline_impl("bucket-x", self._entry())
+        assert cohort_stubs.uploads == []
+
+
+class TestVerifyDeterminismImpl:
+    """The gate's comparator: the pipeline's only correctness check must
+    never fail open."""
+
+    def _run(
+        self,
+        monkeypatch,
+        tmp_path,
+        loaded,
+        recomputed,
+        *,
+        outcome="hit",
+        on_disk=True,
+    ):
+        downloads = []
+        captured = []
+
+        class FakeStore:
+            def download_file(self, path, local_path):
+                downloads.append(path)
+                Path(local_path).write_bytes(b"artifact")
+
+        class FakeBaseline:
+            id = "bl1-verify"
+            dataset = "dataset"
+            tax_benefit_model_version = "model-version"
+            scoping_strategy = "scoping"
+            extra_variables = {"extra": 1}
+            artifact_outcome = None
+
+            def ensure(self):
+                self.artifact_outcome = outcome
+                self.output_dataset = SimpleNamespace(
+                    data=SimpleNamespace(entity_data=loaded)
+                )
+
+        class FakeFresh:
+            def __init__(self, **kwargs):
+                captured.append(kwargs)
+
+            def run(self):
+                self.output_dataset = SimpleNamespace(
+                    data=SimpleNamespace(entity_data=recomputed)
+                )
+
+        monkeypatch.setattr(
+            precompute,
+            "_prepare_cohort_baseline",
+            lambda bucket, expected: (FakeStore(), tmp_path, FakeBaseline()),
+        )
+        monkeypatch.setattr("policyengine.core.Simulation", FakeFresh)
+        if on_disk:
+            (tmp_path / "bl1-verify.h5").write_bytes(b"artifact")
+        entry = BaselinePlanEntry(
+            year=2026,
+            group=["state/ca"],
+            region="state/ca",
+            digest="d",
+            path="baselines/us/d/bl1-verify.h5",
+            simulation_id="bl1-verify",
+            exists=True,
+        )
+        verdict = precompute.verify_determinism_impl("bucket-x", entry)
+        return verdict, downloads, captured
+
+    def _frames(self, age=(30.0, 40.0)):
+        return {"person": pd.DataFrame({"age": list(age)})}
+
+    def test_identical_frames_pass(self, monkeypatch, tmp_path):
+        verdict, downloads, _ = self._run(
+            monkeypatch, tmp_path, self._frames(), self._frames()
+        )
+        assert verdict.equal is True
+        assert verdict.differences == []
+        assert downloads == []
+
+    def test_value_difference_fails(self, monkeypatch, tmp_path):
+        verdict, _, _ = self._run(
+            monkeypatch, tmp_path, self._frames(), self._frames(age=(30.0, 41.0))
+        )
+        assert verdict.equal is False
+        assert verdict.differences == ["person.age: values differ"]
+
+    def test_dtype_difference_fails(self, monkeypatch, tmp_path):
+        left = {"person": pd.DataFrame({"age": pd.array([30, 40], dtype="int64")})}
+        right = {"person": pd.DataFrame({"age": pd.array([30.0, 40.0])})}
+        verdict, _, _ = self._run(monkeypatch, tmp_path, left, right)
+        assert verdict.equal is False
+        assert verdict.differences == ["person.age: dtype differs"]
+
+    def test_column_asymmetry_fails(self, monkeypatch, tmp_path):
+        right = {"person": pd.DataFrame({"age": [30.0, 40.0], "income": [1.0, 2.0]})}
+        verdict, _, _ = self._run(monkeypatch, tmp_path, self._frames(), right)
+        assert verdict.equal is False
+        assert verdict.differences == ["person.income: only on one side"]
+
+    def test_missing_entity_fails(self, monkeypatch, tmp_path):
+        verdict, _, _ = self._run(monkeypatch, tmp_path, self._frames(), {})
+        assert verdict.equal is False
+        assert verdict.differences == ["person: missing on one side"]
+
+    def test_differences_are_truncated_but_verdict_stays_false(
+        self, monkeypatch, tmp_path
+    ):
+        left = {"person": pd.DataFrame({f"c{i}": [1.0] for i in range(60)})}
+        right = {"person": pd.DataFrame({f"c{i}": [2.0] for i in range(60)})}
+        verdict, _, _ = self._run(monkeypatch, tmp_path, left, right)
+        assert verdict.equal is False
+        assert len(verdict.differences) == 50
+
+    def test_unloadable_artifact_fails_loudly(self, monkeypatch, tmp_path):
+        with pytest.raises(RuntimeError, match="could not load the artifact"):
+            self._run(
+                monkeypatch,
+                tmp_path,
+                self._frames(),
+                self._frames(),
+                outcome="incomplete",
+            )
+
+    def test_absent_artifact_is_downloaded_first(self, monkeypatch, tmp_path):
+        verdict, downloads, _ = self._run(
+            monkeypatch, tmp_path, self._frames(), self._frames(), on_disk=False
+        )
+        assert downloads == ["baselines/us/d/bl1-verify.h5"]
+        assert verdict.equal is True
+
+    def test_fresh_run_reuses_the_baseline_inputs(self, monkeypatch, tmp_path):
+        _, _, captured = self._run(
+            monkeypatch, tmp_path, self._frames(), self._frames()
+        )
+        assert captured == [
+            {
+                "dataset": "dataset",
+                "tax_benefit_model_version": "model-version",
+                "policy": None,
+                "scoping_strategy": "scoping",
+                "extra_variables": {"extra": 1},
+            }
+        ]

--- a/projects/policyengine-simulation-executor/tests/test_precompute.py
+++ b/projects/policyengine-simulation-executor/tests/test_precompute.py
@@ -2,89 +2,179 @@
 writer==reader identity contract.
 
 No Modal involved — the library takes function handles as parameters, so
-the orchestration runs against plain fakes here.
+the orchestration runs against plain fakes here. Everything structured is
+a strict model from precompute_models; the fakes speak dicts, exactly
+like Modal's serialization boundary does.
 """
 
 from types import SimpleNamespace
 
 import pytest
+from pydantic import ValidationError
 
 from policyengine_simulation_executor import precompute
+from policyengine_simulation_executor.artifact_keys import canonical_digest
+from policyengine_simulation_executor.precompute_models import (
+    ArtifactManifest,
+    BaselinePlanEntry,
+    BundleReceipt,
+    DatasetPlanEntry,
+    PrecomputePlan,
+)
 
 
-def _plan():
-    return {
-        "datasets": [
-            {
-                "year": 2026,
-                "digest": "d1",
-                "path": "datasets/us/d1/populace_year_2026.h5",
-                "filename": "populace_year_2026.h5",
-                "exists": True,
-            },
-            {
-                "year": 2027,
-                "digest": "d2",
-                "path": "datasets/us/d2/populace_year_2027.h5",
-                "filename": "populace_year_2027.h5",
-                "exists": False,
-            },
+def _receipt() -> BundleReceipt:
+    return BundleReceipt(
+        policyengine_version="4.22.0",
+        model_version="1.0.0",
+        data_version="1.2.3",
+        data_artifact_revision="rev-abc",
+        default_dataset="populace_cps",
+    )
+
+
+def _plan() -> PrecomputePlan:
+    return PrecomputePlan(
+        datasets=[
+            DatasetPlanEntry(
+                year=2026,
+                digest="d1",
+                path="datasets/us/d1/populace_year_2026.h5",
+                filename="populace_year_2026.h5",
+                exists=True,
+            ),
+            DatasetPlanEntry(
+                year=2027,
+                digest="d2",
+                path="datasets/us/d2/populace_year_2027.h5",
+                filename="populace_year_2027.h5",
+                exists=False,
+            ),
         ],
-        "baselines": [
-            {
-                "year": 2026,
-                "group": ["state/ca"],
-                "region": "region_group/state/ca",
-                "digest": "b1",
-                "path": "baselines/us/b1/bl1-aaaa.h5",
-                "simulation_id": "bl1-aaaa",
-                "exists": True,
-            },
-            {
-                "year": 2027,
-                "group": ["state/ca"],
-                "region": "region_group/state/ca",
-                "digest": "b2",
-                "path": "baselines/us/b2/bl1-bbbb.h5",
-                "simulation_id": "bl1-bbbb",
-                "exists": False,
-            },
+        baselines=[
+            BaselinePlanEntry(
+                year=2026,
+                group=["state/ca"],
+                region="region_group/state/ca",
+                digest="b1",
+                path="baselines/us/b1/bl1-aaaa.h5",
+                simulation_id="bl1-aaaa",
+                exists=True,
+            ),
+            BaselinePlanEntry(
+                year=2027,
+                group=["state/ca"],
+                region="region_group/state/ca",
+                digest="b2",
+                path="baselines/us/b2/bl1-bbbb.h5",
+                simulation_id="bl1-bbbb",
+                exists=False,
+            ),
         ],
-        "receipt": {"policyengine_version": "4.22.0", "model_version": "1.0.0"},
-    }
+        receipt=_receipt(),
+    )
+
+
+class TestSchemas:
+    def test_plan_round_trips_through_the_modal_boundary(self):
+        plan = _plan()
+        assert PrecomputePlan.model_validate(plan.model_dump()) == plan
+
+    def test_unknown_keys_are_rejected(self):
+        payload = _plan().model_dump()
+        payload["surprise"] = True
+        with pytest.raises(ValidationError):
+            PrecomputePlan.model_validate(payload)
+
+    def test_missing_keys_are_rejected(self):
+        payload = _plan().model_dump()
+        del payload["baselines"][0]["simulation_id"]
+        with pytest.raises(ValidationError):
+            PrecomputePlan.model_validate(payload)
 
 
 class TestPlanning:
     def test_select_work_computes_only_misses(self):
         work = precompute.select_work(_plan(), force=False)
-        assert [entry["year"] for entry in work["datasets"]] == [2027]
-        assert [entry["simulation_id"] for entry in work["baselines"]] == ["bl1-bbbb"]
+        assert [entry.year for entry in work.datasets] == [2027]
+        assert [entry.simulation_id for entry in work.baselines] == ["bl1-bbbb"]
 
     def test_force_selects_everything(self):
         work = precompute.select_work(_plan(), force=True)
-        assert len(work["datasets"]) == 2
-        assert len(work["baselines"]) == 2
+        assert len(work.datasets) == 2
+        assert len(work.baselines) == 2
 
     def test_years_are_in_priority_order(self):
         assert precompute.PRECOMPUTE_YEARS == [2026, 2027, 2025]
 
     def test_manifest_lists_every_artifact_with_runtime_filenames(self):
-        payload = precompute.build_manifest_payload(_plan())
-        assert payload["schema"] == precompute.MANIFEST_SCHEMA
-        assert payload["receipt"] == _plan()["receipt"]
-        by_type = {}
-        for artifact in payload["artifacts"]:
-            by_type.setdefault(artifact["type"], []).append(artifact)
-        assert [a["filename"] for a in by_type["dataset"]] == [
+        manifest = precompute.build_manifest(_plan())
+        assert manifest.manifest_schema == precompute.MANIFEST_SCHEMA
+        assert manifest.receipt == _receipt()
+        by_type: dict[str, list] = {}
+        for artifact in manifest.artifacts:
+            by_type.setdefault(artifact.type, []).append(artifact)
+        assert [a.filename for a in by_type["dataset"]] == [
             "populace_year_2026.h5",
             "populace_year_2027.h5",
         ]
         # Baseline runtime filename is {simulation_id}.h5 — the exact name
         # Simulation.ensure() resolves beside the dataset.
-        assert [a["filename"] for a in by_type["baseline"]] == [
+        assert [a.filename for a in by_type["baseline"]] == [
             "bl1-aaaa.h5",
             "bl1-bbbb.h5",
         ]
+
+    def test_manifest_payload_is_wire_compatible(self):
+        """The manifest is content-addressed: the typed model must digest
+        identically to the raw dict shape already published to the store
+        (key names included — note "schema", not "manifest_schema")."""
+        raw = {
+            "schema": "mf1",
+            "country": "us",
+            "receipt": {
+                "policyengine_version": "4.22.0",
+                "model_version": "1.0.0",
+                "data_version": "1.2.3",
+                "data_artifact_revision": "rev-abc",
+                "default_dataset": "populace_cps",
+            },
+            "artifacts": [
+                {
+                    "type": "dataset",
+                    "path": "datasets/us/d1/populace_year_2026.h5",
+                    "filename": "populace_year_2026.h5",
+                    "year": 2026,
+                    "digest": "d1",
+                },
+                {
+                    "type": "dataset",
+                    "path": "datasets/us/d2/populace_year_2027.h5",
+                    "filename": "populace_year_2027.h5",
+                    "year": 2027,
+                    "digest": "d2",
+                },
+                {
+                    "type": "baseline",
+                    "path": "baselines/us/b1/bl1-aaaa.h5",
+                    "filename": "bl1-aaaa.h5",
+                    "year": 2026,
+                    "digest": "b1",
+                },
+                {
+                    "type": "baseline",
+                    "path": "baselines/us/b2/bl1-bbbb.h5",
+                    "filename": "bl1-bbbb.h5",
+                    "year": 2027,
+                    "digest": "b2",
+                },
+            ],
+        }
+        payload = precompute.build_manifest(_plan()).canonical_payload()
+        assert payload == raw
+        assert canonical_digest(payload) == canonical_digest(raw)
+        # And the wire shape validates back into the model.
+        assert ArtifactManifest.model_validate(raw).canonical_payload() == raw
 
 
 class FakeHandle:
@@ -96,11 +186,14 @@ class FakeHandle:
 
 
 class FakeFunction:
-    """Stands in for a Modal function handle (.remote / .spawn)."""
+    """Stands in for a Modal function handle (.remote / .spawn).
 
-    def __init__(self, result=None, results_by_key=None):
+    Speaks dicts only, as the real boundary does.
+    """
+
+    def __init__(self, result=None, results_by_year=None):
         self.result = result
-        self.results_by_key = results_by_key or {}
+        self.results_by_year = results_by_year or {}
         self.remote_calls = []
         self.spawn_calls = []
 
@@ -110,31 +203,41 @@ class FakeFunction:
 
     def spawn(self, *args):
         self.spawn_calls.append(args)
-        key = args[1] if len(args) > 1 else None
-        return FakeHandle(self.results_by_key.get(key, self.result))
+        year = args[1]["year"] if len(args) > 1 else None
+        return FakeHandle(self.results_by_year.get(year, self.result))
 
 
 def _dataset_result(year):
-    return {"year": year, "build_seconds": 1.0, "size_bytes": 10, "uploaded": True}
+    return {
+        "year": year,
+        "path": f"datasets/us/d/populace_year_{year}.h5",
+        "uploaded": True,
+        "build_seconds": 1.0,
+        "size_bytes": 10,
+    }
 
 
 def _baseline_result(year):
     return {
         "year": year,
+        "group": ["state/ca"],
         "simulation_id": f"bl1-{year}",
         "outcome": "miss",
-        "compute_seconds": 2.0,
         "uploaded": True,
+        "compute_seconds": 2.0,
+        "size_bytes": 10,
     }
 
 
 class TestRunPrecompute:
     def _functions(self, verify_result=None):
         return {
-            "plan_artifacts": FakeFunction(result=_plan()),
-            "build_dataset": FakeFunction(results_by_key={2027: _dataset_result(2027)}),
+            "plan_artifacts": FakeFunction(result=_plan().model_dump()),
+            "build_dataset": FakeFunction(
+                results_by_year={2027: _dataset_result(2027)}
+            ),
             "compute_baseline": FakeFunction(
-                results_by_key={2027: _baseline_result(2027)}
+                results_by_year={2027: _baseline_result(2027)}
             ),
             "verify_determinism": FakeFunction(
                 result=verify_result or {"equal": True, "differences": []}
@@ -153,14 +256,14 @@ class TestRunPrecompute:
         functions = self._functions()
         digest, lines = self._run(functions)
 
-        assert functions["build_dataset"].spawn_calls == [
-            ("bucket-x", 2027, "datasets/us/d2/populace_year_2027.h5")
-        ]
-        assert [call[1] for call in functions["compute_baseline"].spawn_calls] == [2027]
+        (dataset_spawn,) = functions["build_dataset"].spawn_calls
+        assert dataset_spawn[0] == "bucket-x"
+        assert dataset_spawn[1] == _plan().datasets[1].model_dump()
+        (baseline_spawn,) = functions["compute_baseline"].spawn_calls
+        assert baseline_spawn[1] == _plan().baselines[1].model_dump()
         # The gate probes the first computed baseline, with its plan entry.
         (verify_call,) = functions["verify_determinism"].remote_calls
-        assert verify_call[1] == 2027
-        assert verify_call[3]["simulation_id"] == "bl1-bbbb"
+        assert verify_call[1]["simulation_id"] == "bl1-bbbb"
         assert digest == "digest-123"
 
     def test_last_echo_line_is_the_digest_contract(self):
@@ -171,9 +274,9 @@ class TestRunPrecompute:
     def test_noop_run_spawns_nothing_and_skips_the_gate(self):
         functions = self._functions()
         noop_plan = _plan()
-        for entry in noop_plan["datasets"] + noop_plan["baselines"]:
-            entry["exists"] = True
-        functions["plan_artifacts"] = FakeFunction(result=noop_plan)
+        for entry in noop_plan.datasets + noop_plan.baselines:
+            entry.exists = True
+        functions["plan_artifacts"] = FakeFunction(result=noop_plan.model_dump())
 
         digest, lines = self._run(functions)
         assert functions["build_dataset"].spawn_calls == []
@@ -191,6 +294,14 @@ class TestRunPrecompute:
         with pytest.raises(SystemExit, match="values differ"):
             self._run(functions)
         assert functions["publish_manifest"].remote_calls == []
+
+    def test_malformed_worker_result_fails_loudly(self):
+        functions = self._functions()
+        functions["build_dataset"] = FakeFunction(
+            results_by_year={2027: {"year": 2027, "unexpected": "shape"}}
+        )
+        with pytest.raises(ValidationError):
+            self._run(functions)
 
 
 class TestWriterReaderContract:

--- a/projects/policyengine-simulation-executor/tests/test_precompute.py
+++ b/projects/policyengine-simulation-executor/tests/test_precompute.py
@@ -1,0 +1,307 @@
+"""Precompute library: planning, manifest assembly, orchestration, and the
+writer==reader identity contract.
+
+No Modal involved — the library takes function handles as parameters, so
+the orchestration runs against plain fakes here.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from policyengine_simulation_executor import precompute
+
+
+def _plan():
+    return {
+        "datasets": [
+            {
+                "year": 2026,
+                "digest": "d1",
+                "path": "datasets/us/d1/populace_year_2026.h5",
+                "filename": "populace_year_2026.h5",
+                "exists": True,
+            },
+            {
+                "year": 2027,
+                "digest": "d2",
+                "path": "datasets/us/d2/populace_year_2027.h5",
+                "filename": "populace_year_2027.h5",
+                "exists": False,
+            },
+        ],
+        "baselines": [
+            {
+                "year": 2026,
+                "group": ["state/ca"],
+                "region": "region_group/state/ca",
+                "digest": "b1",
+                "path": "baselines/us/b1/bl1-aaaa.h5",
+                "simulation_id": "bl1-aaaa",
+                "exists": True,
+            },
+            {
+                "year": 2027,
+                "group": ["state/ca"],
+                "region": "region_group/state/ca",
+                "digest": "b2",
+                "path": "baselines/us/b2/bl1-bbbb.h5",
+                "simulation_id": "bl1-bbbb",
+                "exists": False,
+            },
+        ],
+        "receipt": {"policyengine_version": "4.22.0", "model_version": "1.0.0"},
+    }
+
+
+class TestPlanning:
+    def test_select_work_computes_only_misses(self):
+        work = precompute.select_work(_plan(), force=False)
+        assert [entry["year"] for entry in work["datasets"]] == [2027]
+        assert [entry["simulation_id"] for entry in work["baselines"]] == ["bl1-bbbb"]
+
+    def test_force_selects_everything(self):
+        work = precompute.select_work(_plan(), force=True)
+        assert len(work["datasets"]) == 2
+        assert len(work["baselines"]) == 2
+
+    def test_years_are_in_priority_order(self):
+        assert precompute.PRECOMPUTE_YEARS == [2026, 2027, 2025]
+
+    def test_manifest_lists_every_artifact_with_runtime_filenames(self):
+        payload = precompute.build_manifest_payload(_plan())
+        assert payload["schema"] == precompute.MANIFEST_SCHEMA
+        assert payload["receipt"] == _plan()["receipt"]
+        by_type = {}
+        for artifact in payload["artifacts"]:
+            by_type.setdefault(artifact["type"], []).append(artifact)
+        assert [a["filename"] for a in by_type["dataset"]] == [
+            "populace_year_2026.h5",
+            "populace_year_2027.h5",
+        ]
+        # Baseline runtime filename is {simulation_id}.h5 — the exact name
+        # Simulation.ensure() resolves beside the dataset.
+        assert [a["filename"] for a in by_type["baseline"]] == [
+            "bl1-aaaa.h5",
+            "bl1-bbbb.h5",
+        ]
+
+
+class FakeHandle:
+    def __init__(self, result):
+        self._result = result
+
+    def get(self):
+        return self._result
+
+
+class FakeFunction:
+    """Stands in for a Modal function handle (.remote / .spawn)."""
+
+    def __init__(self, result=None, results_by_key=None):
+        self.result = result
+        self.results_by_key = results_by_key or {}
+        self.remote_calls = []
+        self.spawn_calls = []
+
+    def remote(self, *args):
+        self.remote_calls.append(args)
+        return self.result
+
+    def spawn(self, *args):
+        self.spawn_calls.append(args)
+        key = args[1] if len(args) > 1 else None
+        return FakeHandle(self.results_by_key.get(key, self.result))
+
+
+def _dataset_result(year):
+    return {"year": year, "build_seconds": 1.0, "size_bytes": 10, "uploaded": True}
+
+
+def _baseline_result(year):
+    return {
+        "year": year,
+        "simulation_id": f"bl1-{year}",
+        "outcome": "miss",
+        "compute_seconds": 2.0,
+        "uploaded": True,
+    }
+
+
+class TestRunPrecompute:
+    def _functions(self, verify_result=None):
+        return {
+            "plan_artifacts": FakeFunction(result=_plan()),
+            "build_dataset": FakeFunction(results_by_key={2027: _dataset_result(2027)}),
+            "compute_baseline": FakeFunction(
+                results_by_key={2027: _baseline_result(2027)}
+            ),
+            "verify_determinism": FakeFunction(
+                result=verify_result or {"equal": True, "differences": []}
+            ),
+            "publish_manifest": FakeFunction(result="digest-123"),
+        }
+
+    def _run(self, functions, *, force=False):
+        lines = []
+        digest = precompute.run_precompute(
+            "bucket-x", force=force, echo=lines.append, **functions
+        )
+        return digest, lines
+
+    def test_spawns_only_misses_and_gates_on_first_computed(self):
+        functions = self._functions()
+        digest, lines = self._run(functions)
+
+        assert functions["build_dataset"].spawn_calls == [
+            ("bucket-x", 2027, "datasets/us/d2/populace_year_2027.h5")
+        ]
+        assert [call[1] for call in functions["compute_baseline"].spawn_calls] == [2027]
+        # The gate probes the first computed baseline, with its plan entry.
+        (verify_call,) = functions["verify_determinism"].remote_calls
+        assert verify_call[1] == 2027
+        assert verify_call[3]["simulation_id"] == "bl1-bbbb"
+        assert digest == "digest-123"
+
+    def test_last_echo_line_is_the_digest_contract(self):
+        _, lines = self._run(self._functions())
+        assert lines[-1] == "MANIFEST_DIGEST=digest-123"
+        assert lines[-1].startswith(precompute.MANIFEST_DIGEST_PREFIX)
+
+    def test_noop_run_spawns_nothing_and_skips_the_gate(self):
+        functions = self._functions()
+        noop_plan = _plan()
+        for entry in noop_plan["datasets"] + noop_plan["baselines"]:
+            entry["exists"] = True
+        functions["plan_artifacts"] = FakeFunction(result=noop_plan)
+
+        digest, lines = self._run(functions)
+        assert functions["build_dataset"].spawn_calls == []
+        assert functions["compute_baseline"].spawn_calls == []
+        assert functions["verify_determinism"].remote_calls == []
+        # The manifest still publishes: a no-op run must refresh nothing
+        # but the deploy still needs a digest for the fetch layer.
+        assert digest == "digest-123"
+        assert lines[-1] == "MANIFEST_DIGEST=digest-123"
+
+    def test_failed_gate_aborts_before_publishing(self):
+        functions = self._functions(
+            verify_result={"equal": False, "differences": ["person.age: values differ"]}
+        )
+        with pytest.raises(SystemExit, match="values differ"):
+            self._run(functions)
+        assert functions["publish_manifest"].remote_calls == []
+
+
+class TestWriterReaderContract:
+    """The writer and the runtime reader must derive identical identities."""
+
+    @pytest.fixture
+    def identity_stubs(self, monkeypatch):
+        from policyengine.provenance import manifest as manifest_module
+
+        from policyengine_simulation_executor import release_bundle
+
+        monkeypatch.setattr(
+            release_bundle,
+            "get_country_release_bundle",
+            lambda country: SimpleNamespace(
+                country="us",
+                policyengine_version="4.22.0",
+                model_version="9.9.9",
+                data_version="1.2.3",
+                data_artifact_revision="rev-abc",
+                default_dataset="populace_cps",
+            ),
+        )
+        monkeypatch.setattr(release_bundle, "_receipt_dataset", lambda country: None)
+        monkeypatch.setattr(
+            manifest_module,
+            "resolve_dataset_reference",
+            lambda country, dataset: f"{dataset}.h5",
+        )
+        monkeypatch.setattr(
+            manifest_module, "dataset_logical_name", lambda reference: "populace_cps"
+        )
+        monkeypatch.setattr(
+            manifest_module,
+            "get_release_manifest",
+            lambda country: SimpleNamespace(certification=None),
+        )
+
+    @pytest.fixture
+    def fake_regions(self, monkeypatch):
+        from policyengine.core.scoping_strategy import RowFilterStrategy
+
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        def get_region(code):
+            state = code.split("/")[-1].upper()
+            return SimpleNamespace(
+                code=code,
+                scoping_strategy=RowFilterStrategy(
+                    variable_name="state_code", variable_value=state
+                ),
+            )
+
+        monkeypatch.setattr(
+            sr,
+            "_country_module",
+            lambda country: SimpleNamespace(
+                model=SimpleNamespace(get_region=get_region)
+            ),
+        )
+
+    def test_precompute_identity_equals_runtime_id(self, identity_stubs, fake_regions):
+        from policyengine_simulation_executor import simulation_runtime as sr
+        from policyengine_simulation_executor.baseline_artifacts import (
+            deterministic_baseline_id,
+        )
+
+        group = ["state/ca", "state/wv"]
+        writer_identity = precompute.cohort_identity(2026, group)
+
+        params = precompute.cohort_params(2026, group)
+        resolution = sr._resolve_region(
+            country_module=sr._country_module("us"), country="us", params=params
+        )
+        reader_id = deterministic_baseline_id(
+            params,
+            country="us",
+            policy=None,
+            region_code=resolution.code,
+            scoping_strategy=resolution.scoping_strategy,
+            year=2026,
+        )
+        assert writer_identity.simulation_id == reader_id
+        assert writer_identity.store_path.endswith(
+            f"/{writer_identity.simulation_id}.h5"
+        )
+
+    def test_dataset_filename_matches_runtime_stem_lookup(self, monkeypatch):
+        """Real-manifest coverage: the artifact filename equals the exact
+        name the runtime's ensure_datasets existence check resolves."""
+        from policyengine.provenance.manifest import (
+            dataset_logical_name,
+            resolve_dataset_reference,
+        )
+
+        from policyengine_simulation_executor.artifact_keys import (
+            collect_dataset_identity,
+        )
+        from policyengine_simulation_executor.release_bundle import (
+            get_country_release_bundle,
+            resolve_bundle_dataset_name,
+        )
+        from policyengine_simulation_executor.simulation_runtime import DEFAULT_YEAR
+
+        monkeypatch.delenv("POLICYENGINE_BUNDLE_RECEIPT", raising=False)
+        get_country_release_bundle.cache_clear()
+        try:
+            expected_stem = dataset_logical_name(
+                resolve_dataset_reference("us", resolve_bundle_dataset_name("us", None))
+            )
+            identity = collect_dataset_identity("us", DEFAULT_YEAR)
+        finally:
+            get_country_release_bundle.cache_clear()
+        assert identity.filename == f"{expected_stem}_year_{DEFAULT_YEAR}.h5"

--- a/projects/policyengine-simulation-executor/tests/test_precompute_app.py
+++ b/projects/policyengine-simulation-executor/tests/test_precompute_app.py
@@ -1,79 +1,30 @@
-"""Precompute app: function shapes, planning logic, writer==reader pins.
+"""Modal-facing shape of the precompute app.
 
-The app itself runs only under `modal run`; these tests cover everything
-around the remote calls — the image/function declarations (fake modal, as
-in test_modal_bundle_image), the pure work-selection and manifest assembly,
-and the contract that the writer derives identical identities to the
-runtime reader through the same executor code path.
+Only the declarations live in the app module (bodies are in
+policyengine_simulation_executor.precompute and are tested in
+test_precompute.py), so these tests assert the declarations: function
+resources, secrets, and the image's local-source mount.
 """
 
 import importlib
 import sys
-from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from fixtures.fake_modal import install_fake_modal
 
-class FakeImage:
-    def __init__(self):
-        self.calls = []
-
-    @classmethod
-    def debian_slim(cls, **kwargs):
-        image = cls()
-        image.calls.append(("debian_slim", kwargs))
-        return image
-
-    def _record(self, name):
-        def method(*args, **kwargs):
-            self.calls.append((name, args, kwargs))
-            return self
-
-        return method
-
-    def __getattr__(self, name):
-        if name.startswith("__"):
-            raise AttributeError(name)
-        return self._record(name)
-
-
-class FakeSecret:
-    @staticmethod
-    def from_name(name, **kwargs):
-        return {"name": name, **kwargs}
-
-
-class FakeApp:
-    instances = []
-
-    def __init__(self, name):
-        self.name = name
-        self.function_calls = []
-        FakeApp.instances.append(self)
-
-    def function(self, **kwargs):
-        def decorator(fn):
-            self.function_calls.append((fn.__name__, kwargs))
-            return fn
-
-        return decorator
-
-    def local_entrypoint(self, **kwargs):
-        def decorator(fn):
-            return fn
-
-        return decorator
+_WORKER_FUNCTIONS = (
+    "plan_artifacts",
+    "build_dataset",
+    "compute_baseline",
+    "verify_determinism",
+    "publish_manifest",
+)
 
 
 @pytest.fixture
 def precompute_module(monkeypatch):
-    fake_modal = ModuleType("modal")
-    fake_modal.Image = FakeImage
-    fake_modal.Secret = FakeSecret
-    fake_modal.App = FakeApp
-    fake_modal.is_local = lambda: True
-    fake_modal.asgi_app = lambda **kwargs: lambda fn: fn
-    monkeypatch.setitem(sys.modules, "modal", fake_modal)
+    install_fake_modal(monkeypatch)
     for env in (
         "POLICYENGINE_VERSION",
         "POLICYENGINE_CORE_VERSION",
@@ -81,7 +32,6 @@ def precompute_module(monkeypatch):
         "POLICYENGINE_UK_VERSION",
     ):
         monkeypatch.setenv(env, "0.0.0-test")
-    FakeApp.instances = []
     for module in ("src.modal.app", "src.modal.precompute_app"):
         sys.modules.pop(module, None)
     module = importlib.import_module("src.modal.precompute_app")
@@ -91,238 +41,44 @@ def precompute_module(monkeypatch):
 
 
 def _function_kwargs(module, name):
-    app = next(
-        instance
-        for instance in FakeApp.instances
-        if instance.name == "policyengine-simulation-precompute"
+    return dict(module.app.function_calls)[name]
+
+
+def test_declares_exactly_the_worker_functions(precompute_module):
+    assert [name for name, _ in precompute_module.app.function_calls] == list(
+        _WORKER_FUNCTIONS
     )
-    return dict(app.function_calls)[name]
 
 
-class TestAppShape:
-    def test_all_worker_functions_carry_gcp_secret(self, precompute_module):
-        for name in (
-            "plan_artifacts",
-            "build_dataset",
-            "compute_baseline",
-            "verify_determinism",
-            "publish_manifest",
-        ):
-            secrets = _function_kwargs(precompute_module, name)["secrets"]
-            assert {"name": "gcp-credentials", "environment_name": "main"} in secrets
-
-    def test_compute_baseline_matches_segment_worker_shape(self, precompute_module):
-        kwargs = _function_kwargs(precompute_module, "compute_baseline")
-        assert kwargs["cpu"] == 8.0
-        assert kwargs["memory"] == 32768
-        assert kwargs["timeout"] == 3600
-
-    def test_dataset_builder_gets_prebuild_scale_resources(self, precompute_module):
-        kwargs = _function_kwargs(precompute_module, "build_dataset")
-        assert kwargs["cpu"] == 8.0
-        assert kwargs["memory"] == 65536
-
-    def test_image_includes_local_source(self, precompute_module):
-        calls = precompute_module.precompute_image.calls
-        local_source = [call for call in calls if call[0] == "add_local_python_source"]
-        assert local_source, "precompute image must mount executor source"
-        assert set(local_source[-1][1]) == {
-            "src.modal",
-            "policyengine_simulation_executor",
-            "policyengine_simulation_observability",
-            "policyengine_simulation_contract",
-        }
-
-    def test_years_are_in_priority_order(self, precompute_module):
-        assert precompute_module.PRECOMPUTE_YEARS == [2026, 2027, 2025]
+@pytest.mark.parametrize("name", _WORKER_FUNCTIONS)
+def test_every_worker_function_carries_gcp_secret(precompute_module, name):
+    secrets = _function_kwargs(precompute_module, name)["secrets"]
+    assert {
+        "args": ("gcp-credentials",),
+        "kwargs": {"environment_name": "main"},
+    } in secrets
 
 
-def _plan():
-    return {
-        "datasets": [
-            {
-                "year": 2026,
-                "digest": "d1",
-                "path": "datasets/us/d1/populace_year_2026.h5",
-                "filename": "populace_year_2026.h5",
-                "exists": True,
-            },
-            {
-                "year": 2027,
-                "digest": "d2",
-                "path": "datasets/us/d2/populace_year_2027.h5",
-                "filename": "populace_year_2027.h5",
-                "exists": False,
-            },
-        ],
-        "baselines": [
-            {
-                "year": 2026,
-                "group": ["state/ca"],
-                "region": "region_group/state/ca",
-                "digest": "b1",
-                "path": "baselines/us/b1/bl1-aaaa.h5",
-                "simulation_id": "bl1-aaaa",
-                "exists": True,
-            },
-            {
-                "year": 2027,
-                "group": ["state/ca"],
-                "region": "region_group/state/ca",
-                "digest": "b2",
-                "path": "baselines/us/b2/bl1-bbbb.h5",
-                "simulation_id": "bl1-bbbb",
-                "exists": False,
-            },
-        ],
-        "receipt": {"policyengine_version": "4.22.0", "model_version": "1.0.0"},
+def test_compute_baseline_matches_segment_worker_shape(precompute_module):
+    kwargs = _function_kwargs(precompute_module, "compute_baseline")
+    assert kwargs["cpu"] == 8.0
+    assert kwargs["memory"] == 32768
+    assert kwargs["timeout"] == 3600
+
+
+def test_dataset_builder_gets_prebuild_scale_resources(precompute_module):
+    kwargs = _function_kwargs(precompute_module, "build_dataset")
+    assert kwargs["cpu"] == 8.0
+    assert kwargs["memory"] == 65536
+
+
+def test_image_includes_local_source(precompute_module):
+    calls = precompute_module.precompute_image.calls
+    local_source = [call for call in calls if call[0] == "add_local_python_source"]
+    assert local_source, "precompute image must mount executor source"
+    assert set(local_source[-1][1]) == {
+        "src.modal",
+        "policyengine_simulation_executor",
+        "policyengine_simulation_observability",
+        "policyengine_simulation_contract",
     }
-
-
-class TestPlanning:
-    def test_select_work_computes_only_misses(self, precompute_module):
-        work = precompute_module.select_work(_plan(), force=False)
-        assert [entry["year"] for entry in work["datasets"]] == [2027]
-        assert [entry["simulation_id"] for entry in work["baselines"]] == ["bl1-bbbb"]
-
-    def test_force_selects_everything(self, precompute_module):
-        work = precompute_module.select_work(_plan(), force=True)
-        assert len(work["datasets"]) == 2
-        assert len(work["baselines"]) == 2
-
-    def test_manifest_lists_every_artifact_with_runtime_filenames(
-        self, precompute_module
-    ):
-        payload = precompute_module.build_manifest_payload(_plan())
-        assert payload["schema"] == precompute_module.MANIFEST_SCHEMA
-        assert payload["receipt"] == _plan()["receipt"]
-        by_type = {}
-        for artifact in payload["artifacts"]:
-            by_type.setdefault(artifact["type"], []).append(artifact)
-        assert [a["filename"] for a in by_type["dataset"]] == [
-            "populace_year_2026.h5",
-            "populace_year_2027.h5",
-        ]
-        # Baseline runtime filename is {simulation_id}.h5 — the exact name
-        # Simulation.ensure() resolves beside the dataset.
-        assert [a["filename"] for a in by_type["baseline"]] == [
-            "bl1-aaaa.h5",
-            "bl1-bbbb.h5",
-        ]
-
-
-class TestWriterReaderContract:
-    """The single most important pins: writer identity == reader identity."""
-
-    @pytest.fixture
-    def identity_stubs(self, monkeypatch):
-        from policyengine.provenance import manifest as manifest_module
-
-        from policyengine_simulation_executor import release_bundle
-
-        monkeypatch.setattr(
-            release_bundle,
-            "get_country_release_bundle",
-            lambda country: SimpleNamespace(
-                country="us",
-                policyengine_version="4.22.0",
-                model_version="9.9.9",
-                data_version="1.2.3",
-                data_artifact_revision="rev-abc",
-                default_dataset="populace_cps",
-            ),
-        )
-        monkeypatch.setattr(release_bundle, "_receipt_dataset", lambda country: None)
-        monkeypatch.setattr(
-            manifest_module,
-            "resolve_dataset_reference",
-            lambda country, dataset: f"{dataset}.h5",
-        )
-        monkeypatch.setattr(
-            manifest_module, "dataset_logical_name", lambda reference: "populace_cps"
-        )
-        monkeypatch.setattr(
-            manifest_module,
-            "get_release_manifest",
-            lambda country: SimpleNamespace(certification=None),
-        )
-
-    @pytest.fixture
-    def fake_regions(self, monkeypatch):
-        from policyengine.core.scoping_strategy import RowFilterStrategy
-
-        from policyengine_simulation_executor import simulation_runtime as sr
-
-        def get_region(code):
-            state = code.split("/")[-1].upper()
-            return SimpleNamespace(
-                code=code,
-                scoping_strategy=RowFilterStrategy(
-                    variable_name="state_code", variable_value=state
-                ),
-            )
-
-        monkeypatch.setattr(
-            sr,
-            "_country_module",
-            lambda country: SimpleNamespace(
-                model=SimpleNamespace(get_region=get_region)
-            ),
-        )
-
-    def test_precompute_identity_equals_runtime_id(
-        self, precompute_module, identity_stubs, fake_regions
-    ):
-        from policyengine_simulation_executor import simulation_runtime as sr
-        from policyengine_simulation_executor.baseline_artifacts import (
-            deterministic_baseline_id,
-        )
-
-        group = ["state/ca", "state/wv"]
-        writer_identity = precompute_module._cohort_identity(2026, group)
-
-        params = precompute_module._cohort_params(2026, group)
-        resolution = sr._resolve_region(
-            country_module=sr._country_module("us"), country="us", params=params
-        )
-        reader_id = deterministic_baseline_id(
-            params,
-            country="us",
-            policy=None,
-            region_code=resolution.code,
-            scoping_strategy=resolution.scoping_strategy,
-            year=2026,
-        )
-        assert writer_identity.simulation_id == reader_id
-        assert writer_identity.store_path.endswith(
-            f"/{writer_identity.simulation_id}.h5"
-        )
-
-    def test_dataset_filename_matches_runtime_stem_lookup(self, monkeypatch):
-        """Real-manifest pin: the artifact filename equals the exact name
-        the runtime's ensure_datasets existence check resolves (idiom of
-        test_image_setup_prebuild)."""
-        from policyengine.provenance.manifest import (
-            dataset_logical_name,
-            resolve_dataset_reference,
-        )
-
-        from policyengine_simulation_executor.artifact_keys import (
-            collect_dataset_identity,
-        )
-        from policyengine_simulation_executor.release_bundle import (
-            get_country_release_bundle,
-            resolve_bundle_dataset_name,
-        )
-        from policyengine_simulation_executor.simulation_runtime import DEFAULT_YEAR
-
-        monkeypatch.delenv("POLICYENGINE_BUNDLE_RECEIPT", raising=False)
-        get_country_release_bundle.cache_clear()
-        try:
-            expected_stem = dataset_logical_name(
-                resolve_dataset_reference("us", resolve_bundle_dataset_name("us", None))
-            )
-            identity = collect_dataset_identity("us", DEFAULT_YEAR)
-        finally:
-            get_country_release_bundle.cache_clear()
-        assert identity.filename == f"{expected_stem}_year_{DEFAULT_YEAR}.h5"

--- a/projects/policyengine-simulation-executor/tests/test_precompute_app.py
+++ b/projects/policyengine-simulation-executor/tests/test_precompute_app.py
@@ -1,0 +1,328 @@
+"""Precompute app: function shapes, planning logic, writer==reader pins.
+
+The app itself runs only under `modal run`; these tests cover everything
+around the remote calls — the image/function declarations (fake modal, as
+in test_modal_bundle_image), the pure work-selection and manifest assembly,
+and the contract that the writer derives identical identities to the
+runtime reader through the same executor code path.
+"""
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+class FakeImage:
+    def __init__(self):
+        self.calls = []
+
+    @classmethod
+    def debian_slim(cls, **kwargs):
+        image = cls()
+        image.calls.append(("debian_slim", kwargs))
+        return image
+
+    def _record(self, name):
+        def method(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            return self
+
+        return method
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return self._record(name)
+
+
+class FakeSecret:
+    @staticmethod
+    def from_name(name, **kwargs):
+        return {"name": name, **kwargs}
+
+
+class FakeApp:
+    instances = []
+
+    def __init__(self, name):
+        self.name = name
+        self.function_calls = []
+        FakeApp.instances.append(self)
+
+    def function(self, **kwargs):
+        def decorator(fn):
+            self.function_calls.append((fn.__name__, kwargs))
+            return fn
+
+        return decorator
+
+    def local_entrypoint(self, **kwargs):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+
+@pytest.fixture
+def precompute_module(monkeypatch):
+    fake_modal = ModuleType("modal")
+    fake_modal.Image = FakeImage
+    fake_modal.Secret = FakeSecret
+    fake_modal.App = FakeApp
+    fake_modal.is_local = lambda: True
+    fake_modal.asgi_app = lambda **kwargs: lambda fn: fn
+    monkeypatch.setitem(sys.modules, "modal", fake_modal)
+    for env in (
+        "POLICYENGINE_VERSION",
+        "POLICYENGINE_CORE_VERSION",
+        "POLICYENGINE_US_VERSION",
+        "POLICYENGINE_UK_VERSION",
+    ):
+        monkeypatch.setenv(env, "0.0.0-test")
+    FakeApp.instances = []
+    for module in ("src.modal.app", "src.modal.precompute_app"):
+        sys.modules.pop(module, None)
+    module = importlib.import_module("src.modal.precompute_app")
+    yield module
+    for name in ("src.modal.app", "src.modal.precompute_app"):
+        sys.modules.pop(name, None)
+
+
+def _function_kwargs(module, name):
+    app = next(
+        instance
+        for instance in FakeApp.instances
+        if instance.name == "policyengine-simulation-precompute"
+    )
+    return dict(app.function_calls)[name]
+
+
+class TestAppShape:
+    def test_all_worker_functions_carry_gcp_secret(self, precompute_module):
+        for name in (
+            "plan_artifacts",
+            "build_dataset",
+            "compute_baseline",
+            "verify_determinism",
+            "publish_manifest",
+        ):
+            secrets = _function_kwargs(precompute_module, name)["secrets"]
+            assert {"name": "gcp-credentials", "environment_name": "main"} in secrets
+
+    def test_compute_baseline_matches_segment_worker_shape(self, precompute_module):
+        kwargs = _function_kwargs(precompute_module, "compute_baseline")
+        assert kwargs["cpu"] == 8.0
+        assert kwargs["memory"] == 32768
+        assert kwargs["timeout"] == 3600
+
+    def test_dataset_builder_gets_prebuild_scale_resources(self, precompute_module):
+        kwargs = _function_kwargs(precompute_module, "build_dataset")
+        assert kwargs["cpu"] == 8.0
+        assert kwargs["memory"] == 65536
+
+    def test_image_includes_local_source(self, precompute_module):
+        calls = precompute_module.precompute_image.calls
+        local_source = [call for call in calls if call[0] == "add_local_python_source"]
+        assert local_source, "precompute image must mount executor source"
+        assert set(local_source[-1][1]) == {
+            "src.modal",
+            "policyengine_simulation_executor",
+            "policyengine_simulation_observability",
+            "policyengine_simulation_contract",
+        }
+
+    def test_years_are_in_priority_order(self, precompute_module):
+        assert precompute_module.PRECOMPUTE_YEARS == [2026, 2027, 2025]
+
+
+def _plan():
+    return {
+        "datasets": [
+            {
+                "year": 2026,
+                "digest": "d1",
+                "path": "datasets/us/d1/populace_year_2026.h5",
+                "filename": "populace_year_2026.h5",
+                "exists": True,
+            },
+            {
+                "year": 2027,
+                "digest": "d2",
+                "path": "datasets/us/d2/populace_year_2027.h5",
+                "filename": "populace_year_2027.h5",
+                "exists": False,
+            },
+        ],
+        "baselines": [
+            {
+                "year": 2026,
+                "group": ["state/ca"],
+                "region": "region_group/state/ca",
+                "digest": "b1",
+                "path": "baselines/us/b1/bl1-aaaa.h5",
+                "simulation_id": "bl1-aaaa",
+                "exists": True,
+            },
+            {
+                "year": 2027,
+                "group": ["state/ca"],
+                "region": "region_group/state/ca",
+                "digest": "b2",
+                "path": "baselines/us/b2/bl1-bbbb.h5",
+                "simulation_id": "bl1-bbbb",
+                "exists": False,
+            },
+        ],
+        "receipt": {"policyengine_version": "4.22.0", "model_version": "1.0.0"},
+    }
+
+
+class TestPlanning:
+    def test_select_work_computes_only_misses(self, precompute_module):
+        work = precompute_module.select_work(_plan(), force=False)
+        assert [entry["year"] for entry in work["datasets"]] == [2027]
+        assert [entry["simulation_id"] for entry in work["baselines"]] == ["bl1-bbbb"]
+
+    def test_force_selects_everything(self, precompute_module):
+        work = precompute_module.select_work(_plan(), force=True)
+        assert len(work["datasets"]) == 2
+        assert len(work["baselines"]) == 2
+
+    def test_manifest_lists_every_artifact_with_runtime_filenames(
+        self, precompute_module
+    ):
+        payload = precompute_module.build_manifest_payload(_plan())
+        assert payload["schema"] == precompute_module.MANIFEST_SCHEMA
+        assert payload["receipt"] == _plan()["receipt"]
+        by_type = {}
+        for artifact in payload["artifacts"]:
+            by_type.setdefault(artifact["type"], []).append(artifact)
+        assert [a["filename"] for a in by_type["dataset"]] == [
+            "populace_year_2026.h5",
+            "populace_year_2027.h5",
+        ]
+        # Baseline runtime filename is {simulation_id}.h5 — the exact name
+        # Simulation.ensure() resolves beside the dataset.
+        assert [a["filename"] for a in by_type["baseline"]] == [
+            "bl1-aaaa.h5",
+            "bl1-bbbb.h5",
+        ]
+
+
+class TestWriterReaderContract:
+    """The single most important pins: writer identity == reader identity."""
+
+    @pytest.fixture
+    def identity_stubs(self, monkeypatch):
+        from policyengine.provenance import manifest as manifest_module
+
+        from policyengine_simulation_executor import release_bundle
+
+        monkeypatch.setattr(
+            release_bundle,
+            "get_country_release_bundle",
+            lambda country: SimpleNamespace(
+                country="us",
+                policyengine_version="4.22.0",
+                model_version="9.9.9",
+                data_version="1.2.3",
+                data_artifact_revision="rev-abc",
+                default_dataset="populace_cps",
+            ),
+        )
+        monkeypatch.setattr(release_bundle, "_receipt_dataset", lambda country: None)
+        monkeypatch.setattr(
+            manifest_module,
+            "resolve_dataset_reference",
+            lambda country, dataset: f"{dataset}.h5",
+        )
+        monkeypatch.setattr(
+            manifest_module, "dataset_logical_name", lambda reference: "populace_cps"
+        )
+        monkeypatch.setattr(
+            manifest_module,
+            "get_release_manifest",
+            lambda country: SimpleNamespace(certification=None),
+        )
+
+    @pytest.fixture
+    def fake_regions(self, monkeypatch):
+        from policyengine.core.scoping_strategy import RowFilterStrategy
+
+        from policyengine_simulation_executor import simulation_runtime as sr
+
+        def get_region(code):
+            state = code.split("/")[-1].upper()
+            return SimpleNamespace(
+                code=code,
+                scoping_strategy=RowFilterStrategy(
+                    variable_name="state_code", variable_value=state
+                ),
+            )
+
+        monkeypatch.setattr(
+            sr,
+            "_country_module",
+            lambda country: SimpleNamespace(
+                model=SimpleNamespace(get_region=get_region)
+            ),
+        )
+
+    def test_precompute_identity_equals_runtime_id(
+        self, precompute_module, identity_stubs, fake_regions
+    ):
+        from policyengine_simulation_executor import simulation_runtime as sr
+        from policyengine_simulation_executor.baseline_artifacts import (
+            deterministic_baseline_id,
+        )
+
+        group = ["state/ca", "state/wv"]
+        writer_identity = precompute_module._cohort_identity(2026, group)
+
+        params = precompute_module._cohort_params(2026, group)
+        resolution = sr._resolve_region(
+            country_module=sr._country_module("us"), country="us", params=params
+        )
+        reader_id = deterministic_baseline_id(
+            params,
+            country="us",
+            policy=None,
+            region_code=resolution.code,
+            scoping_strategy=resolution.scoping_strategy,
+            year=2026,
+        )
+        assert writer_identity.simulation_id == reader_id
+        assert writer_identity.store_path.endswith(
+            f"/{writer_identity.simulation_id}.h5"
+        )
+
+    def test_dataset_filename_matches_runtime_stem_lookup(self, monkeypatch):
+        """Real-manifest pin: the artifact filename equals the exact name
+        the runtime's ensure_datasets existence check resolves (idiom of
+        test_image_setup_prebuild)."""
+        from policyengine.provenance.manifest import (
+            dataset_logical_name,
+            resolve_dataset_reference,
+        )
+
+        from policyengine_simulation_executor.artifact_keys import (
+            collect_dataset_identity,
+        )
+        from policyengine_simulation_executor.release_bundle import (
+            get_country_release_bundle,
+            resolve_bundle_dataset_name,
+        )
+        from policyengine_simulation_executor.simulation_runtime import DEFAULT_YEAR
+
+        monkeypatch.delenv("POLICYENGINE_BUNDLE_RECEIPT", raising=False)
+        get_country_release_bundle.cache_clear()
+        try:
+            expected_stem = dataset_logical_name(
+                resolve_dataset_reference("us", resolve_bundle_dataset_name("us", None))
+            )
+            identity = collect_dataset_identity("us", DEFAULT_YEAR)
+        finally:
+            get_country_release_bundle.cache_clear()
+        assert identity.filename == f"{expected_stem}_year_{DEFAULT_YEAR}.h5"

--- a/projects/policyengine-simulation-executor/tests/test_precompute_app.py
+++ b/projects/policyengine-simulation-executor/tests/test_precompute_app.py
@@ -2,14 +2,17 @@
 
 Only the declarations live in the app module (bodies are in
 policyengine_simulation_executor.precompute and are tested in
-test_precompute.py), so these tests assert the declarations: function
-resources, secrets, and the image's local-source mount.
+test_precompute.py), so these tests assert the declarations — function
+resources, secrets, the image's local-source mount — plus the wrapper
+bodies' serialization boundary (validate dicts in, dump models out) and
+the local entrypoint's wiring.
 """
 
 import importlib
 import sys
 
 import pytest
+from pydantic import ValidationError
 
 from fixtures.fake_modal import install_fake_modal
 
@@ -81,4 +84,152 @@ def test_image_includes_local_source(precompute_module):
         "policyengine_simulation_executor",
         "policyengine_simulation_observability",
         "policyengine_simulation_contract",
+    }
+
+
+def _sample_plan():
+    from policyengine_simulation_executor.precompute_models import PrecomputePlan
+
+    return PrecomputePlan.model_validate(
+        {
+            "datasets": [
+                {
+                    "year": 2026,
+                    "digest": "d1",
+                    "path": "datasets/us/d1/populace_year_2026.h5",
+                    "filename": "populace_year_2026.h5",
+                    "exists": False,
+                }
+            ],
+            "baselines": [
+                {
+                    "year": 2026,
+                    "group": ["state/ca"],
+                    "region": "state/ca",
+                    "digest": "b1",
+                    "path": "baselines/us/b1/bl1-aaaa.h5",
+                    "simulation_id": "bl1-aaaa",
+                    "exists": False,
+                }
+            ],
+            "receipt": {
+                "policyengine_version": "4.22.0",
+                "model_version": "1.0.0",
+                "data_version": "1.2.3",
+                "data_artifact_revision": "rev-abc",
+                "default_dataset": "populace_cps",
+            },
+        }
+    )
+
+
+def test_wrappers_validate_dicts_in_and_dump_models_out(precompute_module, monkeypatch):
+    """The wrappers ARE the Modal serialization boundary: dict in,
+    validated model to the impl, model back, dict out."""
+    from policyengine_simulation_executor import precompute as lib
+    from policyengine_simulation_executor.precompute_models import (
+        BaselineComputeResult,
+        DatasetBuildResult,
+        DeterminismVerdict,
+    )
+
+    plan = _sample_plan()
+    seen = {}
+
+    monkeypatch.setattr(lib, "plan_artifacts_impl", lambda bucket: plan)
+    assert precompute_module.plan_artifacts("bucket-x") == plan.model_dump()
+
+    dataset_result = DatasetBuildResult(
+        year=2026, path="p", uploaded=True, build_seconds=1.0, size_bytes=3
+    )
+
+    def fake_build_dataset(bucket, expected):
+        seen["dataset"] = (bucket, expected)
+        return dataset_result
+
+    monkeypatch.setattr(lib, "build_dataset_impl", fake_build_dataset)
+    assert (
+        precompute_module.build_dataset("bucket-x", plan.datasets[0].model_dump())
+        == dataset_result.model_dump()
+    )
+    assert seen["dataset"] == ("bucket-x", plan.datasets[0])
+
+    baseline_result = BaselineComputeResult(
+        year=2026,
+        group=["state/ca"],
+        simulation_id="bl1-aaaa",
+        outcome="miss",
+        uploaded=True,
+        compute_seconds=2.0,
+        size_bytes=3,
+    )
+
+    def fake_compute_baseline(bucket, expected):
+        seen["baseline"] = (bucket, expected)
+        return baseline_result
+
+    monkeypatch.setattr(lib, "compute_baseline_impl", fake_compute_baseline)
+    assert (
+        precompute_module.compute_baseline("bucket-x", plan.baselines[0].model_dump())
+        == baseline_result.model_dump()
+    )
+    assert seen["baseline"] == ("bucket-x", plan.baselines[0])
+
+    verdict = DeterminismVerdict(equal=True, differences=[])
+    monkeypatch.setattr(
+        lib, "verify_determinism_impl", lambda bucket, expected: verdict
+    )
+    assert (
+        precompute_module.verify_determinism("bucket-x", plan.baselines[0].model_dump())
+        == verdict.model_dump()
+    )
+
+    def fake_publish_manifest(bucket, validated):
+        seen["publish"] = (bucket, validated)
+        return "digest-abc"
+
+    monkeypatch.setattr(lib, "publish_manifest_impl", fake_publish_manifest)
+    # publish_manifest returns the bare digest string — no dump.
+    assert (
+        precompute_module.publish_manifest("bucket-x", plan.model_dump())
+        == "digest-abc"
+    )
+    assert seen["publish"] == ("bucket-x", plan)
+
+
+def test_wrappers_reject_malformed_input_at_the_edge(precompute_module):
+    with pytest.raises(ValidationError):
+        precompute_module.build_dataset("bucket-x", {"year": 2026})
+    with pytest.raises(ValidationError):
+        precompute_module.compute_baseline("bucket-x", {"unexpected": True})
+
+
+def test_local_entrypoint_wires_bucket_force_and_handles(
+    precompute_module, monkeypatch
+):
+    from policyengine_simulation_executor import artifact_store
+    from policyengine_simulation_executor import precompute as lib
+
+    captured = {}
+
+    def fake_run_precompute(bucket, *, force, **handles):
+        captured["bucket"] = bucket
+        captured["force"] = force
+        captured["handles"] = handles
+        return "digest"
+
+    monkeypatch.setattr(
+        artifact_store, "resolve_bucket_name", lambda explicit=None: "bucket-env"
+    )
+    monkeypatch.setattr(lib, "run_precompute", fake_run_precompute)
+
+    precompute_module.main(force=True)
+    assert captured["bucket"] == "bucket-env"
+    assert captured["force"] is True
+    assert captured["handles"] == {
+        "plan_artifacts": precompute_module.plan_artifacts,
+        "build_dataset": precompute_module.build_dataset,
+        "compute_baseline": precompute_module.compute_baseline,
+        "verify_determinism": precompute_module.verify_determinism,
+        "publish_manifest": precompute_module.publish_manifest,
     }

--- a/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
@@ -228,9 +228,7 @@ def _stub_policyengine_output_calls(monkeypatch, baseline, reform) -> None:
     monkeypatch.setattr(
         SimulationOutputBuilder,
         "_build_congressional_district_impact",
-        lambda self: (
-            _congressional_district_output() if self.country == "us" else None
-        ),
+        lambda self: _congressional_district_output() if self.country == "us" else None,
     )
     monkeypatch.setattr(
         SimulationOutputBuilder,
@@ -424,7 +422,9 @@ def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
     reform_simulation = object()
     build_calls = []
 
-    def fake_build_simulation(params, *, dataset, policy, scoping_strategy=None):
+    def fake_build_simulation(
+        params, *, dataset, policy, scoping_strategy=None, region_code=None
+    ):
         build_calls.append((params, dataset, policy, scoping_strategy))
         return baseline_simulation if len(build_calls) == 1 else reform_simulation
 
@@ -866,7 +866,9 @@ def test_run_simulation_impl_core_builds_and_serializes_macro_output(monkeypatch
         assert country == "us"
         return country_module
 
-    def fake_build_simulation(params, *, dataset, policy, scoping_strategy=None):
+    def fake_build_simulation(
+        params, *, dataset, policy, scoping_strategy=None, region_code=None
+    ):
         build_calls.append((params, dataset, policy, scoping_strategy))
         return baseline_simulation if len(build_calls) == 1 else reform_simulation
 
@@ -942,7 +944,9 @@ def test_run_simulation_impl_core_passes_region_scoping_to_simulations(monkeypat
     )
     build_calls = []
 
-    def fake_build_simulation(params, *, dataset, policy, scoping_strategy=None):
+    def fake_build_simulation(
+        params, *, dataset, policy, scoping_strategy=None, region_code=None
+    ):
         build_calls.append((params, dataset, policy, scoping_strategy))
         return baseline_simulation if len(build_calls) == 1 else reform_simulation
 

--- a/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
@@ -425,7 +425,7 @@ def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
     def fake_build_simulation(
         params, *, dataset, policy, scoping_strategy=None, region_code=None
     ):
-        build_calls.append((params, dataset, policy, scoping_strategy))
+        build_calls.append((params, dataset, policy, scoping_strategy, region_code))
         return baseline_simulation if len(build_calls) == 1 else reform_simulation
 
     class FakeSimulationOutputBuilder:
@@ -503,6 +503,9 @@ def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
         {"simulation_kind": "baseline"},
         {"simulation_kind": "reform"},
     ]
+    # region_code must be the RESOLVED code: it feeds the deterministic
+    # baseline-id predicate, and dropping it silently disables artifact
+    # reuse (every baseline becomes a miss).
     assert build_calls == [
         (
             {
@@ -513,6 +516,7 @@ def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
             dataset,
             {"gov.test.parameter": {"2026-01-01": 1}},
             "mock-scoping",
+            "us",
         ),
         (
             {
@@ -523,6 +527,7 @@ def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
             dataset,
             {"gov.test.parameter": {"2026-01-01": 2}},
             "mock-scoping",
+            "us",
         ),
     ]
 

--- a/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
+++ b/projects/policyengine-simulation-executor/tests/test_simulation_output_builder.py
@@ -532,6 +532,84 @@ def test_run_simulation_impl_records_runtime_timings_without_real_calculation(
     ]
 
 
+def test_run_simulation_impl_exports_baseline_artifact_outcome(monkeypatch):
+    """The hit/incomplete/miss attribute is the rollout metric for the
+    artifact pipeline; losing the export would blind that measurement."""
+    dataset = object()
+    country_module = SimpleNamespace(model=SimpleNamespace(version="1.715.2"))
+    simulations = {
+        "baseline": SimpleNamespace(artifact_outcome="incomplete"),
+        "reform": object(),
+    }
+    build_count = [0]
+
+    def fake_build_simulation(
+        params, *, dataset, policy, scoping_strategy=None, region_code=None
+    ):
+        build_count[0] += 1
+        return simulations["baseline"] if build_count[0] == 1 else simulations["reform"]
+
+    class FakeSimulationOutputBuilder:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def serialize(self):
+            return CURRENT_SINGLE_YEAR_MACRO_RESULT
+
+    attributes = []
+    for env in (
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+        "GCP_CREDENTIALS_JSON",
+        "GOOGLE_CREDENTIALS",
+        "SERVICE_ACCOUNT_JSON",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_runtime._country_module",
+        lambda country: country_module,
+    )
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_runtime._resolve_region",
+        lambda **kwargs: RegionResolution(
+            code="us",
+            dataset_reference="mock-dataset",
+            scoping_strategy="mock-scoping",
+        ),
+    )
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_runtime._load_dataset",
+        lambda params, country_module, region_resolution: dataset,
+    )
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_runtime._build_simulation",
+        fake_build_simulation,
+    )
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_runtime.SimulationOutputBuilder",
+        FakeSimulationOutputBuilder,
+    )
+    monkeypatch.setattr(
+        "policyengine_simulation_executor.simulation_runtime.set_attribute",
+        lambda key, value: attributes.append((key, value)),
+    )
+
+    params = {
+        "country": "us",
+        "baseline": {"gov.test.parameter": {"2026-01-01": 1}},
+        "reform": {"gov.test.parameter": {"2026-01-01": 2}},
+    }
+    run_simulation_impl(params)
+    assert ("baseline_artifact", "incomplete") in attributes
+
+    # A plain Simulation baseline (no artifact_outcome) must emit nothing.
+    attributes.clear()
+    build_count[0] = 0
+    simulations["baseline"] = object()
+    run_simulation_impl(params)
+    assert all(key != "baseline_artifact" for key, _ in attributes)
+
+
 def test_builder_records_output_timings_without_real_calculation(monkeypatch):
     baseline = object()
     reform = object()

--- a/projects/policyengine-simulation-executor/uv.lock
+++ b/projects/policyengine-simulation-executor/uv.lock
@@ -1853,6 +1853,7 @@ name = "policyengine-simulation-executor"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "google-cloud-storage" },
     { name = "logfire" },
     { name = "modal" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -1887,6 +1888,7 @@ dev = [
 ]
 modal-simulation-image = [
     { name = "fastapi" },
+    { name = "google-cloud-storage" },
     { name = "importlib-metadata" },
     { name = "logfire" },
     { name = "pip" },
@@ -1898,6 +1900,7 @@ modal-simulation-image = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'build'", specifier = ">=25.1.0" },
+    { name = "google-cloud-storage", specifier = ">=2" },
     { name = "logfire", specifier = ">=3.0.0" },
     { name = "modal", specifier = ">=0.73.0" },
     { name = "openapi-python-client", marker = "extra == 'build'", specifier = ">=0.21.6" },
@@ -1924,6 +1927,7 @@ provides-extras = ["test", "build"]
 dev = [{ name = "policyengine-simulation-gateway", editable = "../policyengine-simulation-gateway" }]
 modal-simulation-image = [
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-cloud-storage", specifier = ">=2" },
     { name = "importlib-metadata", specifier = ">=8" },
     { name = "logfire", specifier = ">=3.0.0" },
     { name = "pip" },


### PR DESCRIPTION
Fixes #643

## What

Phase 1 of the baseline artifact pipeline: everything needed to precompute the single-year US datasets (2026, 2027, 2025) and the 20 per-cohort national baselines per year into a content-addressed GCS store, and for the runtime to load those baselines instead of computing them. No behavior changes ship in this phase: with no artifacts in any image, every request takes exactly today's compute path (verified by the unchanged suite), and the store has no consumers in the deploy pipeline yet — the CI producer job and the image fetch layer come in the next phases.

Also rides along: the segmented-national poll cap drops 15s -> 8s (worst-case lag between a child finishing and the parent noticing).

## How

- **`artifact_keys`** — sha256 over canonical JSON of the full input closure: versions from the release bundle, the receipt's per-dataset content sha (closes the same-version data re-release hole that `force_build` exists for), and the certification `data_build_fingerprint`. Baseline keys nest the dataset digest and carry `country`/`region`/`scope_key` (the `ScopingStrategy.cache_key`), so UK or single-state artifacts later need no schema change. The deterministic Simulation id `bl1-<digest16>` doubles as the artifact filename `ensure()` already loads from. Golden tests turn any digest or upstream `cache_key` format change into a reviewable diff.
- **`artifact_store`** — GCS client: write-once uploads (`if_generation_match=0`; `PreconditionFailed` is already-present success, the guard for concurrent beta/prod warmers), content-addressed manifests, last-writer-wins `deployed/<env>.json` markers. `google-cloud-storage` becomes an explicit dependency instead of a transitive ride-along via policyengine.
- **Runtime reader** — `_build_simulation` assigns the deterministic id when the baseline qualifies (current-law policy, macro scope, default data, national or region-group scope). `ArtifactBaselineSimulation.ensure()` validates any load (disk or LRU) against `resolve_entity_variables` and falls back to `run()+save()` on missing columns — cliff/LSR requests degrade to compute, never to wrong answers. Outcome exported as the `baseline_artifact` attribute (`hit`/`incomplete`/`miss`).
- **`precompute_app`** — ephemeral `modal run` writer: plans against the store in-container (the bundle receipt the keys digest lives in the image, not on the deploying machine), computes only misses, builds baselines through the executor's own `_resolve_region` + `_build_simulation` on synthetic child requests (writer==reader by construction, asserted by a regression test), applies the same budgetary-pair extras `economic_impact_analysis` would, runs a determinism gate (uploaded artifact vs independent fresh run, frame-by-frame), and prints `MANIFEST_DIGEST=` for the deploy pipeline.

## Tests

`uv run pytest tests/` in the executor project: **310 passed, 2 deselected**. New: `test_artifact_keys` (30: golden digests, per-field sensitivity, upstream cache_key goldens, identity collection), `test_artifact_store` (9: write-once semantics, manifest round-trip, marker overwrites), `test_baseline_artifacts` (21: qualifying-predicate matrix, guard fallback/cache-replacement, class selection), `test_precompute_app` (10: function shapes incl. gcp secret and segment-worker sizing, miss-only planning, manifest filenames, writer==reader id contract, real-manifest stem check). `ruff format`/`ruff check` clean on changed files.

Not run: `make check`'s pyright step (binary not installed locally; CI lint runs ruff only). Not run yet: the manual staging `modal run` of the precompute app — it needs the artifact bucket provisioned (`POLICYENGINE_ARTIFACT_BUCKET`); that run is the phase gate before merge and will also produce the first real dataset-build and cohort-sim duration measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)