### PR TITLE
Document canonical simulation entrypoint edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ time:
 A successful push-triggered full-stack deployment publishes the API client from
 the exact deployed commit.
 
-The stable production service may have a separately managed custom hostname.
-Domain ownership, DNS, TLS, and other one-time cloud setup remain operator
-responsibilities outside committed deployment automation. Entrypoint traffic
-promotion does not change API v1 revision traffic or its simulation-entrypoint
-migration flag.
+The stable production service is exposed through a separately managed global
+external HTTPS load balancer and canonical hostname. Domain ownership, DNS,
+TLS, load-balancer resources, and other one-time cloud setup remain operator
+responsibilities outside committed deployment automation. When the canonical
+hostname is supplied as protected environment metadata, every production
+promotion verifies it after checking the generated stable service URL.
+Entrypoint traffic promotion does not change API v1 revision traffic or its
+simulation-entrypoint migration flag.
 
 The stable gateway app is `policyengine-simulation-gateway`; executors deploy as
 versioned `policyengine-simulation-py{version}` apps. For Modal image and deploy

--- a/projects/policyengine-simulation-entry/DEPLOYMENT.md
+++ b/projects/policyengine-simulation-entry/DEPLOYMENT.md
@@ -63,13 +63,14 @@ the Cloud Run entrypoint remain separately controlled.
 Cloud Run provides a stable service URL and tagged candidate URLs. Beta uses
 those generated URLs; it does not require a custom hostname.
 
-Production may use a persistent custom hostname mapped to its stable Cloud Run
-service. The mapping follows the service's active traffic assignment and is
-not recreated for each release. When a custom hostname is configured as
-protected environment metadata, post-promotion checks verify it in addition
-to the generated stable URL.
+Production uses a persistent canonical hostname served by a separately managed
+global external HTTPS load balancer with a serverless Cloud Run backend. The
+load balancer follows the service's stable traffic assignment and is not
+recreated for each release. The deployment workflow receives the canonical
+URL as protected environment metadata and verifies it after every production
+promotion, in addition to checking the generated stable URL.
 
-Domain ownership, mapping creation, DNS publication, managed TLS activation,
-and infrastructure administration are one-time operator actions governed by
-private runbooks rather than committed bootstrap scripts in this public
-repository.
+Domain ownership, load-balancer creation, DNS publication, managed TLS
+activation, and infrastructure administration are one-time operator actions
+governed by private runbooks rather than committed bootstrap scripts in this
+public repository. Direct Cloud Run domain mapping is not the production edge.


### PR DESCRIPTION
Fixes #660

## Summary

- document the canonical Simulation Entrypoint as a global external HTTPS load-balancer boundary
- make the canonical production hostname required rather than optional
- keep concrete cloud, DNS, IAM, and secret values out of the public repository

## Why

Stage 5 is not complete when API v1 merely calls a generated `run.app` URL. The permanent public simulation boundary needs a production-grade canonical hostname in front of the stable Cloud Run service, while tagged generated URLs remain available for candidate qualification.

## Validation

- `git diff --check`
