### PR TITLE
Fix Cloud Run candidate revision tags

### DIFF
--- a/.github/workflows/simulation-deploy.yml
+++ b/.github/workflows/simulation-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       release_environment: beta
       modal_environment: staging
       entrypoint_service: policyengine-simulation-entry-staging
-      entrypoint_revision_prefix: s
+      entrypoint_revision_prefix: beta-
       entrypoint_min_instances: 0
       entrypoint_max_instances: 2
       promote_entrypoint: false
@@ -54,7 +54,7 @@ jobs:
       release_environment: prod
       modal_environment: main
       entrypoint_service: policyengine-simulation-entry
-      entrypoint_revision_prefix: p
+      entrypoint_revision_prefix: prod-
       entrypoint_min_instances: 1
       entrypoint_max_instances: 20
       promote_entrypoint: true

--- a/projects/policyengine-simulation-entry/tests/test_deployment_assets.py
+++ b/projects/policyengine-simulation-entry/tests/test_deployment_assets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import textwrap
 import tomllib
@@ -94,6 +95,27 @@ def test_deployment_uses_gcloud_workflow_without_terraform():
         / "scripts"
         / "configure-cloud-run-simulation-entry-domains.sh"
     ).exists()
+
+
+def test_cloud_run_revision_tags_are_valid_on_the_first_workflow_run():
+    deploy_workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+    reusable_workflow = REUSABLE_DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+    prefixes = re.findall(
+        r"^\s+entrypoint_revision_prefix:\s+(\S+)$",
+        deploy_workflow,
+        flags=re.MULTILINE,
+    )
+
+    assert (
+        "tag=${{ inputs.entrypoint_revision_prefix }}${GITHUB_RUN_NUMBER}"
+        in reusable_workflow
+    )
+    assert len(prefixes) == 2
+
+    first_run_tags = [f"{prefix}1" for prefix in prefixes]
+    for tag in first_run_tags:
+        assert 3 <= len(tag) <= 63
+        assert re.fullmatch(r"[a-z][a-z0-9-]*[a-z0-9]", tag)
 
 
 def test_full_stack_promotion_order_is_explicit():


### PR DESCRIPTION
Fixes #656

## Summary

- replace the one-character Cloud Run candidate prefixes with `beta-` and `prod-`
- add regression coverage for the shortest tags generated on workflow run 1
- validate generated tag length and naming constraints in the deployment asset tests

## Testing

- `uv run pytest tests/ -q` (`61 passed`)
- `uv run ruff check tests/test_deployment_assets.py`
- `uv run ruff format --check tests/test_deployment_assets.py`
- `actionlint .github/workflows/simulation-deploy.yml .github/workflows/simulation-deploy.reusable.yml`
- `git diff --check`
