### PR TITLE
Fix simulation request correlation and service metadata

### DIFF
--- a/libs/policyengine-simulation-observability/README.md
+++ b/libs/policyengine-simulation-observability/README.md
@@ -1,8 +1,11 @@
 # policyengine-simulation-observability
 
-Shared observability plumbing for the simulation service (gateway and
-executor): the `policyengine-observability` configuration wrapper, legacy
-Logfire helpers, error redaction/reporting, and the telemetry envelope.
+Shared observability plumbing for the simulation entrypoint, gateway, and
+executor: the `policyengine-observability` configuration wrapper, legacy
+Logfire helpers, error redaction/reporting, and the telemetry envelope. Each
+FastAPI service supplies its own service name, while
+`X-PolicyEngine-Request-Id` is the single request-correlation header across
+service boundaries.
 
 This lives in its own lib because it has a different reason to change than
 the gateway↔executor contract: Logfire is retained only while a replacement

--- a/libs/policyengine-simulation-observability/src/policyengine_simulation_observability/__init__.py
+++ b/libs/policyengine-simulation-observability/src/policyengine_simulation_observability/__init__.py
@@ -1,1 +1,2 @@
-"""Shared observability plumbing for the simulation gateway and executor."""
+"""Shared observability plumbing for the simulation entrypoint, gateway,
+and executor."""

--- a/libs/policyengine-simulation-observability/src/policyengine_simulation_observability/observability.py
+++ b/libs/policyengine-simulation-observability/src/policyengine_simulation_observability/observability.py
@@ -132,16 +132,21 @@ def configure_process_observability(
 def init_simulation_observability(
     app: FastAPI,
     *,
+    service_name: str,
     service_role: str = "api",
 ) -> ObservabilityRuntime:
     service_role = _service_role(service_role)
     platform = _platform()
-    config = _config(service_role=service_role, platform=platform)
+    config = _config(
+        service_name=service_name,
+        service_role=service_role,
+        platform=platform,
+    )
     return init_fastapi_observability(
         app,
         config=config,
         runtime=ObservabilityRuntime(config, segment_registry=SegmentName),
-        service_name=SERVICE_NAME,
+        service_name=service_name,
         service_role=service_role,
         span_prefix=SPAN_PREFIX,
         segment_registry=SegmentName,
@@ -155,7 +160,11 @@ def init_process_observability(
 ) -> ObservabilityRuntime:
     service_role = _service_role(service_role)
     platform = _platform()
-    config = _config(service_role=service_role, platform=platform)
+    config = _config(
+        service_name=SERVICE_NAME,
+        service_role=service_role,
+        platform=platform,
+    )
     runtime = ObservabilityRuntime(config, segment_registry=SegmentName)
     runtime.configure()
     set_observability_runtime(runtime)
@@ -182,11 +191,12 @@ def logfire_replacement_attributes() -> dict[str, str]:
 
 def _config(
     *,
+    service_name: str,
     service_role: str,
     platform: str,
 ) -> ObservabilityConfig:
     config = ObservabilityConfig.from_env(
-        service_name=SERVICE_NAME,
+        service_name=service_name,
         service_role=service_role,
         span_prefix=SPAN_PREFIX,
         extra_metric_attribute_keys=SIMULATION_METRIC_ATTRIBUTE_KEYS,
@@ -206,6 +216,7 @@ def _environment() -> str:
         os.getenv("OBSERVABILITY_ENVIRONMENT")
         or os.getenv("MODAL_ENVIRONMENT")
         or os.getenv("DEPLOYMENT_ENVIRONMENT")
+        or os.getenv("APP_ENVIRONMENT")
         or os.getenv("APP_ENV")
         or os.getenv("ENVIRONMENT")
         or "local"

--- a/libs/policyengine-simulation-observability/tests/test_observability.py
+++ b/libs/policyengine-simulation-observability/tests/test_observability.py
@@ -1,4 +1,5 @@
 import json
+import inspect
 import os
 
 import pytest
@@ -14,7 +15,7 @@ from policyengine_observability.runtime import OPERATION_LOGGER, REQUEST_LOGGER
 
 from policyengine_simulation_observability.observability import (
     LOG_DESTINATIONS,
-    SERVICE_NAME,
+    _environment,
     configure_process_observability,
     init_process_observability,
     init_simulation_observability,
@@ -23,6 +24,7 @@ from policyengine_simulation_observability.observability import (
 
 
 OBSERVABILITY_ENV_KEYS = (
+    "OBSERVABILITY_ENVIRONMENT",
     "OBSERVABILITY_PLATFORM",
     "OBSERVABILITY_SERVICE_ROLE",
     "OBSERVABILITY_RUNTIME_ROLE",
@@ -32,6 +34,10 @@ OBSERVABILITY_ENV_KEYS = (
     "OTEL_ENABLED",
     "GOOGLE_CLOUD_PROJECT",
     "MODAL_ENVIRONMENT",
+    "DEPLOYMENT_ENVIRONMENT",
+    "APP_ENVIRONMENT",
+    "APP_ENV",
+    "ENVIRONMENT",
 )
 
 
@@ -143,10 +149,14 @@ def test_init_simulation_observability_forces_stdout_and_disables_exports():
     os.environ["MODAL_ENVIRONMENT"] = "staging"
 
     app = FastAPI()
-    runtime = init_simulation_observability(app, service_role="modal_gateway")
+    runtime = init_simulation_observability(
+        app,
+        service_name="policyengine-simulation-gateway",
+        service_role="modal_gateway",
+    )
 
     assert app.state.policyengine_observability is runtime
-    assert runtime.config.service_name == SERVICE_NAME
+    assert runtime.config.service_name == "policyengine-simulation-gateway"
     assert runtime.config.service_role == "modal_gateway"
     assert runtime.config.environment == "staging"
     assert runtime.config.log_destinations == LOG_DESTINATIONS
@@ -161,7 +171,11 @@ def test_fastapi_observability_emits_structured_request_log(monkeypatch):
     def health():
         return {"status": "healthy"}
 
-    init_simulation_observability(app, service_role="api")
+    init_simulation_observability(
+        app,
+        service_name="policyengine-simulation-entry",
+        service_role="api",
+    )
 
     records = []
     monkeypatch.setattr(
@@ -180,7 +194,7 @@ def test_fastapi_observability_emits_structured_request_log(monkeypatch):
     record = records[0]
     assert record["schema_version"] == "policyengine.observability.request.v1"
     assert record["event"] == "http_request_completed"
-    assert record["service_name"] == SERVICE_NAME
+    assert record["service_name"] == "policyengine-simulation-entry"
     assert record["service_role"] == "api"
     assert record["request_id"] == "request-123"
     assert record["method"] == "GET"
@@ -188,3 +202,81 @@ def test_fastapi_observability_emits_structured_request_log(monkeypatch):
     assert record["status_code"] == 200
     assert record["logfire_status"] == "legacy_candidate_for_replacement"
     assert record["logfire_replacement_candidate"] == "policyengine-observability"
+
+
+def test_fastapi_service_name_is_a_required_keyword_only_argument():
+    parameter = inspect.signature(init_simulation_observability).parameters[
+        "service_name"
+    ]
+
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default is inspect.Parameter.empty
+
+
+@pytest.mark.parametrize("app_environment", ["beta", "prod"])
+def test_app_environment_configures_cloud_run_runtime(app_environment):
+    os.environ["APP_ENVIRONMENT"] = app_environment
+
+    app = FastAPI()
+    runtime = init_simulation_observability(
+        app,
+        service_name="policyengine-simulation-entry",
+        service_role="simulation_entry",
+    )
+
+    assert runtime.config.environment == app_environment
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        (
+            {
+                "OBSERVABILITY_ENVIRONMENT": "observability",
+                "MODAL_ENVIRONMENT": "modal",
+                "DEPLOYMENT_ENVIRONMENT": "deployment",
+                "APP_ENVIRONMENT": "app-environment",
+                "APP_ENV": "app-env",
+                "ENVIRONMENT": "generic",
+            },
+            "observability",
+        ),
+        (
+            {
+                "MODAL_ENVIRONMENT": "modal",
+                "DEPLOYMENT_ENVIRONMENT": "deployment",
+                "APP_ENVIRONMENT": "app-environment",
+                "APP_ENV": "app-env",
+                "ENVIRONMENT": "generic",
+            },
+            "modal",
+        ),
+        (
+            {
+                "DEPLOYMENT_ENVIRONMENT": "deployment",
+                "APP_ENVIRONMENT": "app-environment",
+                "APP_ENV": "app-env",
+                "ENVIRONMENT": "generic",
+            },
+            "deployment",
+        ),
+        (
+            {
+                "APP_ENVIRONMENT": "app-environment",
+                "APP_ENV": "app-env",
+                "ENVIRONMENT": "generic",
+            },
+            "app-environment",
+        ),
+        (
+            {"APP_ENV": "app-env", "ENVIRONMENT": "generic"},
+            "app-env",
+        ),
+        ({"ENVIRONMENT": "generic"}, "generic"),
+        ({}, "local"),
+    ],
+)
+def test_environment_precedence(environment, expected):
+    os.environ.update(environment)
+
+    assert _environment() == expected

--- a/libs/policyengine-simulation-observability/tests/test_observability.py
+++ b/libs/policyengine-simulation-observability/tests/test_observability.py
@@ -1,5 +1,5 @@
-import json
 import inspect
+import json
 import os
 
 import pytest

--- a/projects/policyengine-simulation-entry/src/policyengine_simulation_entry/app.py
+++ b/projects/policyengine-simulation-entry/src/policyengine_simulation_entry/app.py
@@ -125,18 +125,16 @@ def create_app(
         platform="cloud_run",
         service_role="simulation_entry",
     )
-    init_simulation_observability(app, service_role="simulation_entry")
+    init_simulation_observability(
+        app,
+        service_name="policyengine-simulation-entry",
+        service_role="simulation_entry",
+    )
 
     @app.middleware("http")
     async def request_context(request: Request, call_next):
         headers = MutableHeaders(scope=request.scope)
-        request_id = (
-            headers.get("x-request-id")
-            or headers.get(REQUEST_ID_HEADER)
-            or str(uuid.uuid4())
-        )
-        headers["x-request-id"] = request_id
-        # policyengine-observability currently reads its legacy header name.
+        request_id = headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
         headers[REQUEST_ID_HEADER] = request_id
         request.state.request_id = request_id
         started = time.monotonic()
@@ -156,9 +154,9 @@ def create_app(
                 content="Internal Server Error",
                 status_code=500,
                 media_type="text/plain",
+                headers={REQUEST_ID_HEADER: request_id},
             )
         elapsed_ms = round((time.monotonic() - started) * 1000, 2)
-        response.headers["X-Request-ID"] = request_id
         if runtime_settings.revision:
             response.headers["X-PolicyEngine-Simulation-Revision"] = (
                 runtime_settings.revision

--- a/projects/policyengine-simulation-entry/src/policyengine_simulation_entry/backend.py
+++ b/projects/policyengine-simulation-entry/src/policyengine_simulation_entry/backend.py
@@ -9,6 +9,7 @@ from typing import Protocol
 
 import httpx
 from pydantic import ValidationError
+from policyengine_observability import REQUEST_ID_HEADER
 from policyengine_simulation_contract.json_types import JsonObject
 
 from policyengine_simulation_entry.config import Settings
@@ -21,7 +22,7 @@ SAFE_RESPONSE_HEADERS = frozenset(
         "content-type",
         "etag",
         "retry-after",
-        "x-request-id",
+        REQUEST_ID_HEADER.lower(),
     }
 )
 
@@ -181,7 +182,7 @@ class OldGatewayBackend:
             token = await token_provider.get_token()
             headers = {"Authorization": f"Bearer {token}"}
             if request_id:
-                headers["X-Request-ID"] = request_id
+                headers[REQUEST_ID_HEADER] = request_id
 
             try:
                 response = await client.request(
@@ -216,7 +217,11 @@ class OldGatewayBackend:
                 status_code=response.status_code,
                 content=response.content,
                 headers={
-                    key: value
+                    (
+                        REQUEST_ID_HEADER
+                        if key.lower() == REQUEST_ID_HEADER.lower()
+                        else key
+                    ): value
                     for key, value in response.headers.items()
                     if key.lower() in SAFE_RESPONSE_HEADERS
                 },

--- a/projects/policyengine-simulation-entry/tests/test_app.py
+++ b/projects/policyengine-simulation-entry/tests/test_app.py
@@ -184,11 +184,26 @@ def test_versions_and_ping_are_public_proxy_routes(client, backend):
     assert client.post("/ping", json={"value": 1}).json() == {"incremented": 2}
 
 
-def test_request_id_is_propagated_and_returned(client, backend):
-    result = client.get("/versions", headers={"X-Request-ID": "request-123"})
+def test_request_id_is_propagated_logged_and_returned(
+    client,
+    backend,
+    caplog,
+):
+    with caplog.at_level(logging.INFO):
+        result = client.get(
+            "/versions",
+            headers={REQUEST_ID_HEADER: "request-123"},
+        )
 
-    assert result.headers["x-request-id"] == "request-123"
+    assert result.headers[REQUEST_ID_HEADER] == "request-123"
+    assert "x-request-id" not in result.headers
     assert backend.requests[-1].request_id == "request-123"
+    request_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "simulation_entry_request"
+    )
+    assert request_record.request_id == "request-123"
 
 
 def test_generated_request_id_is_shared_with_observability():
@@ -214,11 +229,37 @@ def test_generated_request_id_is_shared_with_observability():
     with TestClient(app) as client:
         result = client.get("/versions")
 
-    request_id = result.headers["x-request-id"]
+    request_id = result.headers[REQUEST_ID_HEADER]
     assert request_id
-    assert result.headers[REQUEST_ID_HEADER] == request_id
+    assert "x-request-id" not in result.headers
     assert backend.requests[-1].request_id == request_id
     assert backend.observability_request_id == request_id
+
+
+def test_x_request_id_is_not_an_alias(client, backend):
+    result = client.get(
+        "/versions",
+        headers={"X-Request-ID": "must-not-be-used"},
+    )
+
+    request_id = result.headers[REQUEST_ID_HEADER]
+    assert request_id
+    assert request_id != "must-not-be-used"
+    assert backend.requests[-1].request_id == request_id
+    assert "x-request-id" not in result.headers
+
+
+def test_entrypoint_uses_its_own_service_name(backend):
+    app = create_app(
+        settings=make_settings(),
+        backend=backend,
+        auth_dependency=lambda: None,
+    )
+
+    assert (
+        app.state.policyengine_observability.config.service_name
+        == "policyengine-simulation-entry"
+    )
 
 
 def test_request_validation_matches_shared_contract(client):
@@ -251,12 +292,17 @@ def test_backend_failures_are_sanitized(error, expected_status, expected_detail)
     from fastapi.testclient import TestClient
 
     with TestClient(app) as client:
-        result = client.get("/jobs/job-1")
+        result = client.get(
+            "/jobs/job-1",
+            headers={REQUEST_ID_HEADER: "request-backend-failure"},
+        )
 
     assert result.status_code == expected_status
     assert result.json() == {"detail": expected_detail}
     assert result.headers["retry-after"] == "10"
     assert result.headers["x-policyengine-simulation-backend"] == "old_gateway"
+    assert result.headers[REQUEST_ID_HEADER] == "request-backend-failure"
+    assert "x-request-id" not in result.headers
 
 
 def test_unexpected_failure_preserves_correlation_headers_and_request_log(caplog):
@@ -275,12 +321,13 @@ def test_unexpected_failure_preserves_correlation_headers_and_request_log(caplog
     with caplog.at_level(logging.INFO), TestClient(app) as client:
         result = client.get(
             "/jobs/job-1",
-            headers={"X-Request-ID": "request-500"},
+            headers={REQUEST_ID_HEADER: "request-500"},
         )
 
     assert result.status_code == 500
     assert result.text == "Internal Server Error"
-    assert result.headers["x-request-id"] == "request-500"
+    assert result.headers[REQUEST_ID_HEADER] == "request-500"
+    assert "x-request-id" not in result.headers
     assert (
         result.headers["x-policyengine-simulation-revision"]
         == "simulation-entry-test-revision"
@@ -295,14 +342,19 @@ def test_unexpected_failure_preserves_correlation_headers_and_request_log(caplog
     assert request_record.job_id == "job-1"
 
 
-@pytest.mark.parametrize("status_code", [400, 404, 409, 500])
+@pytest.mark.parametrize("status_code", [400, 404, 409, 500, 502])
 def test_upstream_error_status_and_body_are_preserved(client, backend, status_code):
     backend.responses[("GET", "/jobs/job-1")] = response(
         status_code,
         {"detail": "upstream response"},
     )
 
-    result = client.get("/jobs/job-1")
+    result = client.get(
+        "/jobs/job-1",
+        headers={REQUEST_ID_HEADER: "request-upstream-error"},
+    )
 
     assert result.status_code == status_code
     assert result.json() == {"detail": "upstream response"}
+    assert result.headers[REQUEST_ID_HEADER] == "request-upstream-error"
+    assert "x-request-id" not in result.headers

--- a/projects/policyengine-simulation-entry/tests/test_backend.py
+++ b/projects/policyengine-simulation-entry/tests/test_backend.py
@@ -4,6 +4,7 @@ import json
 
 import httpx
 import pytest
+from policyengine_observability import REQUEST_ID_HEADER
 
 from policyengine_simulation_entry.backend import (
     BackendAuthenticationError,
@@ -58,7 +59,7 @@ async def test_backend_uses_own_token_and_preserves_safe_response_headers():
             headers={
                 "Retry-After": "2",
                 "Set-Cookie": "must-not-pass",
-                "X-Request-ID": "upstream-request",
+                REQUEST_ID_HEADER: "upstream-request",
             },
         )
 
@@ -79,12 +80,14 @@ async def test_backend_uses_own_token_and_preserves_safe_response_headers():
 
     upstream = requests[-1]
     assert upstream.headers["authorization"] == "Bearer service-token"
-    assert upstream.headers["x-request-id"] == "caller-request"
+    assert upstream.headers[REQUEST_ID_HEADER] == "caller-request"
+    assert "x-request-id" not in upstream.headers
     assert json.loads(result.content) == {
         "job_id": "fc-123",
         "status": "submitted",
     }
     assert result.headers["retry-after"] == "2"
+    assert result.headers[REQUEST_ID_HEADER] == "upstream-request"
     assert "set-cookie" not in result.headers
 
 

--- a/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/main.py
+++ b/projects/policyengine-simulation-executor/src/policyengine_simulation_executor/main.py
@@ -33,7 +33,11 @@ app = FastAPI(
     title="policyengine-simulation-executor",
     summary="Policyengine simulation api",
 )
-init_simulation_observability(app, service_role="api")
+init_simulation_observability(
+    app,
+    service_name="policyengine-simulation-executor",
+    service_role="api",
+)
 
 # attach the api defined in the app package
 initialize(app=app)

--- a/projects/policyengine-simulation-executor/tests/test_standalone_simulation_contract.py
+++ b/projects/policyengine-simulation-executor/tests/test_standalone_simulation_contract.py
@@ -29,6 +29,13 @@ PACKAGED_RUNTIME_MODULES = (
 )
 
 
+def test_standalone_executor_uses_its_own_service_name():
+    assert (
+        app.state.policyengine_observability.config.service_name
+        == "policyengine-simulation-executor"
+    )
+
+
 def test_standalone_package_runtime_does_not_import_unpackaged_modal_source():
     for module_name in PACKAGED_RUNTIME_MODULES:
         module = import_module(module_name)

--- a/projects/policyengine-simulation-gateway/src/policyengine_simulation_gateway/app.py
+++ b/projects/policyengine-simulation-gateway/src/policyengine_simulation_gateway/app.py
@@ -93,7 +93,11 @@ def web_app():
         modal_app_name="policyengine-simulation-gateway",
         modal_function_name="web_app",
     )
-    init_simulation_observability(api, service_role="modal_gateway")
+    init_simulation_observability(
+        api,
+        service_name="policyengine-simulation-gateway",
+        service_role="modal_gateway",
+    )
     configure_logfire("policyengine-simulation-gateway")
 
     # Startup guard: crash the container if GATEWAY_AUTH_DISABLED is set in

--- a/projects/policyengine-simulation-gateway/src/policyengine_simulation_gateway/testing.py
+++ b/projects/policyengine-simulation-gateway/src/policyengine_simulation_gateway/testing.py
@@ -27,7 +27,11 @@ def create_gateway_app(*, authenticate: bool = True) -> FastAPI:
         description="Test instance for unit tests",
         version="0.0.1",
     )
-    init_simulation_observability(app, service_role="modal_gateway")
+    init_simulation_observability(
+        app,
+        service_name="policyengine-simulation-gateway",
+        service_role="modal_gateway",
+    )
     app.include_router(router)
     if authenticate:
         app.dependency_overrides[require_auth] = lambda: None

--- a/projects/policyengine-simulation-gateway/tests/test_observability.py
+++ b/projects/policyengine-simulation-gateway/tests/test_observability.py
@@ -1,0 +1,41 @@
+"""Gateway observability identity and request-correlation tests."""
+
+import json
+
+from policyengine_observability import REQUEST_ID_HEADER
+from policyengine_observability.runtime import REQUEST_LOGGER
+from policyengine_simulation_gateway.testing import create_gateway_app
+
+
+def test_gateway_reads_policyengine_request_id_into_observability_context(
+    monkeypatch,
+):
+    records = []
+    monkeypatch.setattr(
+        REQUEST_LOGGER,
+        "info",
+        lambda message: records.append(json.loads(message)),
+    )
+    app = create_gateway_app()
+
+    from fastapi.testclient import TestClient
+
+    response = TestClient(app).get(
+        "/health",
+        headers={REQUEST_ID_HEADER: "request-through-entrypoint"},
+    )
+
+    assert response.status_code == 200
+    assert len(records) == 1
+    assert records[0]["request_id"] == "request-through-entrypoint"
+    assert records[0]["service_name"] == "policyengine-simulation-gateway"
+    assert records[0]["service_role"] == "modal_gateway"
+
+
+def test_gateway_uses_its_own_service_name():
+    app = create_gateway_app()
+
+    assert (
+        app.state.policyengine_observability.config.service_name
+        == "policyengine-simulation-gateway"
+    )


### PR DESCRIPTION
Fixes #658

## Summary

- standardize simulation HTTP correlation on `X-PolicyEngine-Request-Id`
- preserve supplied or generated IDs through the Cloud Run Entrypoint and Modal gateway
- give the Entrypoint, gateway, and executor explicit FastAPI service identities
- recognize `APP_ENVIRONMENT` without changing the existing environment precedence
- document the three-service observability boundary

## Root cause

The Entrypoint forwarded `X-Request-ID`, but `policyengine-observability` reads `X-PolicyEngine-Request-Id`, so the Modal gateway generated a different UUID. The shared FastAPI initializer also hard-coded the executor service name and did not consider the Cloud Run `APP_ENVIRONMENT` value.

## Impact

Entrypoint and gateway logs can now correlate a synchronous request with the same ID. Structured records identify the correct service and deployed Entrypoint environment. Authentication, routing, secrets, workflows, API schemas, generated clients, and asynchronous job semantics are unchanged.

## Tests

- test-first regression commit captured the expected pre-fix failures
- simulation observability: 28 passed
- simulation entry: 64 passed
- simulation gateway: 103 passed, 1 deployment integration test deselected
- simulation executor: 391 passed, 2 deployment integration tests deselected
- Ruff CI formatting lane: 62 source files formatted
- targeted Pyright: zero errors for every modified source file
- Entrypoint Docker image build: passed
- `git diff --check`: passed

Real Modal integration smoke tests were not run because they create ephemeral deployments; the hermetic Modal image-definition and import-smoke tests passed in the gateway and executor unit suites.