### PR TITLE
Run the artifact precompute as a deploy-pipeline job (producer only)

### DIFF
--- a/.github/scripts/modal-precompute.sh
+++ b/.github/scripts/modal-precompute.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Run the artifact precompute app against a Modal environment.
+# Usage: ./modal-precompute.sh <modal-environment> [force]
+# Run from projects/policyengine-simulation-executor (like modal-deploy-app.sh).
+# Required env vars: POLICYENGINE_ARTIFACT_BUCKET (GCS artifact store bucket).
+# Outputs: sets manifest_digest in GITHUB_OUTPUT, parsed from the app's
+# MANIFEST_DIGEST= stdout contract (the last matching line wins; Modal may
+# append its own output after the entrypoint returns).
+
+set -euo pipefail
+
+MODAL_ENV="${1:?Modal environment required}"
+FORCE="${2:-false}"
+
+if [ -z "${POLICYENGINE_ARTIFACT_BUCKET:-}" ]; then
+  echo "POLICYENGINE_ARTIFACT_BUCKET is required (the GCS artifact store bucket)." >&2
+  echo "Set it as a repository Actions variable, or export it for local runs." >&2
+  exit 1
+fi
+
+RUN_COMMAND=(uv run modal run --env="$MODAL_ENV" src/modal/precompute_app.py)
+if [[ "$FORCE" == "true" || "$FORCE" == "1" ]]; then
+    RUN_COMMAND+=(--force)
+fi
+
+echo "========================================"
+echo "Precomputing artifacts in Modal environment: $MODAL_ENV"
+echo "  Bucket: gs://${POLICYENGINE_ARTIFACT_BUCKET}"
+echo "  Force recompute: ${FORCE}"
+echo "========================================"
+
+OUTPUT_LOG="$(mktemp)"
+trap 'rm -f "$OUTPUT_LOG"' EXIT
+
+"${RUN_COMMAND[@]}" 2>&1 | tee "$OUTPUT_LOG"
+
+DIGEST_LINE="$(tr -d '\r' < "$OUTPUT_LOG" | grep '^MANIFEST_DIGEST=' | tail -n 1 || true)"
+if [ -z "$DIGEST_LINE" ]; then
+  echo "Precompute output contained no MANIFEST_DIGEST= line; cannot export a manifest digest." >&2
+  exit 1
+fi
+
+MANIFEST_DIGEST="${DIGEST_LINE#MANIFEST_DIGEST=}"
+echo "Manifest digest: $MANIFEST_DIGEST"
+echo "manifest_digest=$MANIFEST_DIGEST" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/modal-precompute.sh
+++ b/.github/scripts/modal-precompute.sh
@@ -18,6 +18,14 @@ if [ -z "${POLICYENGINE_ARTIFACT_BUCKET:-}" ]; then
   exit 1
 fi
 
+# Check up front: failing at the final append after a long compute would
+# waste the whole run.
+if [ -z "${GITHUB_OUTPUT:-}" ]; then
+  echo "GITHUB_OUTPUT is required (the manifest digest is exported there)." >&2
+  echo 'For local runs: export GITHUB_OUTPUT="$(mktemp)".' >&2
+  exit 1
+fi
+
 RUN_COMMAND=(uv run modal run --env="$MODAL_ENV" src/modal/precompute_app.py)
 if [[ "$FORCE" == "true" || "$FORCE" == "1" ]]; then
     RUN_COMMAND+=(--force)

--- a/.github/workflows/modal-deploy.reusable.yml
+++ b/.github/workflows/modal-deploy.reusable.yml
@@ -40,8 +40,62 @@ on:
         value: ${{ jobs.deploy.outputs.uk_data_version }}
 
 jobs:
+  precompute:
+    name: Precompute artifacts
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 60
+    outputs:
+      manifest_digest: ${{ steps.run-precompute.outputs.manifest_digest }}
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+
+    - name: Make scripts executable
+      run: chmod +x .github/scripts/*.sh
+
+    - name: Install dependencies
+      working-directory: projects/policyengine-simulation-executor
+      run: uv sync
+
+    # Deliberately duplicates the deploy job's sync: precompute must never
+    # depend on a prior deploy having created the Modal secrets it uses.
+    - name: Sync Modal secrets from GitHub
+      working-directory: projects/policyengine-simulation-executor
+      env:
+        MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+        MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
+        GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
+        GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
+        GATEWAY_AUTH_CLIENT_ID: ${{ secrets.GATEWAY_AUTH_CLIENT_ID }}
+        GATEWAY_AUTH_CLIENT_SECRET: ${{ secrets.GATEWAY_AUTH_CLIENT_SECRET }}
+        GATEWAY_AUTH_REQUIRED: ${{ vars.GATEWAY_AUTH_REQUIRED }}
+      run: ../../.github/scripts/modal-sync-secrets.sh "${{ inputs.modal_environment }}" "${{ inputs.environment }}"
+
+    - name: Run artifact precompute
+      id: run-precompute
+      working-directory: projects/policyengine-simulation-executor
+      env:
+        MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+        MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        POLICYENGINE_ARTIFACT_BUCKET: ${{ vars.POLICYENGINE_ARTIFACT_BUCKET }}
+      run: ../../.github/scripts/modal-precompute.sh "${{ inputs.modal_environment }}" "false"
+
   deploy:
     name: Deploy to Modal
+    needs: [precompute]
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     outputs:

--- a/.github/workflows/modal-deploy.reusable.yml
+++ b/.github/workflows/modal-deploy.reusable.yml
@@ -16,6 +16,11 @@ on:
         default: false
         type: boolean
         description: 'Force latest pointers to this deployment'
+      force_recompute:
+        required: false
+        default: false
+        type: boolean
+        description: 'Recompute artifacts even when the store already has them'
     outputs:
       simulation_api_url:
         description: 'The deployed simulation API URL'
@@ -91,7 +96,7 @@ jobs:
         MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
         MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         POLICYENGINE_ARTIFACT_BUCKET: ${{ vars.POLICYENGINE_ARTIFACT_BUCKET }}
-      run: ../../.github/scripts/modal-precompute.sh "${{ inputs.modal_environment }}" "false"
+      run: ../../.github/scripts/modal-precompute.sh "${{ inputs.modal_environment }}" "${{ inputs.force_recompute }}"
 
   deploy:
     name: Deploy to Modal

--- a/.github/workflows/modal-deploy.yml
+++ b/.github/workflows/modal-deploy.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      force_recompute:
+        description: 'Recompute artifacts even when the store already has them (write-once: existing objects are never replaced)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: modal-deploy-main
@@ -59,6 +64,7 @@ jobs:
       environment: beta
       modal_environment: staging
       force_latest: ${{ inputs.force_latest || false }}
+      force_recompute: ${{ inputs.force_recompute || false }}
     secrets: inherit
 
   deploy_prod:
@@ -70,6 +76,7 @@ jobs:
       environment: prod
       modal_environment: main
       force_latest: ${{ inputs.force_latest || false }}
+      force_recompute: ${{ inputs.force_recompute || false }}
     secrets: inherit
 
   summary:

--- a/projects/policyengine-simulation-executor/README.md
+++ b/projects/policyengine-simulation-executor/README.md
@@ -53,7 +53,7 @@ Operational notes:
   explicit `data` dataset or pinning a `data_version` bypasses it (see
   `_load_dataset` in `simulation_runtime.py`).
 
-## Artifact precompute (baseline artifact pipeline, phase 1)
+## Artifact precompute (baseline artifact pipeline)
 
 The precompute app fills a content-addressed GCS store with single-year US
 datasets (2026, 2027, 2025) and the 20 per-cohort national baseline
@@ -63,7 +63,12 @@ lives in `src/policyengine_simulation_executor/precompute.py` (keys:
 `artifact_keys.py`, store client: `artifact_store.py`); the Modal app
 (`src/modal/precompute_app.py`) is plumbing only.
 
-Run it manually (phase 1; a CI deploy job takes over in a later phase):
+The deploy pipeline runs it automatically: a `precompute` job in the
+reusable deploy workflow fills the store on both legs before each deploy
+(via `.github/scripts/modal-precompute.sh`, bucket from the repo-level
+`POLICYENGINE_ARTIFACT_BUCKET` Actions variable), and the deploy
+workflow's `force_recompute` dispatch input threads through as `--force`.
+Manual runs remain valid for ad-hoc warming:
 
     export POLICYENGINE_ARTIFACT_BUCKET=<bucket-name>
     uv run modal run --env=staging src/modal/precompute_app.py

--- a/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
+++ b/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
@@ -581,6 +581,25 @@ class TestModalPrecompute:
             in reusable_workflow
         )
 
+    def test_deploy_workflow_threads_force_recompute_to_script(self):
+        """The manual recompute flag should reach the precompute script."""
+        deploy_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "modal-deploy.yml"
+        ).read_text(encoding="utf-8")
+        reusable_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "modal-deploy.reusable.yml"
+        ).read_text(encoding="utf-8")
+
+        assert "force_recompute:" in deploy_workflow
+        assert (
+            "force_recompute: ${{ inputs.force_recompute || false }}" in deploy_workflow
+        )
+        assert "force_recompute:" in reusable_workflow
+        assert (
+            'modal-precompute.sh "${{ inputs.modal_environment }}" '
+            '"${{ inputs.force_recompute }}"' in reusable_workflow
+        )
+
     def test_precompute_job_syncs_its_own_secrets(self):
         """Precompute must not depend on a prior deploy's secret sync."""
         reusable_workflow = (

--- a/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
+++ b/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
@@ -411,9 +411,7 @@ class TestModalDeployApp:
         assert "--force-latest" not in registry_call
         # The gateway deploys from its own project (uv_sync image).
         gateway_call = next(
-            call
-            for call in calls
-            if "policyengine_simulation_gateway/app.py" in call
+            call for call in calls if "policyengine_simulation_gateway/app.py" in call
         )
         assert "modal deploy" in gateway_call
 
@@ -426,6 +424,142 @@ class TestModalDeployApp:
             call for call in calls if "update_version_registry" in call
         )
         assert registry_call.endswith("--force-latest")
+
+
+class TestModalPrecompute:
+    """Tests for modal-precompute.sh"""
+
+    script = SCRIPTS_DIR / "modal-precompute.sh"
+
+    def _run_with_fake_uv(
+        self,
+        tmp_path,
+        *args,
+        fake_output="MANIFEST_DIGEST=abc123",
+        bucket="policyengine-sim-artifacts",
+    ):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        log_path = tmp_path / "uv-calls.log"
+        github_output = tmp_path / "github-output.txt"
+        uv_path = bin_dir / "uv"
+        uv_path.write_text(
+            "#!/bin/bash\n"
+            'printf \'%s\\n\' "$*" >> "$UV_FAKE_LOG"\n'
+            "printf '%s\\n' \"$UV_FAKE_OUTPUT\"\n",
+            encoding="utf-8",
+        )
+        uv_path.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "UV_FAKE_LOG": str(log_path),
+                "UV_FAKE_OUTPUT": fake_output,
+                "GITHUB_OUTPUT": str(github_output),
+            }
+        )
+        if bucket is None:
+            env.pop("POLICYENGINE_ARTIFACT_BUCKET", None)
+        else:
+            env["POLICYENGINE_ARTIFACT_BUCKET"] = bucket
+
+        result = subprocess.run(
+            ["bash", str(self.script), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        calls = (
+            log_path.read_text(encoding="utf-8").splitlines()
+            if log_path.exists()
+            else []
+        )
+        github_out = (
+            github_output.read_text(encoding="utf-8") if github_output.exists() else ""
+        )
+        return result, calls, github_out
+
+    def test_script_exists(self):
+        """Script file should exist."""
+        assert self.script.exists(), f"Script not found at {self.script}"
+
+    def test_script_syntax(self):
+        """Script should have valid bash syntax."""
+        result = subprocess.run(
+            ["bash", "-n", str(self.script)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Syntax error: {result.stderr}"
+
+    def test_requires_modal_environment_argument(self):
+        """Should fail when no modal environment is provided."""
+        result = subprocess.run(
+            ["bash", str(self.script)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, "Should fail without modal environment"
+
+    def test_requires_artifact_bucket(self, tmp_path):
+        """Should fail before invoking modal when the bucket env var is unset."""
+        result, calls, _ = self._run_with_fake_uv(tmp_path, "staging", bucket=None)
+
+        assert result.returncode != 0
+        assert "POLICYENGINE_ARTIFACT_BUCKET is required" in result.stderr
+        assert calls == [], "Should not invoke modal without a bucket"
+
+    def test_runs_precompute_app_and_exports_digest(self, tmp_path):
+        """Default run has no --force and the digest reaches GITHUB_OUTPUT."""
+        result, calls, github_out = self._run_with_fake_uv(
+            tmp_path,
+            "staging",
+            fake_output=(
+                "Planning against gs://policyengine-sim-artifacts (force=False)\n"
+                "MANIFEST_DIGEST=abc123\n"
+                "Stopping app - local entrypoint completed."
+            ),
+        )
+
+        assert result.returncode == 0, result.stderr
+        run_call = next(call for call in calls if "modal run" in call)
+        assert "run modal run --env=staging src/modal/precompute_app.py" in run_call
+        assert "--force" not in run_call
+        assert "manifest_digest=abc123" in github_out
+
+    def test_takes_the_last_digest_line(self, tmp_path):
+        """The MANIFEST_DIGEST= contract is last-line-wins."""
+        result, _, github_out = self._run_with_fake_uv(
+            tmp_path,
+            "staging",
+            fake_output="MANIFEST_DIGEST=old\nMANIFEST_DIGEST=new",
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "manifest_digest=new" in github_out
+        assert "manifest_digest=old" not in github_out
+
+    def test_passes_force_when_requested(self, tmp_path):
+        """A truthy force argument appends --force to the modal run."""
+        result, calls, _ = self._run_with_fake_uv(tmp_path, "staging", "true")
+
+        assert result.returncode == 0, result.stderr
+        run_call = next(call for call in calls if "modal run" in call)
+        assert run_call.endswith("--force")
+
+    def test_fails_when_no_digest_line_is_emitted(self, tmp_path):
+        """A run that never prints the digest contract must fail the job."""
+        result, _, github_out = self._run_with_fake_uv(
+            tmp_path,
+            "staging",
+            fake_output="Planning against gs://bucket (force=False)",
+        )
+
+        assert result.returncode != 0
+        assert "no MANIFEST_DIGEST= line" in result.stderr
+        assert "manifest_digest=" not in github_out
 
 
 class TestModalGetUrl:

--- a/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
+++ b/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
@@ -561,6 +561,40 @@ class TestModalPrecompute:
         assert "no MANIFEST_DIGEST= line" in result.stderr
         assert "manifest_digest=" not in github_out
 
+    def test_deploy_workflow_runs_precompute_before_deploy(self):
+        """The reusable workflow must gate deploy on the precompute job."""
+        reusable_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "modal-deploy.reusable.yml"
+        ).read_text(encoding="utf-8")
+
+        assert "precompute:" in reusable_workflow
+        assert "needs: [precompute]" in reusable_workflow
+        assert 'modal-precompute.sh "${{ inputs.modal_environment }}"' in (
+            reusable_workflow
+        )
+        assert (
+            "POLICYENGINE_ARTIFACT_BUCKET: ${{ vars.POLICYENGINE_ARTIFACT_BUCKET }}"
+            in reusable_workflow
+        )
+        assert (
+            "manifest_digest: ${{ steps.run-precompute.outputs.manifest_digest }}"
+            in reusable_workflow
+        )
+
+    def test_precompute_job_syncs_its_own_secrets(self):
+        """Precompute must not depend on a prior deploy's secret sync."""
+        reusable_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "modal-deploy.reusable.yml"
+        ).read_text(encoding="utf-8")
+
+        sync_invocation = (
+            'modal-sync-secrets.sh "${{ inputs.modal_environment }}" '
+            '"${{ inputs.environment }}"'
+        )
+        assert reusable_workflow.count(sync_invocation) == 2, (
+            "Expected the precompute AND deploy jobs to each sync Modal secrets"
+        )
+
 
 class TestModalGetUrl:
     """Tests for modal-get-url.sh"""

--- a/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
+++ b/projects/policyengine-simulation-executor/tests/test_modal_scripts.py
@@ -437,6 +437,7 @@ class TestModalPrecompute:
         *args,
         fake_output="MANIFEST_DIGEST=abc123",
         bucket="policyengine-sim-artifacts",
+        with_github_output=True,
     ):
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
@@ -457,9 +458,12 @@ class TestModalPrecompute:
                 "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
                 "UV_FAKE_LOG": str(log_path),
                 "UV_FAKE_OUTPUT": fake_output,
-                "GITHUB_OUTPUT": str(github_output),
             }
         )
+        if with_github_output:
+            env["GITHUB_OUTPUT"] = str(github_output)
+        else:
+            env.pop("GITHUB_OUTPUT", None)
         if bucket is None:
             env.pop("POLICYENGINE_ARTIFACT_BUCKET", None)
         else:
@@ -510,6 +514,16 @@ class TestModalPrecompute:
         assert result.returncode != 0
         assert "POLICYENGINE_ARTIFACT_BUCKET is required" in result.stderr
         assert calls == [], "Should not invoke modal without a bucket"
+
+    def test_requires_github_output_before_running(self, tmp_path):
+        """A missing GITHUB_OUTPUT must fail fast, not after the compute."""
+        result, calls, _ = self._run_with_fake_uv(
+            tmp_path, "staging", with_github_output=False
+        )
+
+        assert result.returncode != 0
+        assert "GITHUB_OUTPUT is required" in result.stderr
+        assert calls == [], "Should not invoke modal without GITHUB_OUTPUT"
 
     def test_runs_precompute_app_and_exports_digest(self, tmp_path):
         """Default run has no --force and the digest reaches GITHUB_OUTPUT."""


### PR DESCRIPTION
Fixes #648

## What

Phase 2 of the baseline artifact pipeline: the precompute app from #644 becomes a first-class job in the deploy pipeline, with nothing consuming its output yet. Three commits:

1. **`modal-precompute.sh`** wraps the phase-1 manual invocation for CI: requires `POLICYENGINE_ARTIFACT_BUCKET` up front, threads a truthy force argument to `--force`, and parses the app's `MANIFEST_DIGEST=` stdout contract (last matching line wins, so Modal's post-entrypoint output is harmless) into a `manifest_digest` GitHub Actions output — failing loudly when the line never appears.
2. **A `precompute` job** in the reusable deploy workflow ahead of `deploy`, on both legs: it syncs Modal secrets itself (never depending on a prior deploy's sync), runs the app against the leg's Modal environment, and exports the manifest digest as a job output. `deploy` gains `needs: [precompute]` and changes in no other way — the digest is deliberately unconsumed until the phase-3 image cutover, so this merge proves the CI seam while pipeline behavior stays exactly today's.
3. **A `force_recompute` workflow_dispatch input** threaded to the script, mirroring `force_latest` (including the `|| false` guard for push triggers). Write-once still holds: a forced run recomputes but never replaces an existing store object; healing a bad artifact stays delete-then-rerun.

Ordinary deploys pay a fast no-op (the store is already warm); a pin-bump deploy pays the full dataset+baseline recompute inline (~15–20 min measured in phase 1), replacing the manual prewarm ritual with a visible, measured pipeline step.

## Prerequisite (done)

Repo-level Actions variable `POLICYENGINE_ARTIFACT_BUCKET=policyengine-sim-artifacts` is set.

## Checks run

- Executor suite: 372 passed (8 new script tests, 4 new workflow-threading tests).
- Both workflow files parse as YAML.
- Manual staging smoke of `modal-precompute.sh`: no-op plan (3 datasets / 60 baselines, 0 to build or compute), digest matching the current manifest `5cb4c2f5…`, `manifest_digest=` exported to a simulated `GITHUB_OUTPUT`.

## Merge gate (phase 2)

On the post-merge main deploy: `precompute` green on both legs; the prod leg a measurable no-op (the store is global — beta warms it); `deploy` + `integ_test` behaviorally unchanged and green. Note: if a policyengine pin bump merges first, the beta leg correctly pays the full cold recompute and the prod leg then proves the no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)